### PR TITLE
BugFix: Fix device type slug

### DIFF
--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -74,6 +74,8 @@ class NetboxDcimModule(NetboxModule):
         # Used for msg output
         if data.get("name"):
             name = data["name"]
+        elif data.get("model") and not data.get("slug"):
+            name = data["model"]
         elif data.get("slug"):
             name = data["slug"]
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -380,6 +380,7 @@ SLUG_REQUIRED = {
     "cluster_groups",
     "cluster_types",
     "device_roles",
+    "device_types",
     "ipam_roles",
     "rack_groups",
     "rack_roles",

--- a/plugins/modules/netbox_device_type.py
+++ b/plugins/modules/netbox_device_type.py
@@ -51,8 +51,9 @@ options:
       slug:
         description:
           - The slug of the device type. Must follow slug formatting (URL friendly)
+          - If not specified, it will slugify the model
           - ex. test-device-type
-        required: true
+        required: false
       part_number:
         description:
           - The part number of the device type
@@ -165,7 +166,7 @@ def main():
                 options=dict(
                     manufacturer=dict(required=False, type="raw"),
                     model=dict(required=False, type="raw"),
-                    slug=dict(required=True, type="str"),
+                    slug=dict(required=False, type="str"),
                     part_number=dict(required=False, type="str"),
                     u_height=dict(required=False, type="int"),
                     is_full_depth=dict(required=False, type="bool"),

--- a/plugins/modules/netbox_device_type.py
+++ b/plugins/modules/netbox_device_type.py
@@ -165,7 +165,7 @@ def main():
                 required=True,
                 options=dict(
                     manufacturer=dict(required=False, type="raw"),
-                    model=dict(required=False, type="raw"),
+                    model=dict(required=True, type="raw"),
                     slug=dict(required=False, type="str"),
                     part_number=dict(required=False, type="str"),
                     u_height=dict(required=False, type="int"),
@@ -181,7 +181,7 @@ def main():
         )
     )
 
-    required_if = [("state", "present", ["slug"]), ("state", "absent", ["slug"])]
+    required_if = [("state", "present", ["model"]), ("state", "absent", ["model"])]
 
     module = NetboxAnsibleModule(
         argument_spec=argument_spec, supports_check_mode=True, required_if=required_if

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -1906,6 +1906,27 @@
           - test_five['device_type'] == None
           - test_five['msg'] == "device_type test-device-type already absent"
 
+    - name: "DEVICE_TYPE 6: Without Slug"
+      netbox_device_type:
+        netbox_url: http://localhost:32768
+        netbox_token: 0123456789abcdef0123456789abcdef01234567
+        data:
+          model: ws-test-3850
+          manufacturer: Test Manufacturer
+        state: present
+      register: test_six
+
+    - name: "DEVICE_TYPE 6: ASSERT - Without Slug"
+      assert:
+        that:
+          - test_one is changed
+          - test_one['diff']['before']['state'] == "absent"
+          - test_one['diff']['after']['state'] == "present"
+          - test_one['device_type']['slug'] == "ws-test-3850"
+          - test_one['device_type']['model'] == "ws-test-3850"
+          - test_one['device_type']['manufacturer'] == 3
+          - test_one['msg'] == "device_type ws-test-3850 created"
+
 ##
 ##
 ### NETBOX_DEVICE_ROLE

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -1919,13 +1919,13 @@
     - name: "DEVICE_TYPE 6: ASSERT - Without Slug"
       assert:
         that:
-          - test_one is changed
-          - test_one['diff']['before']['state'] == "absent"
-          - test_one['diff']['after']['state'] == "present"
-          - test_one['device_type']['slug'] == "ws-test-3850"
-          - test_one['device_type']['model'] == "ws-test-3850"
-          - test_one['device_type']['manufacturer'] == 3
-          - test_one['msg'] == "device_type ws-test-3850 created"
+          - test_six is changed
+          - test_six['diff']['before']['state'] == "absent"
+          - test_six['diff']['after']['state'] == "present"
+          - test_six['device_type']['slug'] == "ws-test-3850"
+          - test_six['device_type']['model'] == "ws-test-3850"
+          - test_six['device_type']['manufacturer'] == 3
+          - test_six['msg'] == "device_type ws-test-3850 created"
 
 ##
 ##

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -1829,7 +1829,7 @@
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
-          model: ws-test-3750
+          model: "WS Test 3750"
           manufacturer: Test Manufacturer
         state: present
       register: test_two
@@ -1839,7 +1839,7 @@
         that:
           - not test_two['changed']
           - test_one['device_type']['slug'] == "test-device-type"
-          - test_one['device_type']['model'] == "ws-test-3750"
+          - test_one['device_type']['model'] == "WS Test 3750"
           - test_one['device_type']['manufacturer'] == 3
           - test_two['msg'] == "device_type test-device-type already exists"
 
@@ -1895,7 +1895,7 @@
         netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
-          model: test-device-type
+          model: "Test Device Type"
         state: absent
       register: test_five
 
@@ -1904,14 +1904,14 @@
         that:
           - not test_five['changed']
           - test_five['device_type'] == None
-          - test_five['msg'] == "device_type test-device-type already absent"
+          - test_five['msg'] == "device_type Test Device Type already absent"
 
     - name: "DEVICE_TYPE 6: Without Slug"
       netbox_device_type:
         netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
-          model: ws-test-3850
+          model: "WS Test 3850"
           manufacturer: Test Manufacturer
         state: present
       register: test_six
@@ -1923,9 +1923,9 @@
           - test_six['diff']['before']['state'] == "absent"
           - test_six['diff']['after']['state'] == "present"
           - test_six['device_type']['slug'] == "ws-test-3850"
-          - test_six['device_type']['model'] == "ws-test-3850"
+          - test_six['device_type']['model'] == "WS Test 3850"
           - test_six['device_type']['manufacturer'] == 3
-          - test_six['msg'] == "device_type ws-test-3850 created"
+          - test_six['msg'] == "device_type WS Test 3850 created"
 
 ##
 ##

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -1829,7 +1829,7 @@
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
-          model: "WS Test 3750"
+          model: "ws-test-3750"
           manufacturer: Test Manufacturer
         state: present
       register: test_two
@@ -1839,7 +1839,7 @@
         that:
           - not test_two['changed']
           - test_one['device_type']['slug'] == "test-device-type"
-          - test_one['device_type']['model'] == "WS Test 3750"
+          - test_one['device_type']['model'] == "ws-test-3750"
           - test_one['device_type']['manufacturer'] == 3
           - test_two['msg'] == "device_type test-device-type already exists"
 

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -1878,7 +1878,7 @@
         netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
-          slug: test-device-type
+          model: test-device-type
         state: absent
       register: test_four
 
@@ -1895,7 +1895,7 @@
         netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
-          slug: test-device-type
+          model: test-device-type
         state: absent
       register: test_five
 


### PR DESCRIPTION
Fixes #74 

Made **slug** not required, but model is now required. Slug can still be passed in, but if not, it will slugify the model.