### PR TITLE
BugFix: Convert keys in build_query_params

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -324,7 +324,7 @@ ALLOWED_QUERY_PARAMS = {
     "tenant_group": set(["name"]),
     "untagged_vlan": set(["name", "site", "vlan_group", "tenant"]),
     "virtual_machine": set(["name", "cluster"]),
-    "vlan": set(["name", "site", "tenant"]),
+    "vlan": set(["name", "site", "tenant", "group", "vlan_group"]),
     "vlan_group": set(["slug", "site"]),
     "vrf": set(["name", "tenant"]),
 }

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -577,7 +577,6 @@ class NetboxModule(object):
             else:
                 query_dict.update({"device": module_data["device"]})
 
-        query_dict = self._normalize_data(query_dict)
         query_dict = self._convert_identical_keys(query_dict)
         return query_dict
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -542,8 +542,10 @@ class NetboxModule(object):
         query_params = ALLOWED_QUERY_PARAMS.get(parent)
 
         if child:
+            child = self._convert_identical_keys(child)
             matches = query_params.intersection(set(child.keys()))
         else:
+            module_data = self._convert_identical_keys(module_data)
             matches = query_params.intersection(set(module_data.keys()))
 
         for match in matches:

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -324,7 +324,7 @@ ALLOWED_QUERY_PARAMS = {
     "tenant_group": set(["name"]),
     "untagged_vlan": set(["name", "site", "vlan_group", "tenant"]),
     "virtual_machine": set(["name", "cluster"]),
-    "vlan": set(["name", "site", "tenant", "group", "vlan_group"]),
+    "vlan": set(["name", "site", "tenant", "vlan_group"]),
     "vlan_group": set(["slug", "site"]),
     "vrf": set(["name", "tenant"]),
 }
@@ -340,7 +340,6 @@ QUERY_PARAMS_IDS = set(
         "site",
         "tenant",
         "type",
-        "vlan_group",
         "virtual_machine",
     ]
 )
@@ -542,10 +541,8 @@ class NetboxModule(object):
         query_params = ALLOWED_QUERY_PARAMS.get(parent)
 
         if child:
-            child = self._convert_identical_keys(child)
             matches = query_params.intersection(set(child.keys()))
         else:
-            module_data = self._convert_identical_keys(module_data)
             matches = query_params.intersection(set(module_data.keys()))
 
         for match in matches:
@@ -580,6 +577,8 @@ class NetboxModule(object):
             else:
                 query_dict.update({"device": module_data["device"]})
 
+        query_dict = self._normalize_data(query_dict)
+        query_dict = self._convert_identical_keys(query_dict)
         return query_dict
 
     def _change_choices_id(self, endpoint, data):

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -799,7 +799,12 @@ def test_build_query_params_no_child(
                 "tenant": "Test Tenant",
                 "vlan_group": "Test VLAN group",
             },
-            {"name": "Test VLAN", "site_id": 1, "tenant_id": 1, "group_id": 1},
+            {
+                "name": "Test VLAN",
+                "site_id": 1,
+                "tenant_id": 1,
+                "group": "test-vlan-group",
+            },
         ),
         (
             "vlan_group",

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -3,10 +3,6 @@
 # Copyright: (c) 2019, Mikhail Yohman (@FragmentedPacket) <mikhail.yohman@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# import unittest
-# from units.compat import unittest
-# from units.compat.mock import patch, MagicMock, Mock
-
 import pytest
 from unittest.mock import patch, MagicMock, Mock
 from ansible.module_utils.basic import AnsibleModule
@@ -803,7 +799,7 @@ def test_build_query_params_no_child(
                 "tenant": "Test Tenant",
                 "vlan_group": "Test VLAN group",
             },
-            {"name": "Test VLAN", "site_id": 1, "tenant_id": 1},
+            {"name": "Test VLAN", "site_id": 1, "tenant_id": 1, "group_id": 1},
         ),
         (
             "vlan_group",

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -803,7 +803,7 @@ def test_build_query_params_no_child(
                 "name": "Test VLAN",
                 "site_id": 1,
                 "tenant_id": 1,
-                "group": "test-vlan-group",
+                "group": "Test VLAN group",
             },
         ),
         (


### PR DESCRIPTION
This PR should fix #85 

Converts the identical keys to the proper key that Netbox is expecting when building query params