### PR TITLE
Fix #65 Don’t break idempotency if vid is declared as string

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -455,7 +455,7 @@ class NetboxModule(object):
             after_str[k] = str(v)
 
         if before_str == after_str:
-            return None
+            return {"before": {}, "after": {}}
         else:
             return {"before": before, "after": after}
 
@@ -746,7 +746,8 @@ class NetboxModule(object):
                 self._handle_errors(
                     msg="Request failed, couldn't update device: %s" % name
                 )
-            if diff:
+            if diff and (len(diff['before'].keys()) > 0 or\
+                         len(diff['after'].keys()) > 0):
                 self.result["msg"] = "%s %s updated" % (endpoint_name, name)
                 self.result["changed"] = True
                 self.result["diff"] = diff

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -445,7 +445,19 @@ class NetboxModule(object):
 
     def _build_diff(self, before=None, after=None):
         """Builds diff of before and after changes"""
-        return {"before": before, "after": after}
+        before_str = {}
+        after_str = {}
+
+        for k, v in before.items():
+            before_str[k] = str(v)
+
+        for k, v in after.items():
+            after_str[k] = str(v)
+
+        if before_str == after_str:
+            return None
+        else:
+            return {"before": before, "after": after}
 
     def _convert_identical_keys(self, data):
         """


### PR DESCRIPTION
In modules_utils/netbox_ipam.py _build_diff():
When an already present vlan with the same data is pushed, there’s a
diff between vid: before is a int and after is a string.
Changed = True if diff is instanced so every values in before
and after are converted to string in order to compare them. If they are equals,
diff = None.