### PR TITLE
Add Arg Specs to every module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - COLLECTION_NAMESPACE: netbox_community
     - COLLECTION_NAME: ansible_modules
-    - COLLECTION_VERSION: 0.1.4
+    - COLLECTION_VERSION: 0.1.5
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,4 +60,4 @@ script:
   - black . --check
   - timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:32768)" != "200" ]]; do echo "waiting for Netbox"; sleep 5; done' || false
   - python tests/integration/netbox-deploy.py
-  - ansible-playbook tests/integration/integration-tests.yml -v
+  - ansible-playbook tests/integration/integration-tests.yml -vvvv

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 ## Netbox Plugins
 
 - netbox lookup plugin
+- netbox inventory plugin (0.1.5)
 
 ## How to Use
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: netbox_community
 name: ansible_modules
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.4
+version: 0.1.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -809,7 +809,16 @@ class NetboxAnsibleModule(AnsibleModule):
         required_by=None,
     ):
         super().__init__(
-            argument_spec, no_log, supports_check_mode, required_if,
+            argument_spec,
+            bypass_checks=False,
+            no_log=False,
+            mutually_exclusive=None,
+            required_together=None,
+            required_one_of=None,
+            add_file_common_args=False,
+            supports_check_mode=supports_check_mode,
+            required_if=required_if,
+            required_by=None,
         )
 
     def _check_required_if(self, spec, param=None):

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -439,7 +439,7 @@ class NetboxModule(object):
 
     def _connect_netbox_api(self, url, token, ssl_verify):
         try:
-            return pynetbox.api(url, token=token, ssl_verify=ssl_verify, threading=True)
+            return pynetbox.api(url, token=token, ssl_verify=ssl_verify)
         except Exception:
             self.module.fail_json(msg="Failed to establish connection to Netbox API")
 
@@ -796,35 +796,17 @@ class NetboxAnsibleModule(AnsibleModule):
     """
 
     def __init__(
-        self,
-        argument_spec,
-        bypass_checks=False,
-        no_log=False,
-        mutually_exclusive=None,
-        required_together=None,
-        required_one_of=None,
-        add_file_common_args=False,
-        supports_check_mode=False,
-        required_if=None,
-        required_by=None,
+        self, argument_spec, no_log=False, supports_check_mode=False, required_if=None,
     ):
         super().__init__(
-            argument_spec,
-            bypass_checks,
-            no_log,
-            mutually_exclusive,
-            required_together,
-            required_one_of,
-            add_file_common_args,
-            supports_check_mode,
-            required_if,
-            required_by,
+            argument_spec, no_log, supports_check_mode, required_if,
         )
 
     def _check_required_if(self, spec, param=None):
         """ ensure that parameters which conditionally required are present """
         if spec is None:
             return
+
         if param is None:
             param = self.params
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -796,7 +796,17 @@ class NetboxAnsibleModule(AnsibleModule):
     """
 
     def __init__(
-        self, argument_spec, no_log=False, supports_check_mode=False, required_if=None,
+        self,
+        argument_spec,
+        bypass_checks=False,
+        no_log=False,
+        mutually_exclusive=None,
+        required_together=None,
+        required_one_of=None,
+        add_file_common_args=False,
+        supports_check_mode=False,
+        required_if=None,
+        required_by=None,
     ):
         super().__init__(
             argument_spec, no_log, supports_check_mode, required_if,

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -439,7 +439,7 @@ class NetboxModule(object):
 
     def _connect_netbox_api(self, url, token, ssl_verify):
         try:
-            return pynetbox.api(url, token=token, ssl_verify=ssl_verify)
+            return pynetbox.api(url, token=token, ssl_verify=ssl_verify, threading=True)
         except Exception:
             self.module.fail_json(msg="Failed to establish connection to Netbox API")
 
@@ -800,7 +800,6 @@ class NetboxAnsibleModule(AnsibleModule):
         argument_spec,
         bypass_checks=False,
         no_log=False,
-        check_invalid_arguments=None,
         mutually_exclusive=None,
         required_together=None,
         required_one_of=None,
@@ -813,7 +812,6 @@ class NetboxAnsibleModule(AnsibleModule):
             argument_spec,
             bypass_checks,
             no_log,
-            check_invalid_arguments,
             mutually_exclusive,
             required_together,
             required_one_of,

--- a/plugins/modules/netbox_aggregate.py
+++ b/plugins/modules/netbox_aggregate.py
@@ -124,6 +124,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -135,12 +136,22 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    prefix=dict(required=True, type="raw"),
+                    rir=dict(required=False, type="raw"),
+                    date_added=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
 
     required_if = [("state", "present", ["prefix"]), ("state", "absent", ["prefix"])]

--- a/plugins/modules/netbox_circuit.py
+++ b/plugins/modules/netbox_circuit.py
@@ -149,6 +149,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_circuits import (
     NetboxCircuitsModule,
@@ -160,12 +161,39 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    cid=dict(required=True, type="str"),
+                    provider=dict(required=False, type="raw"),
+                    circuit_type=dict(required=False, type="raw"),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(
+                    #    required=False,
+                    #    choices=[
+                    #        "Active",
+                    #        "Offline",
+                    #        "Planned",
+                    #        "Provisioning",
+                    #        "Deprovisioning",
+                    #        "Decommissioned",
+                    #    ],
+                    # ),
+                    tenant=dict(required=False, type="raw"),
+                    install_date=dict(required=False, type="str"),
+                    commit_rate=dict(required=False, type="int"),
+                    description=dict(required=False, type="str"),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
 
     required_if = [("state", "present", ["cid"]), ("state", "absent", ["cid"])]

--- a/plugins/modules/netbox_circuit_termination.py
+++ b/plugins/modules/netbox_circuit_termination.py
@@ -137,6 +137,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_circuits import (
     NetboxCircuitsModule,
@@ -148,13 +149,26 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    circuit=dict(required=True, type="raw"),
+                    term_side=dict(required=True, choices=["A", "Z"]),
+                    site=dict(required=False, type="raw"),
+                    port_speed=dict(required=False, type="int"),
+                    upstream_speed=dict(required=False, type="int"),
+                    xconnect_id=dict(required=False, type="str"),
+                    pp_info=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
+                ),
+            ),
+        )
     )
+
     required_if = [
         ("state", "present", ["circuit", "term_side"]),
         ("state", "absent", ["circuit", "term_side"]),

--- a/plugins/modules/netbox_circuit_type.py
+++ b/plugins/modules/netbox_circuit_type.py
@@ -93,6 +93,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_circuits import (
     NetboxCircuitsModule,
@@ -104,12 +105,18 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                ),
+            ),
+        )
     )
 
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]

--- a/plugins/modules/netbox_cluster.py
+++ b/plugins/modules/netbox_cluster.py
@@ -136,6 +136,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_virtualization import (
     NetboxVirtualizationModule,
@@ -147,12 +148,23 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    cluster_type=dict(required=False, type="raw"),
+                    cluster_group=dict(required=False, type="raw"),
+                    site=dict(required=False, type="raw"),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
 
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]

--- a/plugins/modules/netbox_cluster_group.py
+++ b/plugins/modules/netbox_cluster_group.py
@@ -93,6 +93,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_virtualization import (
     NetboxVirtualizationModule,
@@ -104,12 +105,18 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                ),
+            ),
+        )
     )
 
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]

--- a/plugins/modules/netbox_cluster_type.py
+++ b/plugins/modules/netbox_cluster_type.py
@@ -93,6 +93,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_virtualization import (
     NetboxVirtualizationModule,
@@ -104,12 +105,18 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                ),
+            ),
+        )
     )
 
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]

--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -181,6 +181,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -192,13 +193,52 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    device_type=dict(required=False, type="raw"),
+                    device_role=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="raw"),
+                    platform=dict(required=False, type="raw"),
+                    serial=dict(required=False, type="str"),
+                    asset_tag=dict(required=False, type="str"),
+                    site=dict(required=False, type="raw"),
+                    rack=dict(required=False, type="raw"),
+                    position=dict(required=False, type="int"),
+                    face=dict(
+                        required=False,
+                        type="str",
+                        choices=["Front", "front", "Rear", "rear"],
+                    ),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(
+                    #    required=False,
+                    #    choices=[
+                    #        "Active",
+                    #        "Offline",
+                    #        "Planned",
+                    #        "Staged",
+                    #        "Failed",
+                    #        "Inventory",
+                    #    ],
+                    # ),
+                    primary_ip4=dict(required=False, type="raw"),
+                    primary_ip6=dict(required=False, type="raw"),
+                    cluster=dict(required=False, type="raw"),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_device_bay.py
+++ b/plugins/modules/netbox_device_bay.py
@@ -120,6 +120,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -131,13 +132,23 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    device=dict(required=False, type="raw"),
+                    name=dict(required=True, type="str"),
+                    description=dict(required=False, type="str"),
+                    installed_device=dict(required=False, type="raw"),
+                    tags=dict(required=False, type=list),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -205,6 +205,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -216,13 +217,33 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    device=dict(required=False, type="raw"),
+                    name=dict(required=True, type="str"),
+                    form_factor=dict(required=False, type="raw"),
+                    enabled=dict(required=False, type="bool"),
+                    lag=dict(required=False, type="raw"),
+                    mtu=dict(required=False, type="int"),
+                    mac_address=dict(required=False, type="str"),
+                    mgmt_only=dict(required=False, type="bool"),
+                    description=dict(required=False, type="str"),
+                    mode=dict(
+                        required=False, choices=["Access", "Tagged", "Tagged All"],
+                    ),
+                    untagged_vlan=dict(required=False, type="raw"),
+                    tagged_vlans=dict(required=False, type="raw"),
+                    tags=dict(required=False, type=list),
+                ),
+            ),
+        )
     )
+
     required_if = [
         ("state", "present", ["device", "name"]),
         ("state", "absent", ["device", "name"]),

--- a/plugins/modules/netbox_device_role.py
+++ b/plugins/modules/netbox_device_role.py
@@ -103,6 +103,7 @@ msg:
 """
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -114,13 +115,22 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    color=dict(required=False, type="str"),
+                    slug=dict(required=False, type="str"),
+                    vm_role=dict(required=False, type="bool"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_device_type.py
+++ b/plugins/modules/netbox_device_type.py
@@ -144,6 +144,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -155,13 +156,30 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    manufacturer=dict(required=False, type="raw"),
+                    model=dict(required=False, type="raw"),
+                    slug=dict(required=True, type="str"),
+                    part_number=dict(required=False, type="str"),
+                    u_height=dict(required=False, type="int"),
+                    is_full_depth=dict(required=False, type="bool"),
+                    subdevice_role=dict(
+                        required=False, choices=["Parent", "parent", "Child", "child"]
+                    ),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["slug"]), ("state", "absent", ["slug"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_inventory_item.py
+++ b/plugins/modules/netbox_inventory_item.py
@@ -138,6 +138,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -149,13 +150,26 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    device=dict(required=False, type="raw"),
+                    name=dict(required=True, type="str"),
+                    manufacturer=dict(required=False, type="raw"),
+                    part_id=dict(required=False, type="str"),
+                    serial=dict(required=False, type="str"),
+                    asset_tag=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                ),
+            ),
+        )
     )
+
     required_if = [
         ("state", "present", ["device", "name"]),
         ("state", "absent", ["device", "name"]),

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -224,6 +224,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -235,15 +236,53 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(
-            required=False, default="present", choices=["present", "absent", "new"]
-        ),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    # state choices present, absent, new
+    argument_spec["state"] = dict(
+        required=False, default="present", choices=["present", "absent", "new"]
     )
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    family=dict(required=False, type="int"),
+                    address=dict(required=False, type="str"),
+                    prefix=dict(required=False, type="raw"),
+                    vrf=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="raw"),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(
+                    #    required=False,
+                    #    type="str",
+                    #    choices=["Active", "Reserved", "Deprecated", "DHCP"],
+                    # ),
+                    role=dict(
+                        required=False,
+                        type="str",
+                        choices=[
+                            "Loopback",
+                            "Secondary",
+                            "Anycast",
+                            "VIP",
+                            "VRRP",
+                            "HSRP",
+                            "GLBP",
+                            "CARP",
+                        ],
+                    ),
+                    interface=dict(required=False, type="raw"),
+                    description=dict(required=False, type="str"),
+                    nat_inside=dict(required=False, type="raw"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
+    )
+
     required_if = [
         ("state", "present", ["address", "prefix"], True),
         ("state", "absent", ["address"]),

--- a/plugins/modules/netbox_ipam_role.py
+++ b/plugins/modules/netbox_ipam_role.py
@@ -104,6 +104,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -115,13 +116,21 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                    weight=dict(required=False, type="int"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_manufacturer.py
+++ b/plugins/modules/netbox_manufacturer.py
@@ -93,6 +93,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -104,13 +105,20 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_platform.py
+++ b/plugins/modules/netbox_platform.py
@@ -115,6 +115,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -126,13 +127,23 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                    manufacturer=dict(required=False, type="raw"),
+                    napalm_driver=dict(required=False, type="str"),
+                    napalm_args=dict(required=False, type="dict"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_prefix.py
+++ b/plugins/modules/netbox_prefix.py
@@ -64,7 +64,7 @@ options:
           - |
             Required ONLY if state is C(present) and first_available is C(yes).
             Will get a new available prefix of the given prefix_length in this parent prefix.
-        type: str
+        type: int
       site:
         description:
           - Site that prefix is associated with
@@ -232,6 +232,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -243,14 +244,39 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        first_available=dict(type="bool", required=False, default=False),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    family=dict(required=False, type="int"),
+                    prefix=dict(required=False, type="raw"),
+                    parent=dict(required=False, type="raw"),
+                    prefix_length=dict(required=False, type="int"),
+                    site=dict(required=False, type="str"),
+                    vrf=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="raw"),
+                    vlan=dict(required=False, type="raw"),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(
+                    #    required=False,
+                    #    type="str",
+                    #    choices=["Active", "Container", "Deprecated", "Reserved"],
+                    # ),
+                    prefix_role=dict(required=False, type="raw"),
+                    is_pool=dict(required=False, type="bool"),
+                    description=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+            first_available=dict(required=False, type="bool"),
+        )
     )
+
     required_if = [
         ("state", "present", ["prefix", "parent"], True),
         ("state", "absent", ["prefix"]),

--- a/plugins/modules/netbox_rack.py
+++ b/plugins/modules/netbox_rack.py
@@ -168,6 +168,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -179,13 +180,61 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    facility_id=dict(required=False, type="str"),
+                    site=dict(required=False, type="raw"),
+                    rack_group=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="raw"),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(
+                    #    required=False,
+                    #    type="str",
+                    #    choices=[
+                    #        "Active",
+                    #        "Planned",
+                    #        "Reserved",
+                    #        "Available",
+                    #        "Deprecated",
+                    #    ],
+                    # ),
+                    rack_role=dict(required=False, type="raw"),
+                    serial=dict(required=False, type="str"),
+                    asset_tag=dict(required=False, type="str"),
+                    type=dict(
+                        required=False,
+                        type="str",
+                        choices=[
+                            "2-post frame",
+                            "4-post frame",
+                            "4-post cabinet",
+                            "Wall-mounted frame",
+                            "Wall-mounted cabinet",
+                        ],
+                    ),
+                    width=dict(required=False, type="str", choices=["19", "23",],),
+                    u_height=dict(required=False, type="int"),
+                    desc_units=dict(required=False, type="bool"),
+                    outer_width=dict(required=False, type="int"),
+                    outer_depth=dict(required=False, type="int"),
+                    outer_unit=dict(
+                        required=False, type="str", choices=["Millimeters", "Inches",],
+                    ),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_rack_group.py
+++ b/plugins/modules/netbox_rack_group.py
@@ -99,6 +99,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -110,13 +111,21 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                    site=dict(required=False, type="raw"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_rack_role.py
+++ b/plugins/modules/netbox_rack_role.py
@@ -99,6 +99,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -110,13 +111,21 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                    color=dict(required=False, type="str"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_region.py
+++ b/plugins/modules/netbox_region.py
@@ -103,6 +103,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -114,13 +115,21 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                    parent_region=dict(required=False, type="raw"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_rir.py
+++ b/plugins/modules/netbox_rir.py
@@ -107,6 +107,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -118,13 +119,21 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                    is_private=dict(required=False, type="bool"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_site.py
+++ b/plugins/modules/netbox_site.py
@@ -195,6 +195,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_dcim import (
     NetboxDcimModule,
@@ -206,13 +207,41 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(
+                    #    required=False, choices=["Active", "Planned", "Retired"],
+                    # ),
+                    region=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="raw"),
+                    vlan_role=dict(required=False, type="raw"),
+                    facility=dict(required=False, type="str"),
+                    asn=dict(required=False, type="int"),
+                    time_zone=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
+                    physical_address=dict(required=False, type="str"),
+                    shipping_address=dict(required=False, type="str"),
+                    latitude=dict(required=False, type="float"),
+                    longitude=dict(required=False, type="float"),
+                    contact_name=dict(required=False, type="str"),
+                    contact_phone=dict(required=False, type="str"),
+                    contact_email=dict(required=False, type="str"),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_tenant.py
+++ b/plugins/modules/netbox_tenant.py
@@ -135,6 +135,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_tenancy import (
     NetboxTenancyModule,
@@ -146,13 +147,24 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    tenant_group=dict(required=False, type="raw"),
+                    description=dict(required=False, type="str"),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_tenant_group.py
+++ b/plugins/modules/netbox_tenant_group.py
@@ -101,6 +101,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_tenancy import (
     NetboxTenancyModule,
@@ -112,13 +113,20 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -44,6 +44,9 @@ options:
         description:
           - The name of the virtual machine
         required: true
+      site:
+        description:
+          - The name of the site attach to the virtual machine
       cluster:
         description:
           - The name of the cluster attach to the virtual machine
@@ -159,6 +162,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_virtualization import (
     NetboxVirtualizationModule,
@@ -170,13 +174,34 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    site=dict(required=False, type="raw"),
+                    cluster=dict(required=False, type="raw"),
+                    virtual_machine_role=dict(required=False, type="raw"),
+                    vcpus=dict(required=False, type="int"),
+                    tenant=dict(required=False, type="raw"),
+                    platform=dict(required=False, type="raw"),
+                    primary_ip4=dict(required=False, type="raw"),
+                    primary_ip6=dict(required=False, type="raw"),
+                    memory=dict(required=False, type="int"),
+                    disk=dict(required=False, type="int"),
+                    rack=dict(required=False, type="raw"),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(required=False, type="str", choices=["Active", "Offline", "Staged"]),
+                    tags=dict(required=False, type=list),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_vlan.py
+++ b/plugins/modules/netbox_vlan.py
@@ -145,6 +145,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -156,14 +157,35 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    site=dict(required=False, type="raw"),
+                    vlan_group=dict(required=False, type="raw"),
+                    vid=dict(required=False, type="int"),
+                    name=dict(required=True, type="str"),
+                    tenant=dict(required=False, type="raw"),
+                    # Will uncomment other status dict once slugs are the only option (Netbox 2.8)
+                    status=dict(required=False, type="raw"),
+                    # status=dict(
+                    #    required=False, choices=["Active", "Reserved", "Deprecated"],
+                    # ),
+                    vlan_role=dict(required=False, type="raw"),
+                    description=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
-    required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
+    required_if = [
+        ("state", "present", ["name"]),
+        ("state", "absent", ["name"]),
+    ]
 
     module = NetboxAnsibleModule(
         argument_spec=argument_spec, supports_check_mode=True, required_if=required_if

--- a/plugins/modules/netbox_vlan_group.py
+++ b/plugins/modules/netbox_vlan_group.py
@@ -98,6 +98,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -109,13 +110,21 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
+                    site=dict(required=False, type="raw"),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_vm_interface.py
+++ b/plugins/modules/netbox_vm_interface.py
@@ -163,6 +163,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_virtualization import (
     NetboxVirtualizationModule,
@@ -174,13 +175,30 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    virtual_machine=dict(required=False, type="raw"),
+                    name=dict(required=True, type="str"),
+                    enabled=dict(required=False, type="bool"),
+                    mtu=dict(required=False, type="int"),
+                    mac_address=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
+                    mode=dict(
+                        required=False, choices=["Access", "Tagged", "Tagged All"],
+                    ),
+                    untagged_vlan=dict(required=False, type="raw"),
+                    tagged_vlans=dict(required=False, type="raw"),
+                    tags=dict(required=False, type=list),
+                ),
+            ),
+        )
     )
+
     required_if = [
         ("state", "present", ["virtual_machine", "name"]),
         ("state", "absent", ["virtual_machine", "name"]),

--- a/plugins/modules/netbox_vrf.py
+++ b/plugins/modules/netbox_vrf.py
@@ -128,6 +128,7 @@ msg:
 
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
     NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
 )
 from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_ipam import (
     NetboxIpamModule,
@@ -139,13 +140,25 @@ def main():
     """
     Main entry point for module execution
     """
-    argument_spec = dict(
-        netbox_url=dict(type="str", required=True),
-        netbox_token=dict(type="str", required=True, no_log=True),
-        data=dict(type="dict", required=True),
-        state=dict(required=False, default="present", choices=["present", "absent"]),
-        validate_certs=dict(type="bool", default=True),
+    argument_spec = NETBOX_ARG_SPEC
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    name=dict(required=True, type="str"),
+                    rd=dict(required=False, type="str"),
+                    tenant=dict(required=False, type="raw"),
+                    enforce_unique=dict(required=False, type="bool"),
+                    description=dict(required=False, type="str"),
+                    tags=dict(required=False, type=list),
+                    custom_fields=dict(required=False, type=dict),
+                ),
+            ),
+        )
     )
+
     required_if = [("state", "present", ["name"]), ("state", "absent", ["name"])]
 
     module = NetboxAnsibleModule(

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -1384,7 +1384,7 @@
           - test_five['diff']['after']['tags'][0] == "Schnozzberry"
           - test_five['diff']['after']['type'] == 100
           - test_five['diff']['after']['u_height'] == 48
-          - test_five['diff']['after']['width'] == 23
+          - test_five['diff']['after']['width'] == "23"
           - test_five['rack']['name'] == "Test rack one"
           - test_five['rack']['site'] == 1
           - test_five['rack']['asset_tag'] == "1234"
@@ -1401,7 +1401,7 @@
           - test_five['rack']['tags'][0] == "Schnozzberry"
           - test_five['rack']['type'] == 100
           - test_five['rack']['u_height'] == 48
-          - test_five['rack']['width'] == 23
+          - test_five['rack']['width'] == "23"
           - test_five['msg'] == "rack Test rack one updated"
 
     - name: "6 - Create rack with same asset tag and serial number"

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -196,12 +196,42 @@ def test_normalize_data_returns_correct_data(mock_netbox_module, before, after):
     assert norm_data == after
 
 
-def test_to_slug_returns_valid_slug(mock_netbox_module):
-    not_slug = "Test device-1_2"
-    expected_slug = "test-device-1_2"
-    convert_to_slug = mock_netbox_module._to_slug(not_slug)
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            {
+                "name": "Test Device",
+                "enabled": True,
+                "site": None,
+                "description": None,
+                "platform": None,
+                "status": 0,
+            },
+            {"name": "Test Device", "enabled": True, "status": 0},
+        ),
+    ],
+)
+def test_remove_arg_spec_defaults(mock_netbox_module, data, expected):
+    new_data = mock_netbox_module._remove_arg_spec_default(data)
 
-    assert expected_slug == convert_to_slug
+    assert new_data == expected
+
+
+@pytest.mark.parametrize(
+    "got, expected",
+    [
+        ("Test device-1_2", "test-device-1_2"),
+        ("TEST_DEVICE_1_2", "test_device_1_2"),
+        ("TEST DEVICE 1 2", "test-device-1-2"),
+        (1, 1),
+        (None, None),
+    ],
+)
+def test_to_slug_returns_valid_slug(mock_netbox_module, got, expected):
+    got_slug = mock_netbox_module._to_slug(got)
+
+    assert got_slug == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds arg specs to all modules to help point out issues with user inputted data.

I did use `type=raw` anywhere we may be able to use a string, dict, int, etc. to keep the flexibility.


Ansible also deprecated an optional feature and now just does it automatically in 2.10 so I had to make a change so the tests passed on the devel branch tests

Fixes #75 