### PR TITLE
Feature: Removed static choices and return choices from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 [![Build Status](https://travis-ci.com/netbox-community/ansible_modules.svg?branch=devel)](https://travis-ci.com/netbox-community/ansible_modules)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+![Release](https://img.shields.io/github/v/release/netbox-community/ansible_modules)
 
 # Netbox modules for Ansible using Ansible Collections
 
 ## Requirements
 
 - Netbox 2.5+
-- **pynetbox 4.1.0+**
+- **pynetbox 4.2.5+**
 - Python 3.6+
 - Ansible 2.9+
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -508,7 +508,7 @@ class NetboxModule(object):
             for choice in required_choices:
                 if data.get(choice):
                     if isinstance(data[choice], int):
-                        break
+                        continue
                     choice_value = self._fetch_choice_value(data[choice], endpoint)
                     data[choice] = choice_value
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -181,111 +181,6 @@ ENDPOINT_NAME_MAPPING = {
     "vrfs": "vrf",
 }
 
-# FACE_ID = dict(front=0, rear=1)
-#
-# DEVICE_STATUS = dict(offline=0, active=1, planned=2, staged=3, failed=4, inventory=5)
-#
-# IP_ADDRESS_STATUS = dict(active=1, reserved=2, deprecated=3, dhcp=5)
-#
-# IP_ADDRESS_ROLE = dict(
-#    loopback=10, secondary=20, anycast=30, vip=40, vrrp=41, hsrp=42, glbp=43, carp=44
-# )
-#
-# PREFIX_STATUS = dict(container=0, active=1, reserved=2, deprecated=3)
-#
-# SITE_STATUS = dict(active=1, planned=2, retired=4)
-#
-# RACK_STATUS = dict(active=3, planned=2, reserved=0, available=1, deprecated=4)
-#
-# RACK_UNIT = dict(millimeters=1000, inches=2000)
-#
-# SUBDEVICE_ROLES = dict(parent=True, child=False)
-#
-# VLAN_STATUS = dict(active=1, reserved=2, deprecated=3)
-#
-# SERVICE_PROTOCOL = dict(tcp=6, udp=17)
-#
-# RACK_TYPE = {
-#    "2-post frame": 100,
-#    "4-post frame": 200,
-#    "4-post cabinet": 300,
-#    "wall-mounted frame": 1000,
-#    "wall-mounted cabinet": 1100,
-# }
-#
-# INTF_FORM_FACTOR = {
-#    "virtual": 0,
-#    "link aggregation group (lag)": 200,
-#    "100base-tx (10/100me)": 800,
-#    "1000base-t (1ge)": 1000,
-#    "10gbase-t (10ge)": 1150,
-#    "10gbase-cx4 (10ge)": 1170,
-#    "gbic (1ge)": 1050,
-#    "sfp (1ge)": 1100,
-#    "2.5gbase-t (2.5ge)": 1120,
-#    "5gbase-t (5ge)": 1130,
-#    "sfp+ (10ge)": 1200,
-#    "xfp (10ge)": 1300,
-#    "xenpak (10ge)": 1310,
-#    "x2 (10ge)": 1320,
-#    "sfp28 (25ge)": 1350,
-#    "qsfp+ (40ge)": 1400,
-#    "qsfp28 (50ge)": 1420,
-#    "cfp (100ge)": 1500,
-#    "cfp2 (100ge)": 1510,
-#    "cfp2 (200ge)": 1650,
-#    "cfp4 (100ge)": 1520,
-#    "cisco cpak (100ge)": 1550,
-#    "qsfp28 (100ge)": 1600,
-#    "qsfp56 (200ge)": 1700,
-#    "qsfp-dd (400ge)": 1750,
-#    "ieee 802.11a": 2600,
-#    "ieee 802.11b/g": 2610,
-#    "ieee 802.11n": 2620,
-#    "ieee 802.11ac": 2630,
-#    "ieee 802.11ad": 2640,
-#    "gsm": 2810,
-#    "cdma": 2820,
-#    "lte": 2830,
-#    "oc-3/stm-1": 6100,
-#    "oc-12/stm-4": 6200,
-#    "oc-48/stm-16": 6300,
-#    "oc-192/stm-64": 6400,
-#    "oc-768/stm-256": 6500,
-#    "oc-1920/stm-640": 6600,
-#    "oc-3840/stm-1234": 6700,
-#    "sfp (1gfc)": 3010,
-#    "sfp (2gfc)": 3020,
-#    "sfp (4gfc)": 3040,
-#    "sfp+ (8gfc)": 3080,
-#    "sfp+ (16gfc)": 3160,
-#    "sfp28 (32gfc)": 3320,
-#    "qsfp28 (128gfc)": 3400,
-#    "t1 (1.544 mbps)": 4000,
-#    "e1 (2.048 mbps)": 4010,
-#    "t3 (45 mbps)": 4040,
-#    "e3 (34 mbps)": 4050,
-#    "cisco stackwise": 5000,
-#    "cisco stackwise plus": 5050,
-#    "cisco flexstack": 5100,
-#    "cisco flexstack plus": 5150,
-#    "juniper vcp": 5200,
-#    "extreme summitstack": 5300,
-#    "extreme summitstack-128": 5310,
-#    "extreme summitstack-256": 5320,
-#    "extreme summitstack-512": 5330,
-#    "other": 32767,
-# }
-#
-# INTF_MODE = {"access": 100, "tagged": 200, "tagged all": 300}
-#
-# VIRTUAL_MACHINE_STATUS = dict(offline=0, active=1, staged=3)
-#
-# CIRCUIT_STATUS = dict(
-#    deprovisioning=0, active=1, planned=2, provisioning=3, offline=4, decommissioned=5,
-# )
-
-# This is used when attempting to search for existing endpoints
 ALLOWED_QUERY_PARAMS = {
     "aggregate": set(["prefix", "rir"]),
     "circuit": set(["cid"]),
@@ -346,20 +241,6 @@ QUERY_PARAMS_IDS = set(
     ]
 )
 
-# This is used when converting static choices to an ID value acceptable to Netbox API
-# REQUIRED_ID_FIND = {
-#    "circuits": [{"status": CIRCUIT_STATUS}],
-#    "devices": [{"status": DEVICE_STATUS, "face": FACE_ID}],
-#    "device_types": [{"subdevice_role": SUBDEVICE_ROLES}],
-#    "interfaces": [{"form_factor": INTF_FORM_FACTOR, "mode": INTF_MODE}],
-#    "ip_addresses": [{"status": IP_ADDRESS_STATUS, "role": IP_ADDRESS_ROLE}],
-#    "prefixes": [{"status": PREFIX_STATUS}],
-#    "racks": [{"status": RACK_STATUS, "outer_unit": RACK_UNIT, "type": RACK_TYPE}],
-#    "services": [{"protocol": SERVICE_PROTOCOL}],
-#    "sites": [{"status": SITE_STATUS}],
-#    "virtual_machines": [{"status": VIRTUAL_MACHINE_STATUS, "face": FACE_ID}],
-#    "vlans": [{"status": VLAN_STATUS}],
-# }
 REQUIRED_ID_FIND = {
     "circuits": set(["status"]),
     "devices": set(["status", "face"]),

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -431,6 +431,7 @@ class NetboxModule(object):
         self.state = self.module.params["state"]
         self.check_mode = self.module.check_mode
         self.endpoint = endpoint
+        self.version = None
 
         if not HAS_PYNETBOX:
             self.module.fail_json(
@@ -501,7 +502,7 @@ class NetboxModule(object):
         Returns data
         :params data (dict): Data dictionary after _find_ids method ran
         """
-        if self.version >= 2.7:
+        if self.version and self.version >= 2.7:
             if data.get("form_factor"):
                 data["type"] = data.pop("form_factor")
         for key in data:

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 
 # Import necessary packages
 import traceback
+from itertools import chain
 from ansible.module_utils.compat import ipaddress
 from ansible.module_utils._text import to_text
 
@@ -180,109 +181,109 @@ ENDPOINT_NAME_MAPPING = {
     "vrfs": "vrf",
 }
 
-FACE_ID = dict(front=0, rear=1)
-
-DEVICE_STATUS = dict(offline=0, active=1, planned=2, staged=3, failed=4, inventory=5)
-
-IP_ADDRESS_STATUS = dict(active=1, reserved=2, deprecated=3, dhcp=5)
-
-IP_ADDRESS_ROLE = dict(
-    loopback=10, secondary=20, anycast=30, vip=40, vrrp=41, hsrp=42, glbp=43, carp=44
-)
-
-PREFIX_STATUS = dict(container=0, active=1, reserved=2, deprecated=3)
-
-SITE_STATUS = dict(active=1, planned=2, retired=4)
-
-RACK_STATUS = dict(active=3, planned=2, reserved=0, available=1, deprecated=4)
-
-RACK_UNIT = dict(millimeters=1000, inches=2000)
-
-SUBDEVICE_ROLES = dict(parent=True, child=False)
-
-VLAN_STATUS = dict(active=1, reserved=2, deprecated=3)
-
-SERVICE_PROTOCOL = dict(tcp=6, udp=17)
-
-RACK_TYPE = {
-    "2-post frame": 100,
-    "4-post frame": 200,
-    "4-post cabinet": 300,
-    "wall-mounted frame": 1000,
-    "wall-mounted cabinet": 1100,
-}
-
-INTF_FORM_FACTOR = {
-    "virtual": 0,
-    "link aggregation group (lag)": 200,
-    "100base-tx (10/100me)": 800,
-    "1000base-t (1ge)": 1000,
-    "10gbase-t (10ge)": 1150,
-    "10gbase-cx4 (10ge)": 1170,
-    "gbic (1ge)": 1050,
-    "sfp (1ge)": 1100,
-    "2.5gbase-t (2.5ge)": 1120,
-    "5gbase-t (5ge)": 1130,
-    "sfp+ (10ge)": 1200,
-    "xfp (10ge)": 1300,
-    "xenpak (10ge)": 1310,
-    "x2 (10ge)": 1320,
-    "sfp28 (25ge)": 1350,
-    "qsfp+ (40ge)": 1400,
-    "qsfp28 (50ge)": 1420,
-    "cfp (100ge)": 1500,
-    "cfp2 (100ge)": 1510,
-    "cfp2 (200ge)": 1650,
-    "cfp4 (100ge)": 1520,
-    "cisco cpak (100ge)": 1550,
-    "qsfp28 (100ge)": 1600,
-    "qsfp56 (200ge)": 1700,
-    "qsfp-dd (400ge)": 1750,
-    "ieee 802.11a": 2600,
-    "ieee 802.11b/g": 2610,
-    "ieee 802.11n": 2620,
-    "ieee 802.11ac": 2630,
-    "ieee 802.11ad": 2640,
-    "gsm": 2810,
-    "cdma": 2820,
-    "lte": 2830,
-    "oc-3/stm-1": 6100,
-    "oc-12/stm-4": 6200,
-    "oc-48/stm-16": 6300,
-    "oc-192/stm-64": 6400,
-    "oc-768/stm-256": 6500,
-    "oc-1920/stm-640": 6600,
-    "oc-3840/stm-1234": 6700,
-    "sfp (1gfc)": 3010,
-    "sfp (2gfc)": 3020,
-    "sfp (4gfc)": 3040,
-    "sfp+ (8gfc)": 3080,
-    "sfp+ (16gfc)": 3160,
-    "sfp28 (32gfc)": 3320,
-    "qsfp28 (128gfc)": 3400,
-    "t1 (1.544 mbps)": 4000,
-    "e1 (2.048 mbps)": 4010,
-    "t3 (45 mbps)": 4040,
-    "e3 (34 mbps)": 4050,
-    "cisco stackwise": 5000,
-    "cisco stackwise plus": 5050,
-    "cisco flexstack": 5100,
-    "cisco flexstack plus": 5150,
-    "juniper vcp": 5200,
-    "extreme summitstack": 5300,
-    "extreme summitstack-128": 5310,
-    "extreme summitstack-256": 5320,
-    "extreme summitstack-512": 5330,
-    "other": 32767,
-}
-
-INTF_MODE = {"access": 100, "tagged": 200, "tagged all": 300}
-
-VIRTUAL_MACHINE_STATUS = dict(offline=0, active=1, staged=3)
-
-CIRCUIT_STATUS = dict(
-    deprovisioning=0, active=1, planned=2, provisioning=3, offline=4, decommissioned=5,
-)
+# FACE_ID = dict(front=0, rear=1)
+#
+# DEVICE_STATUS = dict(offline=0, active=1, planned=2, staged=3, failed=4, inventory=5)
+#
+# IP_ADDRESS_STATUS = dict(active=1, reserved=2, deprecated=3, dhcp=5)
+#
+# IP_ADDRESS_ROLE = dict(
+#    loopback=10, secondary=20, anycast=30, vip=40, vrrp=41, hsrp=42, glbp=43, carp=44
+# )
+#
+# PREFIX_STATUS = dict(container=0, active=1, reserved=2, deprecated=3)
+#
+# SITE_STATUS = dict(active=1, planned=2, retired=4)
+#
+# RACK_STATUS = dict(active=3, planned=2, reserved=0, available=1, deprecated=4)
+#
+# RACK_UNIT = dict(millimeters=1000, inches=2000)
+#
+# SUBDEVICE_ROLES = dict(parent=True, child=False)
+#
+# VLAN_STATUS = dict(active=1, reserved=2, deprecated=3)
+#
+# SERVICE_PROTOCOL = dict(tcp=6, udp=17)
+#
+# RACK_TYPE = {
+#    "2-post frame": 100,
+#    "4-post frame": 200,
+#    "4-post cabinet": 300,
+#    "wall-mounted frame": 1000,
+#    "wall-mounted cabinet": 1100,
+# }
+#
+# INTF_FORM_FACTOR = {
+#    "virtual": 0,
+#    "link aggregation group (lag)": 200,
+#    "100base-tx (10/100me)": 800,
+#    "1000base-t (1ge)": 1000,
+#    "10gbase-t (10ge)": 1150,
+#    "10gbase-cx4 (10ge)": 1170,
+#    "gbic (1ge)": 1050,
+#    "sfp (1ge)": 1100,
+#    "2.5gbase-t (2.5ge)": 1120,
+#    "5gbase-t (5ge)": 1130,
+#    "sfp+ (10ge)": 1200,
+#    "xfp (10ge)": 1300,
+#    "xenpak (10ge)": 1310,
+#    "x2 (10ge)": 1320,
+#    "sfp28 (25ge)": 1350,
+#    "qsfp+ (40ge)": 1400,
+#    "qsfp28 (50ge)": 1420,
+#    "cfp (100ge)": 1500,
+#    "cfp2 (100ge)": 1510,
+#    "cfp2 (200ge)": 1650,
+#    "cfp4 (100ge)": 1520,
+#    "cisco cpak (100ge)": 1550,
+#    "qsfp28 (100ge)": 1600,
+#    "qsfp56 (200ge)": 1700,
+#    "qsfp-dd (400ge)": 1750,
+#    "ieee 802.11a": 2600,
+#    "ieee 802.11b/g": 2610,
+#    "ieee 802.11n": 2620,
+#    "ieee 802.11ac": 2630,
+#    "ieee 802.11ad": 2640,
+#    "gsm": 2810,
+#    "cdma": 2820,
+#    "lte": 2830,
+#    "oc-3/stm-1": 6100,
+#    "oc-12/stm-4": 6200,
+#    "oc-48/stm-16": 6300,
+#    "oc-192/stm-64": 6400,
+#    "oc-768/stm-256": 6500,
+#    "oc-1920/stm-640": 6600,
+#    "oc-3840/stm-1234": 6700,
+#    "sfp (1gfc)": 3010,
+#    "sfp (2gfc)": 3020,
+#    "sfp (4gfc)": 3040,
+#    "sfp+ (8gfc)": 3080,
+#    "sfp+ (16gfc)": 3160,
+#    "sfp28 (32gfc)": 3320,
+#    "qsfp28 (128gfc)": 3400,
+#    "t1 (1.544 mbps)": 4000,
+#    "e1 (2.048 mbps)": 4010,
+#    "t3 (45 mbps)": 4040,
+#    "e3 (34 mbps)": 4050,
+#    "cisco stackwise": 5000,
+#    "cisco stackwise plus": 5050,
+#    "cisco flexstack": 5100,
+#    "cisco flexstack plus": 5150,
+#    "juniper vcp": 5200,
+#    "extreme summitstack": 5300,
+#    "extreme summitstack-128": 5310,
+#    "extreme summitstack-256": 5320,
+#    "extreme summitstack-512": 5330,
+#    "other": 32767,
+# }
+#
+# INTF_MODE = {"access": 100, "tagged": 200, "tagged all": 300}
+#
+# VIRTUAL_MACHINE_STATUS = dict(offline=0, active=1, staged=3)
+#
+# CIRCUIT_STATUS = dict(
+#    deprovisioning=0, active=1, planned=2, provisioning=3, offline=4, decommissioned=5,
+# )
 
 # This is used when attempting to search for existing endpoints
 ALLOWED_QUERY_PARAMS = {
@@ -346,18 +347,31 @@ QUERY_PARAMS_IDS = set(
 )
 
 # This is used when converting static choices to an ID value acceptable to Netbox API
+# REQUIRED_ID_FIND = {
+#    "circuits": [{"status": CIRCUIT_STATUS}],
+#    "devices": [{"status": DEVICE_STATUS, "face": FACE_ID}],
+#    "device_types": [{"subdevice_role": SUBDEVICE_ROLES}],
+#    "interfaces": [{"form_factor": INTF_FORM_FACTOR, "mode": INTF_MODE}],
+#    "ip_addresses": [{"status": IP_ADDRESS_STATUS, "role": IP_ADDRESS_ROLE}],
+#    "prefixes": [{"status": PREFIX_STATUS}],
+#    "racks": [{"status": RACK_STATUS, "outer_unit": RACK_UNIT, "type": RACK_TYPE}],
+#    "services": [{"protocol": SERVICE_PROTOCOL}],
+#    "sites": [{"status": SITE_STATUS}],
+#    "virtual_machines": [{"status": VIRTUAL_MACHINE_STATUS, "face": FACE_ID}],
+#    "vlans": [{"status": VLAN_STATUS}],
+# }
 REQUIRED_ID_FIND = {
-    "circuits": [{"status": CIRCUIT_STATUS}],
-    "devices": [{"status": DEVICE_STATUS, "face": FACE_ID}],
-    "device_types": [{"subdevice_role": SUBDEVICE_ROLES}],
-    "interfaces": [{"form_factor": INTF_FORM_FACTOR, "mode": INTF_MODE}],
-    "ip_addresses": [{"status": IP_ADDRESS_STATUS, "role": IP_ADDRESS_ROLE}],
-    "prefixes": [{"status": PREFIX_STATUS}],
-    "racks": [{"status": RACK_STATUS, "outer_unit": RACK_UNIT, "type": RACK_TYPE}],
-    "services": [{"protocol": SERVICE_PROTOCOL}],
-    "sites": [{"status": SITE_STATUS}],
-    "virtual_machines": [{"status": VIRTUAL_MACHINE_STATUS, "face": FACE_ID}],
-    "vlans": [{"status": VLAN_STATUS}],
+    "circuits": set(["status"]),
+    "devices": set(["status", "face"]),
+    "device_types": set(["subdevice_role"]),
+    "interfaces": set(["form_factor", "mode"]),
+    "ip_addresses": set(["status", "role"]),
+    "prefixes": set(["status"]),
+    "racks": set(["status", "outer_unit", "type"]),
+    "services": set(["protocol"]),
+    "sites": set(["status"]),
+    "virtual_machines": set(["status", "face"]),
+    "vlans": set(["status"]),
 }
 
 # This is used to map non-clashing keys to Netbox API compliant keys to prevent bad logic in code for similar keys but different modules
@@ -444,7 +458,7 @@ class NetboxModule(object):
         try:
             nb = pynetbox.api(url, token=token, ssl_verify=ssl_verify)
             try:
-                self.version = nb.version
+                self.version = float(nb.version)
             except AttributeError:
                 self.module.fail_json(msg="Must have pynetbox >=4.1.0")
             except Exception:
@@ -487,6 +501,9 @@ class NetboxModule(object):
         Returns data
         :params data (dict): Data dictionary after _find_ids method ran
         """
+        if self.version >= 2.7:
+            if data.get("form_factor"):
+                data["type"] = data.pop("form_factor")
         for key in data:
             if key in CONVERT_KEYS:
                 new_key = CONVERT_KEYS[key]
@@ -580,6 +597,23 @@ class NetboxModule(object):
 
         return query_dict
 
+    def _fetch_choice_value(self, search, endpoint):
+        app = self._find_app(endpoint)
+        nb_app = getattr(self.nb, app)
+        nb_endpoint = getattr(nb_app, endpoint)
+        endpoint_choices = nb_endpoint.choices()
+
+        choices = [x for x in chain.from_iterable(endpoint_choices.values())]
+
+        for item in choices:
+            if item["display_name"].lower() == search.lower():
+                return item["value"]
+            elif item["value"] == search.lower():
+                return item["value"]
+        self._handle_errors(
+            msg="%s was not found as a valid choice for %s" % (search, endpoint)
+        )
+
     def _change_choices_id(self, endpoint, data):
         """Used to change data that is static and under _choices for the application.
         ex. DEVICE_STATUS
@@ -590,17 +624,11 @@ class NetboxModule(object):
         if REQUIRED_ID_FIND.get(endpoint):
             required_choices = REQUIRED_ID_FIND[endpoint]
             for choice in required_choices:
-                for key, value in choice.items():
-                    if data.get(key):
-                        if isinstance(data[key], int):
-                            break
-                        try:
-                            data[key] = value[data[key].lower()]
-                        except KeyError:
-                            self._handle_errors(
-                                msg="%s may not be a valid choice. If it is valid, please submit bug report."
-                                % (key)
-                            )
+                if data.get(choice):
+                    if isinstance(data[choice], int):
+                        break
+                    choice_value = self._fetch_choice_value(data[choice], endpoint)
+                    data[choice] = choice_value
 
         return data
 

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -5,7 +5,7 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE"
-  hosts: localhosthost
+  hosts: localhost
   connection: local
   gather_facts: no
   collections:
@@ -189,7 +189,7 @@
 ##
 - name: "TEST NETBOX_DEVICE_INTERFACE"
   hosts: localhost
-  connection: localhost
+  connection: local
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -412,7 +412,7 @@
 ##
 ##
 - name: "TEST NETBOX_IP_ADDRESS"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -745,7 +745,7 @@
 ##
 ##
 - name: "TEST NETBOX_PREFIX"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -998,7 +998,7 @@
 ##
 ##
 - name: "TEST NETBOX_SITE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -1137,7 +1137,7 @@
 ##
 - name: "TEST NETBOX_TENANT"
   hosts: localhost
-  connection: localhost
+  connection: local
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -1250,7 +1250,7 @@
 ##
 - name: "TEST NETBOX_TENANT_GROUP"
   hosts: localhost
-  connection: localhost
+  connection: local
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -1314,7 +1314,7 @@
 ##
 - name: "TEST NETBOX_RACK"
   hosts: localhost
-  connection: localhost
+  connection: local
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -1498,7 +1498,7 @@
 ##
 ##
 - name: "TEST NETBOX_RACK_ROLE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -1587,7 +1587,7 @@
 ##
 ##
 - name: "TEST NETBOX_RACK_GROUP"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -1657,7 +1657,7 @@
 ##
 ##
 - name: "TEST NETBOX_MANUFACTURER"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -1756,7 +1756,7 @@
 ##
 ##
 - name: "TEST NETBOX_PLATFORM"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -1863,7 +1863,7 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_TYPE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2002,7 +2002,7 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_ROLE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2111,7 +2111,7 @@
 ##
 ##
 - name: "TEST NETBOX_IPAM_ROLE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2213,7 +2213,7 @@
 ##
 ##
 - name: "TEST NETBOX_VLAN_GROUP"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2339,7 +2339,7 @@
 ##
 ##
 - name: "TEST NETBOX_VLAN"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2490,7 +2490,7 @@
 ##
 ##
 - name: "TEST NETBOX_VRF"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2626,7 +2626,7 @@
 ##
 ##
 - name: "TEST NETBOX_RIR"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2713,7 +2713,7 @@
 ##
 ##
 - name: "TEST NETBOX_AGGREGATE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2836,7 +2836,7 @@
 ##
 ##
 - name: "TEST NETBOX_REGION"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -2923,7 +2923,7 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_BAY"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3018,7 +3018,7 @@
 ##
 ##
 - name: "TEST NETBOX_INVENTORY_ITEM"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3130,7 +3130,7 @@
 ##
 ##
 - name: "TEST NETBOX_VIRTUAL_MACHINES"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3237,7 +3237,7 @@
 ##
 ##
 - name: "TEST NETBOX_CLUSTER"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3340,7 +3340,7 @@
 ##
 ##
 - name: "TEST NETBOX_CLUSTER_GROUP"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3444,7 +3444,7 @@
 ##
 ##
 - name: "TEST NETBOX_CLUSTER_TYPE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3548,7 +3548,7 @@
 ##
 ##
 - name: "TEST NETBOX_VM_INTERFACE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3714,7 +3714,7 @@
 ##
 ##
 - name: "TEST NETBOX_PROVIDER"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3820,7 +3820,7 @@
 ##
 ##
 - name: "TEST NETBOX_CIRCUIT_TYPE"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -3923,7 +3923,7 @@
 ##
 ##
 - name: "TEST NETBOX_CIRCUIT"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -4039,7 +4039,7 @@
 ##
 ##
 - name: "TEST NETBOX_CIRCUIT_TERMINATION"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
   collections:
@@ -4276,7 +4276,7 @@
 ##
 ##
 - name: "TEST NETBOX_LOOKUP"
-  connection: localhost
+  connection: local
   hosts: localhost
   gather_facts: False
 

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -14,7 +14,7 @@
   tasks:
     - name: "1 - Device with required information"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -41,7 +41,7 @@
 
     - name: "2 - Duplicate device"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -65,7 +65,7 @@
 
     - name: "3 - Update device"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -88,7 +88,7 @@
 
     - name: "4 - Create device with tags and assign to rack"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "TestR1"
@@ -124,7 +124,7 @@
 
     - name: "5 - Delete previous device"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "TestR1"
@@ -141,7 +141,7 @@
 
     - name: "6 - Delete R1"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -158,7 +158,7 @@
 
     - name: "7 - Add primary_ip4/6 to test100"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "test100"
@@ -188,7 +188,7 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_INTERFACE"
-  hosts: netbox-demo.org
+  hosts: local
   connection: local
   gather_facts: no
   collections:
@@ -197,7 +197,7 @@
   tasks:
     - name: "1 - Interface with required information"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -216,7 +216,7 @@
 
     - name: "2 - Update test100 - GigabitEthernet3"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -239,7 +239,7 @@
 
     - name: "3 - Delete interface test100 - GigabitEthernet3"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -257,7 +257,7 @@
 
     - name: "4 - Create LAG with several specified options"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -286,7 +286,7 @@
 
     - name: "5 - Create interface and assign it to parent LAG"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -319,7 +319,7 @@
 
     - name: "6 - Create interface as trunk port"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -359,7 +359,7 @@
 
     - name: "7 - Duplicate Interface"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -376,7 +376,7 @@
 
     - name: "8 - Create interface and assign it to parent LAG - non dict"
       netbox_device_interface:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -413,7 +413,7 @@
 ##
 - name: "TEST NETBOX_IP_ADDRESS"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -421,7 +421,7 @@
   tasks:
     - name: "1 - Create IP address within Netbox with only required information - State: Present"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -439,7 +439,7 @@
 
     - name: "2 - Update 192.168.1.10/30"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -462,7 +462,7 @@
 
     - name: "3 - Delete IP - 192.168.1.10 - State: Absent"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -479,7 +479,7 @@
 
     - name: "4 - Create IP in global VRF - 192.168.1.20/30 - State: Present"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.20/30
@@ -497,7 +497,7 @@
 
     - name: "5 - Create IP in global VRF - 192.168.1.20/30 - State: New"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.20/30
@@ -515,7 +515,7 @@
 
     - name: "6 - Create new address with only prefix specified - State: new"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 192.168.100.0/24
@@ -533,7 +533,7 @@
 
     - name: "7 - Create IP address with several specified"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -566,7 +566,7 @@
 
     - name: "8 - Create IP address and assign a nat_inside IP"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -595,7 +595,7 @@
 
     - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -618,7 +618,7 @@
 
     - name: "10 - Create IP address on GigabitEthernet2 - test100 - State: new"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -642,7 +642,7 @@
 
     - name: "11 - Create IP address on GigabitEthernet2 - test100 - State: present"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -664,7 +664,7 @@
 
     - name: "12 - Duplicate - 192.168.100.2/24 on interface"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.100.2/24
@@ -684,7 +684,7 @@
 
     - name: "13 - Duplicate - 192.168.100.2/24"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.100.2/24
@@ -700,7 +700,7 @@
 
     - name: "14 - Create IP address on Eth0 - test100-vm - State: present"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -723,7 +723,7 @@
 
     - name: "15 - Create IP address with no mask - State: Present"
       netbox_ip_address:
-        netbox_url: http://netbox-demo.org.org:32768
+        netbox_url: http://local.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 10.120.10.1
@@ -746,7 +746,7 @@
 ##
 - name: "TEST NETBOX_PREFIX"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -754,7 +754,7 @@
   tasks:
     - name: "1 - Create prefix within Netbox with only required information"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -772,7 +772,7 @@
 
     - name: "2 - Duplicate"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -788,7 +788,7 @@
 
     - name: "3 - Update 10.156.0.0/19"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -813,7 +813,7 @@
 
     - name: "4 - Delete prefix within netbox"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -830,7 +830,7 @@
 
     - name: "5 - Create prefix with several specified options"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -873,7 +873,7 @@
 
     - name: "6 - Get a new /24 inside 10.156.0.0/19 within Netbox - Parent doesn't exist"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -890,7 +890,7 @@
 
     - name: "7 - Create prefix within Netbox with only required information"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -908,7 +908,7 @@
 
     - name: "8 - Get a new /24 inside 10.156.0.0/19 within Netbox"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -928,7 +928,7 @@
 
     - name: "9 - Create 10.157.0.0/19"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.157.0.0/19
@@ -950,7 +950,7 @@
 
     - name: "10 - Get a new /24 inside 10.157.0.0/19 within Netbox with additional values"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.157.0.0/19
@@ -974,7 +974,7 @@
 
     - name: "11 - Get a new /24 inside 10.156.0.0/19 within Netbox"
       netbox_prefix:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -999,7 +999,7 @@
 ##
 - name: "TEST NETBOX_SITE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1007,7 +1007,7 @@
   tasks:
     - name: "1 - Create site within Netbox with only required information"
       netbox_site:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1025,7 +1025,7 @@
 
     - name: "2 - Duplicate"
       netbox_site:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1041,7 +1041,7 @@
 
     - name: "3 - Update Test - Colorado"
       netbox_site:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1066,7 +1066,7 @@
 
     - name: "4 - Create site with all parameters"
       netbox_site:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - California
@@ -1114,7 +1114,7 @@
 
     - name: "5 - Delete site within netbox"
       netbox_site:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1136,7 +1136,7 @@
 ##
 ##
 - name: "TEST NETBOX_TENANT"
-  hosts: netbox-demo.org
+  hosts: local
   connection: local
   gather_facts: no
   collections:
@@ -1145,7 +1145,7 @@
   tasks:
     - name: "1 - Test tenant creation"
       netbox_tenant:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1163,7 +1163,7 @@
 
     - name: "Test duplicate tenant"
       netbox_tenant:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1179,7 +1179,7 @@
 
     - name: "3 - Test update"
       netbox_tenant:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1198,7 +1198,7 @@
 
     - name: "4 - Test delete"
       netbox_tenant:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1215,7 +1215,7 @@
 
     - name: "5 - Create tenant with all parameters"
       netbox_tenant:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1249,7 +1249,7 @@
 ##
 ##
 - name: "TEST NETBOX_TENANT_GROUP"
-  hosts: netbox-demo.org
+  hosts: local
   connection: local
   gather_facts: no
   collections:
@@ -1258,7 +1258,7 @@
   tasks:
     - name: "1 - Test tenant group creation"
       netbox_tenant_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1276,7 +1276,7 @@
 
     - name: "Test duplicate tenant group"
       netbox_tenant_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1292,7 +1292,7 @@
 
     - name: "3 - Test delete"
       netbox_tenant_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1313,7 +1313,7 @@
 ##
 ##
 - name: "TEST NETBOX_RACK"
-  hosts: netbox-demo.org
+  hosts: local
   connection: local
   gather_facts: no
   collections:
@@ -1322,7 +1322,7 @@
   tasks:
     - name: "1 - Test rack creation"
       netbox_rack:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1340,7 +1340,7 @@
 
     - name: "Test duplicate rack"
       netbox_rack:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1356,7 +1356,7 @@
 
     - name: "3 - Create new rack with similar name"
       netbox_rack:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack - Test Site
@@ -1376,7 +1376,7 @@
 
     - name: "4 - Attempt to create Test rack one again"
       netbox_rack:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack one
@@ -1394,7 +1394,7 @@
 
     - name: "5 - Update Test rack one with more options"
       netbox_rack:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack one
@@ -1458,7 +1458,7 @@
 
     - name: "6 - Create rack with same asset tag and serial number"
       netbox_rack:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack two
@@ -1477,7 +1477,7 @@
 
     - name: "7 - Test delete"
       netbox_rack:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1499,7 +1499,7 @@
 ##
 - name: "TEST NETBOX_RACK_ROLE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1507,7 +1507,7 @@
   tasks:
     - name: "RACK_ROLE 1: Necessary info creation"
       netbox_rack_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1528,7 +1528,7 @@
 
     - name: "RACK_ROLE 2: Create duplicate"
       netbox_rack_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1546,7 +1546,7 @@
 
     - name: "RACK_ROLE 3: Update"
       netbox_rack_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1566,7 +1566,7 @@
 
     - name: "RACK_ROLE 4: Delete"
       netbox_rack_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1588,7 +1588,7 @@
 ##
 - name: "TEST NETBOX_RACK_GROUP"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1596,7 +1596,7 @@
   tasks:
     - name: "RACK_GROUP 1: Necessary info creation"
       netbox_rack_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1617,7 +1617,7 @@
 
     - name: "RACK_GROUP 2: Create duplicate"
       netbox_rack_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1636,7 +1636,7 @@
 
     - name: "RACK_GROUP 3: ASSERT - Delete"
       netbox_rack_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1658,7 +1658,7 @@
 ##
 - name: "TEST NETBOX_MANUFACTURER"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1666,7 +1666,7 @@
   tasks:
     - name: "MANUFACTURER 1: Necessary info creation"
       netbox_manufacturer:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1685,7 +1685,7 @@
 
     - name: "MANUFACTURER 2: Create duplicate"
       netbox_manufacturer:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1702,7 +1702,7 @@
 
     - name: "MANUFACTURER 3: Update"
       netbox_manufacturer:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: test manufacturer two
@@ -1719,7 +1719,7 @@
 
     - name: "MANUFACTURER 4: ASSERT - Delete"
       netbox_manufacturer:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: test manufacturer two
@@ -1736,7 +1736,7 @@
 
     - name: "MANUFACTURER 5: ASSERT - Delete non existing"
       netbox_manufacturer:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1757,7 +1757,7 @@
 ##
 - name: "TEST NETBOX_PLATFORM"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1765,7 +1765,7 @@
   tasks:
     - name: "PLATFORM 1: Necessary info creation"
       netbox_platform:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1784,7 +1784,7 @@
 
     - name: "PLATFORM 2: Create duplicate"
       netbox_platform:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1801,7 +1801,7 @@
 
     - name: "PLATFORM 3: ASSERT - Update"
       netbox_platform:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1826,7 +1826,7 @@
 
     - name: "PLATFORM 4: ASSERT - Delete"
       netbox_platform:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1843,7 +1843,7 @@
 
     - name: "PLATFORM 5: ASSERT - Delete non existing"
       netbox_platform:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1864,7 +1864,7 @@
 ##
 - name: "TEST NETBOX_DEVICE_TYPE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1872,7 +1872,7 @@
   tasks:
     - name: "DEVICE_TYPE 1: Necessary info creation"
       netbox_device_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1894,7 +1894,7 @@
 
     - name: "DEVICE_TYPE 2: Create duplicate"
       netbox_device_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1914,7 +1914,7 @@
 
     - name: "DEVICE_TYPE 3: ASSERT - Update"
       netbox_device_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1944,7 +1944,7 @@
 
     - name: "DEVICE_TYPE 4: ASSERT - Delete"
       netbox_device_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: test-device-type
@@ -1961,7 +1961,7 @@
 
     - name: "DEVICE_TYPE 5: ASSERT - Delete non existing"
       netbox_device_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: "Test Device Type"
@@ -1977,7 +1977,7 @@
 
     - name: "DEVICE_TYPE 6: Without Slug"
       netbox_device_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: "WS Test 3850"
@@ -2003,7 +2003,7 @@
 ##
 - name: "TEST NETBOX_DEVICE_ROLE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2011,7 +2011,7 @@
   tasks:
     - name: "DEVICE_ROLE 1: Necessary info creation"
       netbox_device_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2032,7 +2032,7 @@
 
     - name: "DEVICE_ROLE 2: Create duplicate"
       netbox_device_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2051,7 +2051,7 @@
 
     - name: "DEVICE_ROLE 3: ASSERT - Update"
       netbox_device_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2074,7 +2074,7 @@
 
     - name: "DEVICE_ROLE 4: ASSERT - Delete"
       netbox_device_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Device Role
@@ -2091,7 +2091,7 @@
 
     - name: "DEVICE_ROLE 5: ASSERT - Delete non existing"
       netbox_device_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Device Role
@@ -2112,7 +2112,7 @@
 ##
 - name: "TEST NETBOX_IPAM_ROLE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2120,7 +2120,7 @@
   tasks:
     - name: "IPAM_ROLE 1: Necessary info creation"
       netbox_ipam_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2139,7 +2139,7 @@
 
     - name: "IPAM_ROLE 2: Create duplicate"
       netbox_ipam_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2156,7 +2156,7 @@
 
     - name: "IPAM_ROLE 3: ASSERT - Update"
       netbox_ipam_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2176,7 +2176,7 @@
 
     - name: "IPAM_ROLE 4: ASSERT - Delete"
       netbox_ipam_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test IPAM Role
@@ -2193,7 +2193,7 @@
 
     - name: "IPAM_ROLE 5: ASSERT - Delete non existing"
       netbox_ipam_role:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test IPAM Role
@@ -2214,7 +2214,7 @@
 ##
 - name: "TEST NETBOX_VLAN_GROUP"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2222,7 +2222,7 @@
   tasks:
     - name: "VLAN_GROUP 1: Necessary info creation"
       netbox_vlan_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2243,7 +2243,7 @@
 
     - name: "VLAN_GROUP 2: Create duplicate"
       netbox_vlan_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2262,7 +2262,7 @@
 
     - name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
       netbox_vlan_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2281,7 +2281,7 @@
 
     - name: "VLAN_GROUP 4: ASSERT - Create vlan group, no site"
       netbox_vlan_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2297,7 +2297,7 @@
 
     - name: "VLAN_GROUP 5: ASSERT - Delete"
       netbox_vlan_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: VLAN Group One
@@ -2318,7 +2318,7 @@
 
     - name: "VLAN_GROUP 6: ASSERT - Delete non existing"
       netbox_vlan_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: VLAN Group One
@@ -2340,7 +2340,7 @@
 ##
 - name: "TEST NETBOX_VLAN"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2348,7 +2348,7 @@
   tasks:
     - name: "VLAN 1: Necessary info creation"
       netbox_vlan:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2368,7 +2368,7 @@
 
     - name: "VLAN 2: Create duplicate"
       netbox_vlan:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2386,7 +2386,7 @@
 
     - name: "VLAN 3: Create VLAN with same name, but different site"
       netbox_vlan:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2409,7 +2409,7 @@
 
     - name: "VLAN 4: ASSERT - Update"
       netbox_vlan:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2446,7 +2446,7 @@
 
     - name: "VLAN 5: ASSERT - Delete more than one result"
       netbox_vlan:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2462,7 +2462,7 @@
 
     - name: "VLAN 6: ASSERT - Delete"
       netbox_vlan:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2491,7 +2491,7 @@
 ##
 - name: "TEST NETBOX_VRF"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2499,7 +2499,7 @@
   tasks:
     - name: "VRF 1: Necessary info creation"
       netbox_vrf:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2517,7 +2517,7 @@
 
     - name: "VRF 2: Create duplicate"
       netbox_vrf:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2533,7 +2533,7 @@
 
     - name: "VRF 3: Create VRF with same name, but different tenant"
       netbox_vrf:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2553,7 +2553,7 @@
 
     - name: "VRF 4: ASSERT - Update"
       netbox_vrf:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2584,7 +2584,7 @@
 
     - name: "VRF 5: ASSERT - Delete more than one result"
       netbox_vrf:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2600,7 +2600,7 @@
 
     - name: "VRF 6: ASSERT - Delete"
       netbox_vrf:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2627,7 +2627,7 @@
 ##
 - name: "TEST NETBOX_RIR"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2635,7 +2635,7 @@
   tasks:
     - name: "RIR 1: Necessary info creation"
       netbox_rir:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test RIR One
@@ -2654,7 +2654,7 @@
 
     - name: "RIR 2: Create duplicate"
       netbox_rir:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test RIR One
@@ -2671,7 +2671,7 @@
 
     - name: "RIR 3: ASSERT - Update"
       netbox_rir:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test RIR One"
@@ -2691,7 +2691,7 @@
 
     - name: "RIR 4: ASSERT - Delete"
       netbox_rir:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test RIR One"
@@ -2714,7 +2714,7 @@
 ##
 - name: "TEST NETBOX_AGGREGATE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2722,7 +2722,7 @@
   tasks:
     - name: "AGGREGATE 1: Necessary info creation"
       netbox_aggregate:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2743,7 +2743,7 @@
 
     - name: "AGGREGATE 2: Create duplicate"
       netbox_aggregate:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2761,7 +2761,7 @@
 
     - name: "AGGREGATE 3: ASSERT - Update"
       netbox_aggregate:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2790,7 +2790,7 @@
 
     - name: "AGGREGATE 4: ASSERT - Delete"
       netbox_aggregate:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2811,7 +2811,7 @@
 
     - name: "AGGREGATE 5: Necessary info creation"
       netbox_aggregate:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "2001::/32"
@@ -2837,7 +2837,7 @@
 ##
 - name: "TEST NETBOX_REGION"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2845,7 +2845,7 @@
   tasks:
     - name: "REGION 1: Necessary info creation"
       netbox_region:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2864,7 +2864,7 @@
 
     - name: "REGION 2: Create duplicate"
       netbox_region:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2881,7 +2881,7 @@
 
     - name: "REGION 3: ASSERT - Update"
       netbox_region:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2901,7 +2901,7 @@
 
     - name: "REGION 4: ASSERT - Delete"
       netbox_region:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2924,7 +2924,7 @@
 ##
 - name: "TEST NETBOX_DEVICE_BAY"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2932,7 +2932,7 @@
   tasks:
     - name: "DEVICE_BAY 1: Necessary info creation"
       netbox_device_bay:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2952,7 +2952,7 @@
 
     - name: "DEVICE_BAY 2: Create duplicate"
       netbox_device_bay:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2970,7 +2970,7 @@
 
     - name: "DEVICE_BAY 3: ASSERT - Update"
       netbox_device_bay:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2995,7 +2995,7 @@
 
     - name: "DEVICE_BAY 4: ASSERT - Delete"
       netbox_device_bay:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Device Bay One"
@@ -3019,7 +3019,7 @@
 ##
 - name: "TEST NETBOX_INVENTORY_ITEM"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3027,7 +3027,7 @@
   tasks:
     - name: "INVENTORY_ITEM 1: Necessary info creation"
       netbox_inventory_item:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3047,7 +3047,7 @@
 
     - name: "INVENTORY_ITEM 2: Create duplicate"
       netbox_inventory_item:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3065,7 +3065,7 @@
 
     - name: "INVENTORY_ITEM 3: ASSERT - Update"
       netbox_inventory_item:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3102,7 +3102,7 @@
 
     - name: "INVENTORY_ITEM 4: ASSERT - Delete"
       netbox_inventory_item:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3131,7 +3131,7 @@
 ##
 - name: "TEST NETBOX_VIRTUAL_MACHINES"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3139,7 +3139,7 @@
   tasks:
     - name: "VIRTUAL_MACHINE 1: Necessary info creation"
       netbox_virtual_machine:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3159,7 +3159,7 @@
 
     - name: "VIRTUAL_MACHINE 2: Create duplicate"
       netbox_virtual_machine:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3177,7 +3177,7 @@
 
     - name: "VIRTUAL_MACHINE 3: Update"
       netbox_virtual_machine:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3211,7 +3211,7 @@
 
     - name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
       netbox_virtual_machine:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3238,7 +3238,7 @@
 ##
 - name: "TEST NETBOX_CLUSTER"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3246,7 +3246,7 @@
   tasks:
     - name: "CLUSTER 1: Necessary info creation"
       netbox_cluster:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3266,7 +3266,7 @@
 
     - name: "CLUSTER 2: Create duplicate"
       netbox_cluster:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3284,7 +3284,7 @@
 
     - name: "CLUSTER 3: Update"
       netbox_cluster:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3315,7 +3315,7 @@
 
     - name: "CLUSTER 4: ASSERT - Delete"
       netbox_cluster:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3341,7 +3341,7 @@
 ##
 - name: "TEST NETBOX_CLUSTER_GROUP"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3349,7 +3349,7 @@
   tasks:
     - name: "CLUSTER_GROUP 1: Necessary info creation"
       netbox_cluster_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3368,7 +3368,7 @@
 
     - name: "CLUSTER_GROUP 2: Create duplicate"
       netbox_cluster_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3385,7 +3385,7 @@
 
     - name: "CLUSTER_GROUP 3: User specified slug"
       netbox_cluster_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group Two"
@@ -3405,7 +3405,7 @@
 
     - name: "CLUSTER_GROUP 4: ASSERT - Delete"
       netbox_cluster_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3422,7 +3422,7 @@
 
     - name: "CLUSTER_GROUP 5: ASSERT - Delete"
       netbox_cluster_group:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group Two"
@@ -3445,7 +3445,7 @@
 ##
 - name: "TEST NETBOX_CLUSTER_TYPE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3453,7 +3453,7 @@
   tasks:
     - name: "CLUSTER_TYPE 1: Necessary info creation"
       netbox_cluster_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3472,7 +3472,7 @@
 
     - name: "CLUSTER_TYPE 2: Create duplicate"
       netbox_cluster_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3489,7 +3489,7 @@
 
     - name: "CLUSTER_TYPE 3: User specified slug"
       netbox_cluster_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type Two"
@@ -3509,7 +3509,7 @@
 
     - name: "CLUSTER_TYPE 4: ASSERT - Delete"
       netbox_cluster_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3526,7 +3526,7 @@
 
     - name: "CLUSTER_TYPE 5: ASSERT - Delete"
       netbox_cluster_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type Two"
@@ -3549,7 +3549,7 @@
 ##
 - name: "TEST NETBOX_VM_INTERFACE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3557,7 +3557,7 @@
   tasks:
     - name: "NETBOX_VM_INTERFACE 1: Necessary info creation"
       netbox_vm_interface:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3577,7 +3577,7 @@
 
     - name: "NETBOX_VM_INTERFACE 2: Create duplicate"
       netbox_vm_interface:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3595,7 +3595,7 @@
 
     - name: "NETBOX_VM_INTERFACE 3: Updated"
       netbox_vm_interface:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3644,7 +3644,7 @@
 
     - name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
       netbox_vm_interface:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Eth10"
@@ -3662,7 +3662,7 @@
 
     - name: "NETBOX_VM_INTERFACE 5: Attempt to update interface with same name on other VMs"
       netbox_vm_interface:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3715,7 +3715,7 @@
 ##
 - name: "TEST NETBOX_PROVIDER"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3723,7 +3723,7 @@
   tasks:
     - name: "NETBOX_PROVIDER 1: Create provider within Netbox with only required information"
       netbox_provider:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3742,7 +3742,7 @@
 
     - name: "NETBOX_PROVIDER 2: Duplicate"
       netbox_provider:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3759,7 +3759,7 @@
 
     - name: "NETBOX_PROVIDER 3: Update provider with other fields"
       netbox_provider:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3794,7 +3794,7 @@
 
     - name: "NETBOX_PROVIDER 4: Delete provider within netbox"
       netbox_provider:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3821,7 +3821,7 @@
 ##
 - name: "TEST NETBOX_CIRCUIT_TYPE"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3829,7 +3829,7 @@
   tasks:
     - name: "CIRCUIT_TYPE 1: Necessary info creation"
       netbox_circuit_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3848,7 +3848,7 @@
 
     - name: "CIRCUIT_TYPE 2: Create duplicate"
       netbox_circuit_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3865,7 +3865,7 @@
 
     - name: "CIRCUIT_TYPE 3: User specified slug"
       netbox_circuit_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type Two"
@@ -3885,7 +3885,7 @@
 
     - name: "CIRCUIT_TYPE 4: ASSERT - Delete"
       netbox_circuit_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3902,7 +3902,7 @@
 
     - name: "CIRCUIT_TYPE 5: ASSERT - Delete"
       netbox_circuit_type:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type Two"
@@ -3924,7 +3924,7 @@
 ##
 - name: "TEST NETBOX_CIRCUIT"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3932,7 +3932,7 @@
   tasks:
     - name: "NETBOX_CIRCUIT 1: Create provider within Netbox with only required information"
       netbox_circuit:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -3954,7 +3954,7 @@
 
     - name: "NETBOX_CIRCUIT 2: Duplicate"
       netbox_circuit:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -3974,7 +3974,7 @@
 
     - name: "NETBOX_CIRCUIT 3: Update provider with other fields"
       netbox_circuit:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -4012,7 +4012,7 @@
 
     - name: "NETBOX_CIRCUIT 4: Delete provider within netbox"
       netbox_circuit:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -4040,7 +4040,7 @@
 ##
 - name: "TEST NETBOX_CIRCUIT_TERMINATION"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -4048,7 +4048,7 @@
   tasks:
     - name: "NETBOX_CIRCUIT_TERMINATION 1: Create provider within Netbox with only required information"
       netbox_circuit_termination:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4072,7 +4072,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 2: Duplicate"
       netbox_circuit_termination:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4092,7 +4092,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 3: Update provider with other fields"
       netbox_circuit_termination:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4124,7 +4124,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 4: Create Z Side"
       netbox_circuit_termination:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4148,7 +4148,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 5: Delete provider within netbox"
       netbox_circuit_termination:
-        netbox_url: http://netbox-demo.org:32768
+        netbox_url: http://local:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4178,7 +4178,7 @@
     ##
     - name: "1 - Device with required information needs to add new service"
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "FOR_SERVICE"
@@ -4190,7 +4190,7 @@
 
     - name: "NETBOX_SERVICE: Create new service"
       netbox_service:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4213,7 +4213,7 @@
 
     - name: "NETBOX_SERVICE: Test idempotence"
       netbox_service:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4232,7 +4232,7 @@
           - test_service_idempotence['msg'] == "services node-exporter already exists"
     - name: "NETBOX_SERVICE: Test update"
       netbox_service:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4252,7 +4252,7 @@
 
     - name: "NETBOX_SERVICE: Test service deletion"
       netbox_service:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4277,7 +4277,7 @@
 ##
 - name: "TEST NETBOX_LOOKUP"
   connection: local
-  hosts: netbox-demo.org
+  hosts: local
   gather_facts: False
 
   tasks:
@@ -4285,29 +4285,29 @@
       assert:
         that: "{{ query_result|count }} == 3"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'sites', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'sites', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`Wibble`]')|count }} == 0"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`TestDeviceR1`]')|count }} == 1"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 4: VLAN ID 400 can be queried and is named 'Test VLAN'"
       assert:
         that: "{{ (query_result|json_query('[?value.vid==`400`].value.name'))[0] == 'Test VLAN' }}"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'vlans', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'vlans', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 5: Add one of two devices for lookup filter test."
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "L1"
@@ -4321,7 +4321,7 @@
 
     - name: "NETBOX_LOOKUP 6: Add two of two devices for lookup filter test."
       netbox_device:
-        netbox_url: "http://netbox-demo.org:32768"
+        netbox_url: "http://local:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "L2"
@@ -4337,4 +4337,4 @@
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`L2`]')|count }} == 1"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -292,7 +292,7 @@
           device: test100
           name: GigabitEthernet3
           enabled: false
-          form_factor: 1000Base-t (1GE)
+          form_factor: 1000Base-T (1GE)
           lag:
             name: port-channel1
           mtu: 1600
@@ -325,7 +325,7 @@
           device: test100
           name: GigabitEthernet21
           enabled: false
-          form_factor: 1000Base-t (1GE)
+          form_factor: 1000Base-T (1GE)
           untagged_vlan:
             name: Wireless
             site: Test Site
@@ -382,7 +382,7 @@
           device: test100
           name: GigabitEthernet4
           enabled: false
-          form_factor: 1000Base-t (1GE)
+          form_factor: 1000Base-T (1GE)
           lag: "port-channel1"
           mtu: 1600
           mgmt_only: false
@@ -4171,11 +4171,11 @@
           - test_five['msg'] == "circuit_termination test_circuit_a deleted"
           -
 
-##
-##
-### NETBOX_SERVICE
-##
-##
+    ##
+    ##
+    ### NETBOX_SERVICE
+    ##
+    ##
     - name: "1 - Device with required information needs to add new service"
       netbox_device:
         netbox_url: "http://localhost:32768"
@@ -4250,7 +4250,6 @@
           - test_service_update['diff']['after']['protocol'] == 17
           - test_service_update['msg'] == "services node-exporter updated"
 
-
     - name: "NETBOX_SERVICE: Test service deletion"
       netbox_service:
         netbox_url: "http://localhost:32768"
@@ -4270,7 +4269,6 @@
           - test_service_delete['diff']['after']['state'] == "absent"
           - test_service_delete['diff']['before']['state'] == "present"
           - test_service_delete['msg'] == "services node-exporter deleted"
-
 
 ##
 ##
@@ -4317,7 +4315,7 @@
           device_role: "Core Switch"
           site: "Test Site"
           status: "Staged"
-          tags: 
+          tags:
             - "nolookup"
         state: present
 
@@ -4331,7 +4329,7 @@
           device_role: "Core Switch"
           site: "Test Site"
           status: "Staged"
-          tags: 
+          tags:
             - "lookup"
         state: present
 
@@ -4339,7 +4337,4 @@
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`L2`]')|count }} == 1"
       vars:
-          query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
-
-
-
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -14,7 +14,7 @@
   tasks:
     - name: "1 - Device with required information"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -41,7 +41,7 @@
 
     - name: "2 - Duplicate device"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -65,7 +65,7 @@
 
     - name: "3 - Update device"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -88,7 +88,7 @@
 
     - name: "4 - Create device with tags and assign to rack"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "TestR1"
@@ -124,7 +124,7 @@
 
     - name: "5 - Delete previous device"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "TestR1"
@@ -141,7 +141,7 @@
 
     - name: "6 - Delete R1"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -158,7 +158,7 @@
 
     - name: "7 - Add primary_ip4/6 to test100"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "test100"
@@ -188,7 +188,7 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_INTERFACE"
-  hosts: localhost
+  hosts: netbox-demo.org
   connection: local
   gather_facts: no
   collections:
@@ -197,7 +197,7 @@
   tasks:
     - name: "1 - Interface with required information"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -216,7 +216,7 @@
 
     - name: "2 - Update test100 - GigabitEthernet3"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -239,7 +239,7 @@
 
     - name: "3 - Delete interface test100 - GigabitEthernet3"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -257,7 +257,7 @@
 
     - name: "4 - Create LAG with several specified options"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -286,7 +286,7 @@
 
     - name: "5 - Create interface and assign it to parent LAG"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -319,7 +319,7 @@
 
     - name: "6 - Create interface as trunk port"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -359,7 +359,7 @@
 
     - name: "7 - Duplicate Interface"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -376,7 +376,7 @@
 
     - name: "8 - Create interface and assign it to parent LAG - non dict"
       netbox_device_interface:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -413,7 +413,7 @@
 ##
 - name: "TEST NETBOX_IP_ADDRESS"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -421,7 +421,7 @@
   tasks:
     - name: "1 - Create IP address within Netbox with only required information - State: Present"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -439,7 +439,7 @@
 
     - name: "2 - Update 192.168.1.10/30"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -462,7 +462,7 @@
 
     - name: "3 - Delete IP - 192.168.1.10 - State: Absent"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -479,7 +479,7 @@
 
     - name: "4 - Create IP in global VRF - 192.168.1.20/30 - State: Present"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.20/30
@@ -497,7 +497,7 @@
 
     - name: "5 - Create IP in global VRF - 192.168.1.20/30 - State: New"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.20/30
@@ -515,7 +515,7 @@
 
     - name: "6 - Create new address with only prefix specified - State: new"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 192.168.100.0/24
@@ -533,7 +533,7 @@
 
     - name: "7 - Create IP address with several specified"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -566,7 +566,7 @@
 
     - name: "8 - Create IP address and assign a nat_inside IP"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -595,7 +595,7 @@
 
     - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -618,7 +618,7 @@
 
     - name: "10 - Create IP address on GigabitEthernet2 - test100 - State: new"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -642,7 +642,7 @@
 
     - name: "11 - Create IP address on GigabitEthernet2 - test100 - State: present"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -664,7 +664,7 @@
 
     - name: "12 - Duplicate - 192.168.100.2/24 on interface"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.100.2/24
@@ -684,7 +684,7 @@
 
     - name: "13 - Duplicate - 192.168.100.2/24"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.100.2/24
@@ -700,7 +700,7 @@
 
     - name: "14 - Create IP address on Eth0 - test100-vm - State: present"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -723,7 +723,7 @@
 
     - name: "15 - Create IP address with no mask - State: Present"
       netbox_ip_address:
-        netbox_url: http://localhost.org:32768
+        netbox_url: http://netbox-demo.org.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 10.120.10.1
@@ -746,7 +746,7 @@
 ##
 - name: "TEST NETBOX_PREFIX"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -754,7 +754,7 @@
   tasks:
     - name: "1 - Create prefix within Netbox with only required information"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -772,7 +772,7 @@
 
     - name: "2 - Duplicate"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -788,7 +788,7 @@
 
     - name: "3 - Update 10.156.0.0/19"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -813,7 +813,7 @@
 
     - name: "4 - Delete prefix within netbox"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -830,7 +830,7 @@
 
     - name: "5 - Create prefix with several specified options"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -873,7 +873,7 @@
 
     - name: "6 - Get a new /24 inside 10.156.0.0/19 within Netbox - Parent doesn't exist"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -890,7 +890,7 @@
 
     - name: "7 - Create prefix within Netbox with only required information"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -908,7 +908,7 @@
 
     - name: "8 - Get a new /24 inside 10.156.0.0/19 within Netbox"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -928,7 +928,7 @@
 
     - name: "9 - Create 10.157.0.0/19"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.157.0.0/19
@@ -950,7 +950,7 @@
 
     - name: "10 - Get a new /24 inside 10.157.0.0/19 within Netbox with additional values"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.157.0.0/19
@@ -974,7 +974,7 @@
 
     - name: "11 - Get a new /24 inside 10.156.0.0/19 within Netbox"
       netbox_prefix:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -999,7 +999,7 @@
 ##
 - name: "TEST NETBOX_SITE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1007,7 +1007,7 @@
   tasks:
     - name: "1 - Create site within Netbox with only required information"
       netbox_site:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1025,7 +1025,7 @@
 
     - name: "2 - Duplicate"
       netbox_site:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1041,7 +1041,7 @@
 
     - name: "3 - Update Test - Colorado"
       netbox_site:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1066,7 +1066,7 @@
 
     - name: "4 - Create site with all parameters"
       netbox_site:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - California
@@ -1114,7 +1114,7 @@
 
     - name: "5 - Delete site within netbox"
       netbox_site:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1136,7 +1136,7 @@
 ##
 ##
 - name: "TEST NETBOX_TENANT"
-  hosts: localhost
+  hosts: netbox-demo.org
   connection: local
   gather_facts: no
   collections:
@@ -1145,7 +1145,7 @@
   tasks:
     - name: "1 - Test tenant creation"
       netbox_tenant:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1163,7 +1163,7 @@
 
     - name: "Test duplicate tenant"
       netbox_tenant:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1179,7 +1179,7 @@
 
     - name: "3 - Test update"
       netbox_tenant:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1198,7 +1198,7 @@
 
     - name: "4 - Test delete"
       netbox_tenant:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1215,7 +1215,7 @@
 
     - name: "5 - Create tenant with all parameters"
       netbox_tenant:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1249,7 +1249,7 @@
 ##
 ##
 - name: "TEST NETBOX_TENANT_GROUP"
-  hosts: localhost
+  hosts: netbox-demo.org
   connection: local
   gather_facts: no
   collections:
@@ -1258,7 +1258,7 @@
   tasks:
     - name: "1 - Test tenant group creation"
       netbox_tenant_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1276,7 +1276,7 @@
 
     - name: "Test duplicate tenant group"
       netbox_tenant_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1292,7 +1292,7 @@
 
     - name: "3 - Test delete"
       netbox_tenant_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1313,7 +1313,7 @@
 ##
 ##
 - name: "TEST NETBOX_RACK"
-  hosts: localhost
+  hosts: netbox-demo.org
   connection: local
   gather_facts: no
   collections:
@@ -1322,7 +1322,7 @@
   tasks:
     - name: "1 - Test rack creation"
       netbox_rack:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1340,7 +1340,7 @@
 
     - name: "Test duplicate rack"
       netbox_rack:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1356,7 +1356,7 @@
 
     - name: "3 - Create new rack with similar name"
       netbox_rack:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack - Test Site
@@ -1376,7 +1376,7 @@
 
     - name: "4 - Attempt to create Test rack one again"
       netbox_rack:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack one
@@ -1394,7 +1394,7 @@
 
     - name: "5 - Update Test rack one with more options"
       netbox_rack:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack one
@@ -1458,7 +1458,7 @@
 
     - name: "6 - Create rack with same asset tag and serial number"
       netbox_rack:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack two
@@ -1477,7 +1477,7 @@
 
     - name: "7 - Test delete"
       netbox_rack:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1499,7 +1499,7 @@
 ##
 - name: "TEST NETBOX_RACK_ROLE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1507,7 +1507,7 @@
   tasks:
     - name: "RACK_ROLE 1: Necessary info creation"
       netbox_rack_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1528,7 +1528,7 @@
 
     - name: "RACK_ROLE 2: Create duplicate"
       netbox_rack_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1546,7 +1546,7 @@
 
     - name: "RACK_ROLE 3: Update"
       netbox_rack_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1566,7 +1566,7 @@
 
     - name: "RACK_ROLE 4: Delete"
       netbox_rack_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1588,7 +1588,7 @@
 ##
 - name: "TEST NETBOX_RACK_GROUP"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1596,7 +1596,7 @@
   tasks:
     - name: "RACK_GROUP 1: Necessary info creation"
       netbox_rack_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1617,7 +1617,7 @@
 
     - name: "RACK_GROUP 2: Create duplicate"
       netbox_rack_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1636,7 +1636,7 @@
 
     - name: "RACK_GROUP 3: ASSERT - Delete"
       netbox_rack_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1658,7 +1658,7 @@
 ##
 - name: "TEST NETBOX_MANUFACTURER"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1666,7 +1666,7 @@
   tasks:
     - name: "MANUFACTURER 1: Necessary info creation"
       netbox_manufacturer:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1685,7 +1685,7 @@
 
     - name: "MANUFACTURER 2: Create duplicate"
       netbox_manufacturer:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1702,7 +1702,7 @@
 
     - name: "MANUFACTURER 3: Update"
       netbox_manufacturer:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: test manufacturer two
@@ -1719,7 +1719,7 @@
 
     - name: "MANUFACTURER 4: ASSERT - Delete"
       netbox_manufacturer:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: test manufacturer two
@@ -1736,7 +1736,7 @@
 
     - name: "MANUFACTURER 5: ASSERT - Delete non existing"
       netbox_manufacturer:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1757,7 +1757,7 @@
 ##
 - name: "TEST NETBOX_PLATFORM"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1765,7 +1765,7 @@
   tasks:
     - name: "PLATFORM 1: Necessary info creation"
       netbox_platform:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1784,7 +1784,7 @@
 
     - name: "PLATFORM 2: Create duplicate"
       netbox_platform:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1801,7 +1801,7 @@
 
     - name: "PLATFORM 3: ASSERT - Update"
       netbox_platform:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1826,7 +1826,7 @@
 
     - name: "PLATFORM 4: ASSERT - Delete"
       netbox_platform:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1843,7 +1843,7 @@
 
     - name: "PLATFORM 5: ASSERT - Delete non existing"
       netbox_platform:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1864,7 +1864,7 @@
 ##
 - name: "TEST NETBOX_DEVICE_TYPE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1872,7 +1872,7 @@
   tasks:
     - name: "DEVICE_TYPE 1: Necessary info creation"
       netbox_device_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1894,7 +1894,7 @@
 
     - name: "DEVICE_TYPE 2: Create duplicate"
       netbox_device_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1914,7 +1914,7 @@
 
     - name: "DEVICE_TYPE 3: ASSERT - Update"
       netbox_device_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1944,7 +1944,7 @@
 
     - name: "DEVICE_TYPE 4: ASSERT - Delete"
       netbox_device_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: test-device-type
@@ -1961,7 +1961,7 @@
 
     - name: "DEVICE_TYPE 5: ASSERT - Delete non existing"
       netbox_device_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: "Test Device Type"
@@ -1977,7 +1977,7 @@
 
     - name: "DEVICE_TYPE 6: Without Slug"
       netbox_device_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: "WS Test 3850"
@@ -2003,7 +2003,7 @@
 ##
 - name: "TEST NETBOX_DEVICE_ROLE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2011,7 +2011,7 @@
   tasks:
     - name: "DEVICE_ROLE 1: Necessary info creation"
       netbox_device_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2032,7 +2032,7 @@
 
     - name: "DEVICE_ROLE 2: Create duplicate"
       netbox_device_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2051,7 +2051,7 @@
 
     - name: "DEVICE_ROLE 3: ASSERT - Update"
       netbox_device_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2074,7 +2074,7 @@
 
     - name: "DEVICE_ROLE 4: ASSERT - Delete"
       netbox_device_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Device Role
@@ -2091,7 +2091,7 @@
 
     - name: "DEVICE_ROLE 5: ASSERT - Delete non existing"
       netbox_device_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Device Role
@@ -2112,7 +2112,7 @@
 ##
 - name: "TEST NETBOX_IPAM_ROLE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2120,7 +2120,7 @@
   tasks:
     - name: "IPAM_ROLE 1: Necessary info creation"
       netbox_ipam_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2139,7 +2139,7 @@
 
     - name: "IPAM_ROLE 2: Create duplicate"
       netbox_ipam_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2156,7 +2156,7 @@
 
     - name: "IPAM_ROLE 3: ASSERT - Update"
       netbox_ipam_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2176,7 +2176,7 @@
 
     - name: "IPAM_ROLE 4: ASSERT - Delete"
       netbox_ipam_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test IPAM Role
@@ -2193,7 +2193,7 @@
 
     - name: "IPAM_ROLE 5: ASSERT - Delete non existing"
       netbox_ipam_role:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test IPAM Role
@@ -2214,7 +2214,7 @@
 ##
 - name: "TEST NETBOX_VLAN_GROUP"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2222,7 +2222,7 @@
   tasks:
     - name: "VLAN_GROUP 1: Necessary info creation"
       netbox_vlan_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2243,7 +2243,7 @@
 
     - name: "VLAN_GROUP 2: Create duplicate"
       netbox_vlan_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2262,7 +2262,7 @@
 
     - name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
       netbox_vlan_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2281,7 +2281,7 @@
 
     - name: "VLAN_GROUP 4: ASSERT - Create vlan group, no site"
       netbox_vlan_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2297,7 +2297,7 @@
 
     - name: "VLAN_GROUP 5: ASSERT - Delete"
       netbox_vlan_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: VLAN Group One
@@ -2318,7 +2318,7 @@
 
     - name: "VLAN_GROUP 6: ASSERT - Delete non existing"
       netbox_vlan_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: VLAN Group One
@@ -2340,7 +2340,7 @@
 ##
 - name: "TEST NETBOX_VLAN"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2348,7 +2348,7 @@
   tasks:
     - name: "VLAN 1: Necessary info creation"
       netbox_vlan:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2368,7 +2368,7 @@
 
     - name: "VLAN 2: Create duplicate"
       netbox_vlan:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2386,7 +2386,7 @@
 
     - name: "VLAN 3: Create VLAN with same name, but different site"
       netbox_vlan:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2409,7 +2409,7 @@
 
     - name: "VLAN 4: ASSERT - Update"
       netbox_vlan:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2446,7 +2446,7 @@
 
     - name: "VLAN 5: ASSERT - Delete more than one result"
       netbox_vlan:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2462,7 +2462,7 @@
 
     - name: "VLAN 6: ASSERT - Delete"
       netbox_vlan:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2491,7 +2491,7 @@
 ##
 - name: "TEST NETBOX_VRF"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2499,7 +2499,7 @@
   tasks:
     - name: "VRF 1: Necessary info creation"
       netbox_vrf:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2517,7 +2517,7 @@
 
     - name: "VRF 2: Create duplicate"
       netbox_vrf:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2533,7 +2533,7 @@
 
     - name: "VRF 3: Create VRF with same name, but different tenant"
       netbox_vrf:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2553,7 +2553,7 @@
 
     - name: "VRF 4: ASSERT - Update"
       netbox_vrf:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2584,7 +2584,7 @@
 
     - name: "VRF 5: ASSERT - Delete more than one result"
       netbox_vrf:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2600,7 +2600,7 @@
 
     - name: "VRF 6: ASSERT - Delete"
       netbox_vrf:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2627,7 +2627,7 @@
 ##
 - name: "TEST NETBOX_RIR"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2635,7 +2635,7 @@
   tasks:
     - name: "RIR 1: Necessary info creation"
       netbox_rir:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test RIR One
@@ -2654,7 +2654,7 @@
 
     - name: "RIR 2: Create duplicate"
       netbox_rir:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test RIR One
@@ -2671,7 +2671,7 @@
 
     - name: "RIR 3: ASSERT - Update"
       netbox_rir:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test RIR One"
@@ -2691,7 +2691,7 @@
 
     - name: "RIR 4: ASSERT - Delete"
       netbox_rir:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test RIR One"
@@ -2714,7 +2714,7 @@
 ##
 - name: "TEST NETBOX_AGGREGATE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2722,7 +2722,7 @@
   tasks:
     - name: "AGGREGATE 1: Necessary info creation"
       netbox_aggregate:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2743,7 +2743,7 @@
 
     - name: "AGGREGATE 2: Create duplicate"
       netbox_aggregate:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2761,7 +2761,7 @@
 
     - name: "AGGREGATE 3: ASSERT - Update"
       netbox_aggregate:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2790,7 +2790,7 @@
 
     - name: "AGGREGATE 4: ASSERT - Delete"
       netbox_aggregate:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2811,7 +2811,7 @@
 
     - name: "AGGREGATE 5: Necessary info creation"
       netbox_aggregate:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "2001::/32"
@@ -2837,7 +2837,7 @@
 ##
 - name: "TEST NETBOX_REGION"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2845,7 +2845,7 @@
   tasks:
     - name: "REGION 1: Necessary info creation"
       netbox_region:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2864,7 +2864,7 @@
 
     - name: "REGION 2: Create duplicate"
       netbox_region:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2881,7 +2881,7 @@
 
     - name: "REGION 3: ASSERT - Update"
       netbox_region:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2901,7 +2901,7 @@
 
     - name: "REGION 4: ASSERT - Delete"
       netbox_region:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2924,7 +2924,7 @@
 ##
 - name: "TEST NETBOX_DEVICE_BAY"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2932,7 +2932,7 @@
   tasks:
     - name: "DEVICE_BAY 1: Necessary info creation"
       netbox_device_bay:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2952,7 +2952,7 @@
 
     - name: "DEVICE_BAY 2: Create duplicate"
       netbox_device_bay:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2970,7 +2970,7 @@
 
     - name: "DEVICE_BAY 3: ASSERT - Update"
       netbox_device_bay:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2995,7 +2995,7 @@
 
     - name: "DEVICE_BAY 4: ASSERT - Delete"
       netbox_device_bay:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Device Bay One"
@@ -3019,7 +3019,7 @@
 ##
 - name: "TEST NETBOX_INVENTORY_ITEM"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3027,7 +3027,7 @@
   tasks:
     - name: "INVENTORY_ITEM 1: Necessary info creation"
       netbox_inventory_item:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3047,7 +3047,7 @@
 
     - name: "INVENTORY_ITEM 2: Create duplicate"
       netbox_inventory_item:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3065,7 +3065,7 @@
 
     - name: "INVENTORY_ITEM 3: ASSERT - Update"
       netbox_inventory_item:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3102,7 +3102,7 @@
 
     - name: "INVENTORY_ITEM 4: ASSERT - Delete"
       netbox_inventory_item:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3131,7 +3131,7 @@
 ##
 - name: "TEST NETBOX_VIRTUAL_MACHINES"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3139,7 +3139,7 @@
   tasks:
     - name: "VIRTUAL_MACHINE 1: Necessary info creation"
       netbox_virtual_machine:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3159,7 +3159,7 @@
 
     - name: "VIRTUAL_MACHINE 2: Create duplicate"
       netbox_virtual_machine:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3177,7 +3177,7 @@
 
     - name: "VIRTUAL_MACHINE 3: Update"
       netbox_virtual_machine:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3211,7 +3211,7 @@
 
     - name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
       netbox_virtual_machine:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3238,7 +3238,7 @@
 ##
 - name: "TEST NETBOX_CLUSTER"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3246,7 +3246,7 @@
   tasks:
     - name: "CLUSTER 1: Necessary info creation"
       netbox_cluster:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3266,7 +3266,7 @@
 
     - name: "CLUSTER 2: Create duplicate"
       netbox_cluster:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3284,7 +3284,7 @@
 
     - name: "CLUSTER 3: Update"
       netbox_cluster:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3315,7 +3315,7 @@
 
     - name: "CLUSTER 4: ASSERT - Delete"
       netbox_cluster:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3341,7 +3341,7 @@
 ##
 - name: "TEST NETBOX_CLUSTER_GROUP"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3349,7 +3349,7 @@
   tasks:
     - name: "CLUSTER_GROUP 1: Necessary info creation"
       netbox_cluster_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3368,7 +3368,7 @@
 
     - name: "CLUSTER_GROUP 2: Create duplicate"
       netbox_cluster_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3385,7 +3385,7 @@
 
     - name: "CLUSTER_GROUP 3: User specified slug"
       netbox_cluster_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group Two"
@@ -3405,7 +3405,7 @@
 
     - name: "CLUSTER_GROUP 4: ASSERT - Delete"
       netbox_cluster_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3422,7 +3422,7 @@
 
     - name: "CLUSTER_GROUP 5: ASSERT - Delete"
       netbox_cluster_group:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group Two"
@@ -3445,7 +3445,7 @@
 ##
 - name: "TEST NETBOX_CLUSTER_TYPE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3453,7 +3453,7 @@
   tasks:
     - name: "CLUSTER_TYPE 1: Necessary info creation"
       netbox_cluster_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3472,7 +3472,7 @@
 
     - name: "CLUSTER_TYPE 2: Create duplicate"
       netbox_cluster_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3489,7 +3489,7 @@
 
     - name: "CLUSTER_TYPE 3: User specified slug"
       netbox_cluster_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type Two"
@@ -3509,7 +3509,7 @@
 
     - name: "CLUSTER_TYPE 4: ASSERT - Delete"
       netbox_cluster_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3526,7 +3526,7 @@
 
     - name: "CLUSTER_TYPE 5: ASSERT - Delete"
       netbox_cluster_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type Two"
@@ -3549,7 +3549,7 @@
 ##
 - name: "TEST NETBOX_VM_INTERFACE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3557,7 +3557,7 @@
   tasks:
     - name: "NETBOX_VM_INTERFACE 1: Necessary info creation"
       netbox_vm_interface:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3577,7 +3577,7 @@
 
     - name: "NETBOX_VM_INTERFACE 2: Create duplicate"
       netbox_vm_interface:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3595,7 +3595,7 @@
 
     - name: "NETBOX_VM_INTERFACE 3: Updated"
       netbox_vm_interface:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3644,7 +3644,7 @@
 
     - name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
       netbox_vm_interface:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Eth10"
@@ -3662,7 +3662,7 @@
 
     - name: "NETBOX_VM_INTERFACE 5: Attempt to update interface with same name on other VMs"
       netbox_vm_interface:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3715,7 +3715,7 @@
 ##
 - name: "TEST NETBOX_PROVIDER"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3723,7 +3723,7 @@
   tasks:
     - name: "NETBOX_PROVIDER 1: Create provider within Netbox with only required information"
       netbox_provider:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3742,7 +3742,7 @@
 
     - name: "NETBOX_PROVIDER 2: Duplicate"
       netbox_provider:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3759,7 +3759,7 @@
 
     - name: "NETBOX_PROVIDER 3: Update provider with other fields"
       netbox_provider:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3794,7 +3794,7 @@
 
     - name: "NETBOX_PROVIDER 4: Delete provider within netbox"
       netbox_provider:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3821,7 +3821,7 @@
 ##
 - name: "TEST NETBOX_CIRCUIT_TYPE"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3829,7 +3829,7 @@
   tasks:
     - name: "CIRCUIT_TYPE 1: Necessary info creation"
       netbox_circuit_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3848,7 +3848,7 @@
 
     - name: "CIRCUIT_TYPE 2: Create duplicate"
       netbox_circuit_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3865,7 +3865,7 @@
 
     - name: "CIRCUIT_TYPE 3: User specified slug"
       netbox_circuit_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type Two"
@@ -3885,7 +3885,7 @@
 
     - name: "CIRCUIT_TYPE 4: ASSERT - Delete"
       netbox_circuit_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3902,7 +3902,7 @@
 
     - name: "CIRCUIT_TYPE 5: ASSERT - Delete"
       netbox_circuit_type:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type Two"
@@ -3924,7 +3924,7 @@
 ##
 - name: "TEST NETBOX_CIRCUIT"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3932,7 +3932,7 @@
   tasks:
     - name: "NETBOX_CIRCUIT 1: Create provider within Netbox with only required information"
       netbox_circuit:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -3954,7 +3954,7 @@
 
     - name: "NETBOX_CIRCUIT 2: Duplicate"
       netbox_circuit:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -3974,7 +3974,7 @@
 
     - name: "NETBOX_CIRCUIT 3: Update provider with other fields"
       netbox_circuit:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -4012,7 +4012,7 @@
 
     - name: "NETBOX_CIRCUIT 4: Delete provider within netbox"
       netbox_circuit:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -4040,7 +4040,7 @@
 ##
 - name: "TEST NETBOX_CIRCUIT_TERMINATION"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -4048,7 +4048,7 @@
   tasks:
     - name: "NETBOX_CIRCUIT_TERMINATION 1: Create provider within Netbox with only required information"
       netbox_circuit_termination:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4072,7 +4072,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 2: Duplicate"
       netbox_circuit_termination:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4092,7 +4092,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 3: Update provider with other fields"
       netbox_circuit_termination:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4124,7 +4124,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 4: Create Z Side"
       netbox_circuit_termination:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4148,7 +4148,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 5: Delete provider within netbox"
       netbox_circuit_termination:
-        netbox_url: http://localhost:32768
+        netbox_url: http://netbox-demo.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4178,7 +4178,7 @@
     ##
     - name: "1 - Device with required information needs to add new service"
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "FOR_SERVICE"
@@ -4190,7 +4190,7 @@
 
     - name: "NETBOX_SERVICE: Create new service"
       netbox_service:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4213,7 +4213,7 @@
 
     - name: "NETBOX_SERVICE: Test idempotence"
       netbox_service:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4232,7 +4232,7 @@
           - test_service_idempotence['msg'] == "services node-exporter already exists"
     - name: "NETBOX_SERVICE: Test update"
       netbox_service:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4252,7 +4252,7 @@
 
     - name: "NETBOX_SERVICE: Test service deletion"
       netbox_service:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4277,7 +4277,7 @@
 ##
 - name: "TEST NETBOX_LOOKUP"
   connection: local
-  hosts: localhost
+  hosts: netbox-demo.org
   gather_facts: False
 
   tasks:
@@ -4285,29 +4285,29 @@
       assert:
         that: "{{ query_result|count }} == 3"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'sites', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`Wibble`]')|count }} == 0"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`TestDeviceR1`]')|count }} == 1"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 4: VLAN ID 400 can be queried and is named 'Test VLAN'"
       assert:
         that: "{{ (query_result|json_query('[?value.vid==`400`].value.name'))[0] == 'Test VLAN' }}"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'vlans', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'vlans', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 5: Add one of two devices for lookup filter test."
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "L1"
@@ -4321,7 +4321,7 @@
 
     - name: "NETBOX_LOOKUP 6: Add two of two devices for lookup filter test."
       netbox_device:
-        netbox_url: "http://localhost:32768"
+        netbox_url: "http://netbox-demo.org:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "L2"
@@ -4337,4 +4337,4 @@
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`L2`]')|count }} == 1"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://netbox-demo.org:32768', token='0123456789abcdef0123456789abcdef01234567') }}"

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -5,7 +5,7 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE"
-  hosts: localhost
+  hosts: localhosthost
   connection: local
   gather_facts: no
   collections:
@@ -14,7 +14,7 @@
   tasks:
     - name: "1 - Device with required information"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -41,7 +41,7 @@
 
     - name: "2 - Duplicate device"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -65,7 +65,7 @@
 
     - name: "3 - Update device"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -88,7 +88,7 @@
 
     - name: "4 - Create device with tags and assign to rack"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "TestR1"
@@ -124,7 +124,7 @@
 
     - name: "5 - Delete previous device"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "TestR1"
@@ -141,7 +141,7 @@
 
     - name: "6 - Delete R1"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "R1"
@@ -158,7 +158,7 @@
 
     - name: "7 - Add primary_ip4/6 to test100"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "test100"
@@ -188,8 +188,8 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_INTERFACE"
-  hosts: local
-  connection: local
+  hosts: localhost
+  connection: localhost
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -197,7 +197,7 @@
   tasks:
     - name: "1 - Interface with required information"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -216,7 +216,7 @@
 
     - name: "2 - Update test100 - GigabitEthernet3"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -239,7 +239,7 @@
 
     - name: "3 - Delete interface test100 - GigabitEthernet3"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -257,7 +257,7 @@
 
     - name: "4 - Create LAG with several specified options"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -286,7 +286,7 @@
 
     - name: "5 - Create interface and assign it to parent LAG"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -319,7 +319,7 @@
 
     - name: "6 - Create interface as trunk port"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -359,7 +359,7 @@
 
     - name: "7 - Duplicate Interface"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -376,7 +376,7 @@
 
     - name: "8 - Create interface and assign it to parent LAG - non dict"
       netbox_device_interface:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: test100
@@ -412,8 +412,8 @@
 ##
 ##
 - name: "TEST NETBOX_IP_ADDRESS"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -421,7 +421,7 @@
   tasks:
     - name: "1 - Create IP address within Netbox with only required information - State: Present"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -439,7 +439,7 @@
 
     - name: "2 - Update 192.168.1.10/30"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -462,7 +462,7 @@
 
     - name: "3 - Delete IP - 192.168.1.10 - State: Absent"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.10/30
@@ -479,7 +479,7 @@
 
     - name: "4 - Create IP in global VRF - 192.168.1.20/30 - State: Present"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.20/30
@@ -497,7 +497,7 @@
 
     - name: "5 - Create IP in global VRF - 192.168.1.20/30 - State: New"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.1.20/30
@@ -515,7 +515,7 @@
 
     - name: "6 - Create new address with only prefix specified - State: new"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 192.168.100.0/24
@@ -533,7 +533,7 @@
 
     - name: "7 - Create IP address with several specified"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -566,7 +566,7 @@
 
     - name: "8 - Create IP address and assign a nat_inside IP"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -595,7 +595,7 @@
 
     - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -618,7 +618,7 @@
 
     - name: "10 - Create IP address on GigabitEthernet2 - test100 - State: new"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -642,7 +642,7 @@
 
     - name: "11 - Create IP address on GigabitEthernet2 - test100 - State: present"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -664,7 +664,7 @@
 
     - name: "12 - Duplicate - 192.168.100.2/24 on interface"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.100.2/24
@@ -684,7 +684,7 @@
 
     - name: "13 - Duplicate - 192.168.100.2/24"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 192.168.100.2/24
@@ -700,7 +700,7 @@
 
     - name: "14 - Create IP address on Eth0 - test100-vm - State: present"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -723,7 +723,7 @@
 
     - name: "15 - Create IP address with no mask - State: Present"
       netbox_ip_address:
-        netbox_url: http://local.org:32768
+        netbox_url: http://localhost.org:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           address: 10.120.10.1
@@ -745,8 +745,8 @@
 ##
 ##
 - name: "TEST NETBOX_PREFIX"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -754,7 +754,7 @@
   tasks:
     - name: "1 - Create prefix within Netbox with only required information"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -772,7 +772,7 @@
 
     - name: "2 - Duplicate"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -788,7 +788,7 @@
 
     - name: "3 - Update 10.156.0.0/19"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -813,7 +813,7 @@
 
     - name: "4 - Delete prefix within netbox"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -830,7 +830,7 @@
 
     - name: "5 - Create prefix with several specified options"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           family: 4
@@ -873,7 +873,7 @@
 
     - name: "6 - Get a new /24 inside 10.156.0.0/19 within Netbox - Parent doesn't exist"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -890,7 +890,7 @@
 
     - name: "7 - Create prefix within Netbox with only required information"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.156.0.0/19
@@ -908,7 +908,7 @@
 
     - name: "8 - Get a new /24 inside 10.156.0.0/19 within Netbox"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -928,7 +928,7 @@
 
     - name: "9 - Create 10.157.0.0/19"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: 10.157.0.0/19
@@ -950,7 +950,7 @@
 
     - name: "10 - Get a new /24 inside 10.157.0.0/19 within Netbox with additional values"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.157.0.0/19
@@ -974,7 +974,7 @@
 
     - name: "11 - Get a new /24 inside 10.156.0.0/19 within Netbox"
       netbox_prefix:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           parent: 10.156.0.0/19
@@ -998,8 +998,8 @@
 ##
 ##
 - name: "TEST NETBOX_SITE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1007,7 +1007,7 @@
   tasks:
     - name: "1 - Create site within Netbox with only required information"
       netbox_site:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1025,7 +1025,7 @@
 
     - name: "2 - Duplicate"
       netbox_site:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1041,7 +1041,7 @@
 
     - name: "3 - Update Test - Colorado"
       netbox_site:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1066,7 +1066,7 @@
 
     - name: "4 - Create site with all parameters"
       netbox_site:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - California
@@ -1114,7 +1114,7 @@
 
     - name: "5 - Delete site within netbox"
       netbox_site:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test - Colorado
@@ -1136,8 +1136,8 @@
 ##
 ##
 - name: "TEST NETBOX_TENANT"
-  hosts: local
-  connection: local
+  hosts: localhost
+  connection: localhost
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -1145,7 +1145,7 @@
   tasks:
     - name: "1 - Test tenant creation"
       netbox_tenant:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1163,7 +1163,7 @@
 
     - name: "Test duplicate tenant"
       netbox_tenant:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1179,7 +1179,7 @@
 
     - name: "3 - Test update"
       netbox_tenant:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1198,7 +1198,7 @@
 
     - name: "4 - Test delete"
       netbox_tenant:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1215,7 +1215,7 @@
 
     - name: "5 - Create tenant with all parameters"
       netbox_tenant:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Tenant ABC"
@@ -1249,8 +1249,8 @@
 ##
 ##
 - name: "TEST NETBOX_TENANT_GROUP"
-  hosts: local
-  connection: local
+  hosts: localhost
+  connection: localhost
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -1258,7 +1258,7 @@
   tasks:
     - name: "1 - Test tenant group creation"
       netbox_tenant_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1276,7 +1276,7 @@
 
     - name: "Test duplicate tenant group"
       netbox_tenant_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1292,7 +1292,7 @@
 
     - name: "3 - Test delete"
       netbox_tenant_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Tenant Group Two"
@@ -1313,8 +1313,8 @@
 ##
 ##
 - name: "TEST NETBOX_RACK"
-  hosts: local
-  connection: local
+  hosts: localhost
+  connection: localhost
   gather_facts: no
   collections:
     - netbox_community.ansible_modules
@@ -1322,7 +1322,7 @@
   tasks:
     - name: "1 - Test rack creation"
       netbox_rack:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1340,7 +1340,7 @@
 
     - name: "Test duplicate rack"
       netbox_rack:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1356,7 +1356,7 @@
 
     - name: "3 - Create new rack with similar name"
       netbox_rack:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack - Test Site
@@ -1376,7 +1376,7 @@
 
     - name: "4 - Attempt to create Test rack one again"
       netbox_rack:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack one
@@ -1394,7 +1394,7 @@
 
     - name: "5 - Update Test rack one with more options"
       netbox_rack:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack one
@@ -1458,7 +1458,7 @@
 
     - name: "6 - Create rack with same asset tag and serial number"
       netbox_rack:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test rack two
@@ -1477,7 +1477,7 @@
 
     - name: "7 - Test delete"
       netbox_rack:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test rack one"
@@ -1498,8 +1498,8 @@
 ##
 ##
 - name: "TEST NETBOX_RACK_ROLE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1507,7 +1507,7 @@
   tasks:
     - name: "RACK_ROLE 1: Necessary info creation"
       netbox_rack_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1528,7 +1528,7 @@
 
     - name: "RACK_ROLE 2: Create duplicate"
       netbox_rack_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1546,7 +1546,7 @@
 
     - name: "RACK_ROLE 3: Update"
       netbox_rack_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1566,7 +1566,7 @@
 
     - name: "RACK_ROLE 4: Delete"
       netbox_rack_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Role
@@ -1587,8 +1587,8 @@
 ##
 ##
 - name: "TEST NETBOX_RACK_GROUP"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1596,7 +1596,7 @@
   tasks:
     - name: "RACK_GROUP 1: Necessary info creation"
       netbox_rack_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1617,7 +1617,7 @@
 
     - name: "RACK_GROUP 2: Create duplicate"
       netbox_rack_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1636,7 +1636,7 @@
 
     - name: "RACK_GROUP 3: ASSERT - Delete"
       netbox_rack_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Rack Group
@@ -1657,8 +1657,8 @@
 ##
 ##
 - name: "TEST NETBOX_MANUFACTURER"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1666,7 +1666,7 @@
   tasks:
     - name: "MANUFACTURER 1: Necessary info creation"
       netbox_manufacturer:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1685,7 +1685,7 @@
 
     - name: "MANUFACTURER 2: Create duplicate"
       netbox_manufacturer:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1702,7 +1702,7 @@
 
     - name: "MANUFACTURER 3: Update"
       netbox_manufacturer:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: test manufacturer two
@@ -1719,7 +1719,7 @@
 
     - name: "MANUFACTURER 4: ASSERT - Delete"
       netbox_manufacturer:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: test manufacturer two
@@ -1736,7 +1736,7 @@
 
     - name: "MANUFACTURER 5: ASSERT - Delete non existing"
       netbox_manufacturer:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Manufacturer Two
@@ -1756,8 +1756,8 @@
 ##
 ##
 - name: "TEST NETBOX_PLATFORM"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1765,7 +1765,7 @@
   tasks:
     - name: "PLATFORM 1: Necessary info creation"
       netbox_platform:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1784,7 +1784,7 @@
 
     - name: "PLATFORM 2: Create duplicate"
       netbox_platform:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1801,7 +1801,7 @@
 
     - name: "PLATFORM 3: ASSERT - Update"
       netbox_platform:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1826,7 +1826,7 @@
 
     - name: "PLATFORM 4: ASSERT - Delete"
       netbox_platform:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1843,7 +1843,7 @@
 
     - name: "PLATFORM 5: ASSERT - Delete non existing"
       netbox_platform:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Platform
@@ -1863,8 +1863,8 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_TYPE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -1872,7 +1872,7 @@
   tasks:
     - name: "DEVICE_TYPE 1: Necessary info creation"
       netbox_device_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1894,7 +1894,7 @@
 
     - name: "DEVICE_TYPE 2: Create duplicate"
       netbox_device_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1914,7 +1914,7 @@
 
     - name: "DEVICE_TYPE 3: ASSERT - Update"
       netbox_device_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           slug: test-device-type
@@ -1944,7 +1944,7 @@
 
     - name: "DEVICE_TYPE 4: ASSERT - Delete"
       netbox_device_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: test-device-type
@@ -1961,7 +1961,7 @@
 
     - name: "DEVICE_TYPE 5: ASSERT - Delete non existing"
       netbox_device_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: "Test Device Type"
@@ -1977,7 +1977,7 @@
 
     - name: "DEVICE_TYPE 6: Without Slug"
       netbox_device_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           model: "WS Test 3850"
@@ -2002,8 +2002,8 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_ROLE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2011,7 +2011,7 @@
   tasks:
     - name: "DEVICE_ROLE 1: Necessary info creation"
       netbox_device_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2032,7 +2032,7 @@
 
     - name: "DEVICE_ROLE 2: Create duplicate"
       netbox_device_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2051,7 +2051,7 @@
 
     - name: "DEVICE_ROLE 3: ASSERT - Update"
       netbox_device_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Device Role"
@@ -2074,7 +2074,7 @@
 
     - name: "DEVICE_ROLE 4: ASSERT - Delete"
       netbox_device_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Device Role
@@ -2091,7 +2091,7 @@
 
     - name: "DEVICE_ROLE 5: ASSERT - Delete non existing"
       netbox_device_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Device Role
@@ -2111,8 +2111,8 @@
 ##
 ##
 - name: "TEST NETBOX_IPAM_ROLE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2120,7 +2120,7 @@
   tasks:
     - name: "IPAM_ROLE 1: Necessary info creation"
       netbox_ipam_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2139,7 +2139,7 @@
 
     - name: "IPAM_ROLE 2: Create duplicate"
       netbox_ipam_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2156,7 +2156,7 @@
 
     - name: "IPAM_ROLE 3: ASSERT - Update"
       netbox_ipam_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test IPAM Role"
@@ -2176,7 +2176,7 @@
 
     - name: "IPAM_ROLE 4: ASSERT - Delete"
       netbox_ipam_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test IPAM Role
@@ -2193,7 +2193,7 @@
 
     - name: "IPAM_ROLE 5: ASSERT - Delete non existing"
       netbox_ipam_role:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test IPAM Role
@@ -2213,8 +2213,8 @@
 ##
 ##
 - name: "TEST NETBOX_VLAN_GROUP"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2222,7 +2222,7 @@
   tasks:
     - name: "VLAN_GROUP 1: Necessary info creation"
       netbox_vlan_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2243,7 +2243,7 @@
 
     - name: "VLAN_GROUP 2: Create duplicate"
       netbox_vlan_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2262,7 +2262,7 @@
 
     - name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
       netbox_vlan_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2281,7 +2281,7 @@
 
     - name: "VLAN_GROUP 4: ASSERT - Create vlan group, no site"
       netbox_vlan_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "VLAN Group One"
@@ -2297,7 +2297,7 @@
 
     - name: "VLAN_GROUP 5: ASSERT - Delete"
       netbox_vlan_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: VLAN Group One
@@ -2318,7 +2318,7 @@
 
     - name: "VLAN_GROUP 6: ASSERT - Delete non existing"
       netbox_vlan_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: VLAN Group One
@@ -2339,8 +2339,8 @@
 ##
 ##
 - name: "TEST NETBOX_VLAN"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2348,7 +2348,7 @@
   tasks:
     - name: "VLAN 1: Necessary info creation"
       netbox_vlan:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2368,7 +2368,7 @@
 
     - name: "VLAN 2: Create duplicate"
       netbox_vlan:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2386,7 +2386,7 @@
 
     - name: "VLAN 3: Create VLAN with same name, but different site"
       netbox_vlan:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VLAN 500
@@ -2409,7 +2409,7 @@
 
     - name: "VLAN 4: ASSERT - Update"
       netbox_vlan:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2446,7 +2446,7 @@
 
     - name: "VLAN 5: ASSERT - Delete more than one result"
       netbox_vlan:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2462,7 +2462,7 @@
 
     - name: "VLAN 6: ASSERT - Delete"
       netbox_vlan:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VLAN 500"
@@ -2490,8 +2490,8 @@
 ##
 ##
 - name: "TEST NETBOX_VRF"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2499,7 +2499,7 @@
   tasks:
     - name: "VRF 1: Necessary info creation"
       netbox_vrf:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2517,7 +2517,7 @@
 
     - name: "VRF 2: Create duplicate"
       netbox_vrf:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2533,7 +2533,7 @@
 
     - name: "VRF 3: Create VRF with same name, but different tenant"
       netbox_vrf:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test VRF One
@@ -2553,7 +2553,7 @@
 
     - name: "VRF 4: ASSERT - Update"
       netbox_vrf:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2584,7 +2584,7 @@
 
     - name: "VRF 5: ASSERT - Delete more than one result"
       netbox_vrf:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2600,7 +2600,7 @@
 
     - name: "VRF 6: ASSERT - Delete"
       netbox_vrf:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VRF One"
@@ -2626,8 +2626,8 @@
 ##
 ##
 - name: "TEST NETBOX_RIR"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2635,7 +2635,7 @@
   tasks:
     - name: "RIR 1: Necessary info creation"
       netbox_rir:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test RIR One
@@ -2654,7 +2654,7 @@
 
     - name: "RIR 2: Create duplicate"
       netbox_rir:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test RIR One
@@ -2671,7 +2671,7 @@
 
     - name: "RIR 3: ASSERT - Update"
       netbox_rir:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test RIR One"
@@ -2691,7 +2691,7 @@
 
     - name: "RIR 4: ASSERT - Delete"
       netbox_rir:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test RIR One"
@@ -2713,8 +2713,8 @@
 ##
 ##
 - name: "TEST NETBOX_AGGREGATE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2722,7 +2722,7 @@
   tasks:
     - name: "AGGREGATE 1: Necessary info creation"
       netbox_aggregate:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2743,7 +2743,7 @@
 
     - name: "AGGREGATE 2: Create duplicate"
       netbox_aggregate:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2761,7 +2761,7 @@
 
     - name: "AGGREGATE 3: ASSERT - Update"
       netbox_aggregate:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2790,7 +2790,7 @@
 
     - name: "AGGREGATE 4: ASSERT - Delete"
       netbox_aggregate:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "10.0.0.0/8"
@@ -2811,7 +2811,7 @@
 
     - name: "AGGREGATE 5: Necessary info creation"
       netbox_aggregate:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           prefix: "2001::/32"
@@ -2836,8 +2836,8 @@
 ##
 ##
 - name: "TEST NETBOX_REGION"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2845,7 +2845,7 @@
   tasks:
     - name: "REGION 1: Necessary info creation"
       netbox_region:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2864,7 +2864,7 @@
 
     - name: "REGION 2: Create duplicate"
       netbox_region:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2881,7 +2881,7 @@
 
     - name: "REGION 3: ASSERT - Update"
       netbox_region:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2901,7 +2901,7 @@
 
     - name: "REGION 4: ASSERT - Delete"
       netbox_region:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Region One"
@@ -2923,8 +2923,8 @@
 ##
 ##
 - name: "TEST NETBOX_DEVICE_BAY"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -2932,7 +2932,7 @@
   tasks:
     - name: "DEVICE_BAY 1: Necessary info creation"
       netbox_device_bay:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2952,7 +2952,7 @@
 
     - name: "DEVICE_BAY 2: Create duplicate"
       netbox_device_bay:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2970,7 +2970,7 @@
 
     - name: "DEVICE_BAY 3: ASSERT - Update"
       netbox_device_bay:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "Test Nexus One"
@@ -2995,7 +2995,7 @@
 
     - name: "DEVICE_BAY 4: ASSERT - Delete"
       netbox_device_bay:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Device Bay One"
@@ -3018,8 +3018,8 @@
 ##
 ##
 - name: "TEST NETBOX_INVENTORY_ITEM"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3027,7 +3027,7 @@
   tasks:
     - name: "INVENTORY_ITEM 1: Necessary info creation"
       netbox_inventory_item:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3047,7 +3047,7 @@
 
     - name: "INVENTORY_ITEM 2: Create duplicate"
       netbox_inventory_item:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3065,7 +3065,7 @@
 
     - name: "INVENTORY_ITEM 3: ASSERT - Update"
       netbox_inventory_item:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3102,7 +3102,7 @@
 
     - name: "INVENTORY_ITEM 4: ASSERT - Delete"
       netbox_inventory_item:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           device: "test100"
@@ -3130,8 +3130,8 @@
 ##
 ##
 - name: "TEST NETBOX_VIRTUAL_MACHINES"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3139,7 +3139,7 @@
   tasks:
     - name: "VIRTUAL_MACHINE 1: Necessary info creation"
       netbox_virtual_machine:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3159,7 +3159,7 @@
 
     - name: "VIRTUAL_MACHINE 2: Create duplicate"
       netbox_virtual_machine:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3177,7 +3177,7 @@
 
     - name: "VIRTUAL_MACHINE 3: Update"
       netbox_virtual_machine:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3211,7 +3211,7 @@
 
     - name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
       netbox_virtual_machine:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test VM One"
@@ -3237,8 +3237,8 @@
 ##
 ##
 - name: "TEST NETBOX_CLUSTER"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3246,7 +3246,7 @@
   tasks:
     - name: "CLUSTER 1: Necessary info creation"
       netbox_cluster:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3266,7 +3266,7 @@
 
     - name: "CLUSTER 2: Create duplicate"
       netbox_cluster:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3284,7 +3284,7 @@
 
     - name: "CLUSTER 3: Update"
       netbox_cluster:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3315,7 +3315,7 @@
 
     - name: "CLUSTER 4: ASSERT - Delete"
       netbox_cluster:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster One"
@@ -3340,8 +3340,8 @@
 ##
 ##
 - name: "TEST NETBOX_CLUSTER_GROUP"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3349,7 +3349,7 @@
   tasks:
     - name: "CLUSTER_GROUP 1: Necessary info creation"
       netbox_cluster_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3368,7 +3368,7 @@
 
     - name: "CLUSTER_GROUP 2: Create duplicate"
       netbox_cluster_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3385,7 +3385,7 @@
 
     - name: "CLUSTER_GROUP 3: User specified slug"
       netbox_cluster_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group Two"
@@ -3405,7 +3405,7 @@
 
     - name: "CLUSTER_GROUP 4: ASSERT - Delete"
       netbox_cluster_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group One"
@@ -3422,7 +3422,7 @@
 
     - name: "CLUSTER_GROUP 5: ASSERT - Delete"
       netbox_cluster_group:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Group Two"
@@ -3444,8 +3444,8 @@
 ##
 ##
 - name: "TEST NETBOX_CLUSTER_TYPE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3453,7 +3453,7 @@
   tasks:
     - name: "CLUSTER_TYPE 1: Necessary info creation"
       netbox_cluster_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3472,7 +3472,7 @@
 
     - name: "CLUSTER_TYPE 2: Create duplicate"
       netbox_cluster_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3489,7 +3489,7 @@
 
     - name: "CLUSTER_TYPE 3: User specified slug"
       netbox_cluster_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type Two"
@@ -3509,7 +3509,7 @@
 
     - name: "CLUSTER_TYPE 4: ASSERT - Delete"
       netbox_cluster_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type One"
@@ -3526,7 +3526,7 @@
 
     - name: "CLUSTER_TYPE 5: ASSERT - Delete"
       netbox_cluster_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Cluster Type Two"
@@ -3548,8 +3548,8 @@
 ##
 ##
 - name: "TEST NETBOX_VM_INTERFACE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3557,7 +3557,7 @@
   tasks:
     - name: "NETBOX_VM_INTERFACE 1: Necessary info creation"
       netbox_vm_interface:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3577,7 +3577,7 @@
 
     - name: "NETBOX_VM_INTERFACE 2: Create duplicate"
       netbox_vm_interface:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3595,7 +3595,7 @@
 
     - name: "NETBOX_VM_INTERFACE 3: Updated"
       netbox_vm_interface:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3644,7 +3644,7 @@
 
     - name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
       netbox_vm_interface:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Eth10"
@@ -3662,7 +3662,7 @@
 
     - name: "NETBOX_VM_INTERFACE 5: Attempt to update interface with same name on other VMs"
       netbox_vm_interface:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           virtual_machine: "test100-vm"
@@ -3714,8 +3714,8 @@
 ##
 ##
 - name: "TEST NETBOX_PROVIDER"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3723,7 +3723,7 @@
   tasks:
     - name: "NETBOX_PROVIDER 1: Create provider within Netbox with only required information"
       netbox_provider:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3742,7 +3742,7 @@
 
     - name: "NETBOX_PROVIDER 2: Duplicate"
       netbox_provider:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3759,7 +3759,7 @@
 
     - name: "NETBOX_PROVIDER 3: Update provider with other fields"
       netbox_provider:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3794,7 +3794,7 @@
 
     - name: "NETBOX_PROVIDER 4: Delete provider within netbox"
       netbox_provider:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: Test Provider One
@@ -3820,8 +3820,8 @@
 ##
 ##
 - name: "TEST NETBOX_CIRCUIT_TYPE"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3829,7 +3829,7 @@
   tasks:
     - name: "CIRCUIT_TYPE 1: Necessary info creation"
       netbox_circuit_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3848,7 +3848,7 @@
 
     - name: "CIRCUIT_TYPE 2: Create duplicate"
       netbox_circuit_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3865,7 +3865,7 @@
 
     - name: "CIRCUIT_TYPE 3: User specified slug"
       netbox_circuit_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type Two"
@@ -3885,7 +3885,7 @@
 
     - name: "CIRCUIT_TYPE 4: ASSERT - Delete"
       netbox_circuit_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type One"
@@ -3902,7 +3902,7 @@
 
     - name: "CIRCUIT_TYPE 5: ASSERT - Delete"
       netbox_circuit_type:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           name: "Test Circuit Type Two"
@@ -3923,8 +3923,8 @@
 ##
 ##
 - name: "TEST NETBOX_CIRCUIT"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -3932,7 +3932,7 @@
   tasks:
     - name: "NETBOX_CIRCUIT 1: Create provider within Netbox with only required information"
       netbox_circuit:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -3954,7 +3954,7 @@
 
     - name: "NETBOX_CIRCUIT 2: Duplicate"
       netbox_circuit:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -3974,7 +3974,7 @@
 
     - name: "NETBOX_CIRCUIT 3: Update provider with other fields"
       netbox_circuit:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -4012,7 +4012,7 @@
 
     - name: "NETBOX_CIRCUIT 4: Delete provider within netbox"
       netbox_circuit:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           cid: Test Circuit One
@@ -4039,8 +4039,8 @@
 ##
 ##
 - name: "TEST NETBOX_CIRCUIT_TERMINATION"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
   collections:
     - netbox_community.ansible_modules
@@ -4048,7 +4048,7 @@
   tasks:
     - name: "NETBOX_CIRCUIT_TERMINATION 1: Create provider within Netbox with only required information"
       netbox_circuit_termination:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4072,7 +4072,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 2: Duplicate"
       netbox_circuit_termination:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4092,7 +4092,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 3: Update provider with other fields"
       netbox_circuit_termination:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4124,7 +4124,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 4: Create Z Side"
       netbox_circuit_termination:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4148,7 +4148,7 @@
 
     - name: "NETBOX_CIRCUIT_TERMINATION 5: Delete provider within netbox"
       netbox_circuit_termination:
-        netbox_url: http://local:32768
+        netbox_url: http://localhost:32768
         netbox_token: 0123456789abcdef0123456789abcdef01234567
         data:
           circuit: Test Circuit
@@ -4178,7 +4178,7 @@
     ##
     - name: "1 - Device with required information needs to add new service"
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "FOR_SERVICE"
@@ -4190,7 +4190,7 @@
 
     - name: "NETBOX_SERVICE: Create new service"
       netbox_service:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4213,7 +4213,7 @@
 
     - name: "NETBOX_SERVICE: Test idempotence"
       netbox_service:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4232,7 +4232,7 @@
           - test_service_idempotence['msg'] == "services node-exporter already exists"
     - name: "NETBOX_SERVICE: Test update"
       netbox_service:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4252,7 +4252,7 @@
 
     - name: "NETBOX_SERVICE: Test service deletion"
       netbox_service:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           device: "FOR_SERVICE"
@@ -4276,8 +4276,8 @@
 ##
 ##
 - name: "TEST NETBOX_LOOKUP"
-  connection: local
-  hosts: local
+  connection: localhost
+  hosts: localhost
   gather_facts: False
 
   tasks:
@@ -4285,29 +4285,29 @@
       assert:
         that: "{{ query_result|count }} == 3"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'sites', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`Wibble`]')|count }} == 0"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`TestDeviceR1`]')|count }} == 1"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 4: VLAN ID 400 can be queried and is named 'Test VLAN'"
       assert:
         that: "{{ (query_result|json_query('[?value.vid==`400`].value.name'))[0] == 'Test VLAN' }}"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'vlans', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'vlans', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
     - name: "NETBOX_LOOKUP 5: Add one of two devices for lookup filter test."
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "L1"
@@ -4321,7 +4321,7 @@
 
     - name: "NETBOX_LOOKUP 6: Add two of two devices for lookup filter test."
       netbox_device:
-        netbox_url: "http://local:32768"
+        netbox_url: "http://localhost:32768"
         netbox_token: "0123456789abcdef0123456789abcdef01234567"
         data:
           name: "L2"
@@ -4337,4 +4337,4 @@
       assert:
         that: "{{ query_result|json_query('[?value.display_name==`L2`]')|count }} == 1"
       vars:
-        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://local:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+        query_result: "{{ query('netbox_community.ansible_modules.netbox', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"

--- a/tests/unit/module_utils/fixtures/choices/circuits.json
+++ b/tests/unit/module_utils/fixtures/choices/circuits.json
@@ -1,0 +1,28 @@
+{
+    "status": [
+        {
+            "value": "planned",
+            "display_name": "Planned"
+        },
+        {
+            "value": "provisioning",
+            "display_name": "Provisioning"
+        },
+        {
+            "value": "active",
+            "display_name": "Active"
+        },
+        {
+            "value": "offline",
+            "display_name": "Offline"
+        },
+        {
+            "value": "deprovisioning",
+            "display_name": "Deprovisioning"
+        },
+        {
+            "value": "decommissioned",
+            "display_name": "Decommissioned"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/device_types.json
+++ b/tests/unit/module_utils/fixtures/choices/device_types.json
@@ -1,0 +1,12 @@
+{
+    "subdevice_role": [
+        {
+            "value": "parent",
+            "display_name": "Parent"
+        },
+        {
+            "value": "child",
+            "display_name": "Child"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/devices.json
+++ b/tests/unit/module_utils/fixtures/choices/devices.json
@@ -1,0 +1,42 @@
+{
+    "face": [
+        {
+            "value": "front",
+            "display_name": "Front"
+        },
+        {
+            "value": "rear",
+            "display_name": "Rear"
+        }
+    ],
+    "status": [
+        {
+            "value": "offline",
+            "display_name": "Offline"
+        },
+        {
+            "value": "active",
+            "display_name": "Active"
+        },
+        {
+            "value": "planned",
+            "display_name": "Planned"
+        },
+        {
+            "value": "staged",
+            "display_name": "Staged"
+        },
+        {
+            "value": "failed",
+            "display_name": "Failed"
+        },
+        {
+            "value": "inventory",
+            "display_name": "Inventory"
+        },
+        {
+            "value": "decommissioning",
+            "display_name": "Decommissioning"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/interfaces.json
+++ b/tests/unit/module_utils/fixtures/choices/interfaces.json
@@ -1,0 +1,306 @@
+{
+    "type": [
+        {
+            "value": "virtual",
+            "display_name": "Virtual"
+        },
+        {
+            "value": "lag",
+            "display_name": "Link Aggregation Group (LAG)"
+        },
+        {
+            "value": "100base-tx",
+            "display_name": "100BASE-TX (10/100ME)"
+        },
+        {
+            "value": "1000base-t",
+            "display_name": "1000BASE-T (1GE)"
+        },
+        {
+            "value": "2.5gbase-t",
+            "display_name": "2.5GBASE-T (2.5GE)"
+        },
+        {
+            "value": "5gbase-t",
+            "display_name": "5GBASE-T (5GE)"
+        },
+        {
+            "value": "10gbase-t",
+            "display_name": "10GBASE-T (10GE)"
+        },
+        {
+            "value": "10gbase-cx4",
+            "display_name": "10GBASE-CX4 (10GE)"
+        },
+        {
+            "value": "1000base-x-gbic",
+            "display_name": "GBIC (1GE)"
+        },
+        {
+            "value": "1000base-x-sfp",
+            "display_name": "SFP (1GE)"
+        },
+        {
+            "value": "10gbase-x-sfpp",
+            "display_name": "SFP+ (10GE)"
+        },
+        {
+            "value": "10gbase-x-xfp",
+            "display_name": "XFP (10GE)"
+        },
+        {
+            "value": "10gbase-x-xenpak",
+            "display_name": "XENPAK (10GE)"
+        },
+        {
+            "value": "10gbase-x-x2",
+            "display_name": "X2 (10GE)"
+        },
+        {
+            "value": "25gbase-x-sfp28",
+            "display_name": "SFP28 (25GE)"
+        },
+        {
+            "value": "40gbase-x-qsfpp",
+            "display_name": "QSFP+ (40GE)"
+        },
+        {
+            "value": "50gbase-x-sfp28",
+            "display_name": "QSFP28 (50GE)"
+        },
+        {
+            "value": "100gbase-x-cfp",
+            "display_name": "CFP (100GE)"
+        },
+        {
+            "value": "100gbase-x-cfp2",
+            "display_name": "CFP2 (100GE)"
+        },
+        {
+            "value": "200gbase-x-cfp2",
+            "display_name": "CFP2 (200GE)"
+        },
+        {
+            "value": "100gbase-x-cfp4",
+            "display_name": "CFP4 (100GE)"
+        },
+        {
+            "value": "100gbase-x-cpak",
+            "display_name": "Cisco CPAK (100GE)"
+        },
+        {
+            "value": "100gbase-x-qsfp28",
+            "display_name": "QSFP28 (100GE)"
+        },
+        {
+            "value": "200gbase-x-qsfp56",
+            "display_name": "QSFP56 (200GE)"
+        },
+        {
+            "value": "400gbase-x-qsfpdd",
+            "display_name": "QSFP-DD (400GE)"
+        },
+        {
+            "value": "400gbase-x-osfp",
+            "display_name": "OSFP (400GE)"
+        },
+        {
+            "value": "ieee802.11a",
+            "display_name": "IEEE 802.11a"
+        },
+        {
+            "value": "ieee802.11g",
+            "display_name": "IEEE 802.11b/g"
+        },
+        {
+            "value": "ieee802.11n",
+            "display_name": "IEEE 802.11n"
+        },
+        {
+            "value": "ieee802.11ac",
+            "display_name": "IEEE 802.11ac"
+        },
+        {
+            "value": "ieee802.11ad",
+            "display_name": "IEEE 802.11ad"
+        },
+        {
+            "value": "ieee802.11ax",
+            "display_name": "IEEE 802.11ax"
+        },
+        {
+            "value": "gsm",
+            "display_name": "GSM"
+        },
+        {
+            "value": "cdma",
+            "display_name": "CDMA"
+        },
+        {
+            "value": "lte",
+            "display_name": "LTE"
+        },
+        {
+            "value": "sonet-oc3",
+            "display_name": "OC-3/STM-1"
+        },
+        {
+            "value": "sonet-oc12",
+            "display_name": "OC-12/STM-4"
+        },
+        {
+            "value": "sonet-oc48",
+            "display_name": "OC-48/STM-16"
+        },
+        {
+            "value": "sonet-oc192",
+            "display_name": "OC-192/STM-64"
+        },
+        {
+            "value": "sonet-oc768",
+            "display_name": "OC-768/STM-256"
+        },
+        {
+            "value": "sonet-oc1920",
+            "display_name": "OC-1920/STM-640"
+        },
+        {
+            "value": "sonet-oc3840",
+            "display_name": "OC-3840/STM-1234"
+        },
+        {
+            "value": "1gfc-sfp",
+            "display_name": "SFP (1GFC)"
+        },
+        {
+            "value": "2gfc-sfp",
+            "display_name": "SFP (2GFC)"
+        },
+        {
+            "value": "4gfc-sfp",
+            "display_name": "SFP (4GFC)"
+        },
+        {
+            "value": "8gfc-sfpp",
+            "display_name": "SFP+ (8GFC)"
+        },
+        {
+            "value": "16gfc-sfpp",
+            "display_name": "SFP+ (16GFC)"
+        },
+        {
+            "value": "32gfc-sfp28",
+            "display_name": "SFP28 (32GFC)"
+        },
+        {
+            "value": "128gfc-sfp28",
+            "display_name": "QSFP28 (128GFC)"
+        },
+        {
+            "value": "inifiband-sdr",
+            "display_name": "SDR (2 Gbps)"
+        },
+        {
+            "value": "inifiband-ddr",
+            "display_name": "DDR (4 Gbps)"
+        },
+        {
+            "value": "inifiband-qdr",
+            "display_name": "QDR (8 Gbps)"
+        },
+        {
+            "value": "inifiband-fdr10",
+            "display_name": "FDR10 (10 Gbps)"
+        },
+        {
+            "value": "inifiband-fdr",
+            "display_name": "FDR (13.5 Gbps)"
+        },
+        {
+            "value": "inifiband-edr",
+            "display_name": "EDR (25 Gbps)"
+        },
+        {
+            "value": "inifiband-hdr",
+            "display_name": "HDR (50 Gbps)"
+        },
+        {
+            "value": "inifiband-ndr",
+            "display_name": "NDR (100 Gbps)"
+        },
+        {
+            "value": "inifiband-xdr",
+            "display_name": "XDR (250 Gbps)"
+        },
+        {
+            "value": "t1",
+            "display_name": "T1 (1.544 Mbps)"
+        },
+        {
+            "value": "e1",
+            "display_name": "E1 (2.048 Mbps)"
+        },
+        {
+            "value": "t3",
+            "display_name": "T3 (45 Mbps)"
+        },
+        {
+            "value": "e3",
+            "display_name": "E3 (34 Mbps)"
+        },
+        {
+            "value": "cisco-stackwise",
+            "display_name": "Cisco StackWise"
+        },
+        {
+            "value": "cisco-stackwise-plus",
+            "display_name": "Cisco StackWise Plus"
+        },
+        {
+            "value": "cisco-flexstack",
+            "display_name": "Cisco FlexStack"
+        },
+        {
+            "value": "cisco-flexstack-plus",
+            "display_name": "Cisco FlexStack Plus"
+        },
+        {
+            "value": "juniper-vcp",
+            "display_name": "Juniper VCP"
+        },
+        {
+            "value": "extreme-summitstack",
+            "display_name": "Extreme SummitStack"
+        },
+        {
+            "value": "extreme-summitstack-128",
+            "display_name": "Extreme SummitStack-128"
+        },
+        {
+            "value": "extreme-summitstack-256",
+            "display_name": "Extreme SummitStack-256"
+        },
+        {
+            "value": "extreme-summitstack-512",
+            "display_name": "Extreme SummitStack-512"
+        },
+        {
+            "value": "other",
+            "display_name": "Other"
+        }
+    ],
+    "mode": [
+        {
+            "value": "access",
+            "display_name": "Access"
+        },
+        {
+            "value": "tagged",
+            "display_name": "Tagged"
+        },
+        {
+            "value": "tagged-all",
+            "display_name": "Tagged (All)"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/prefixes.json
+++ b/tests/unit/module_utils/fixtures/choices/prefixes.json
@@ -1,0 +1,20 @@
+{
+    "status": [
+        {
+            "value": "container",
+            "display_name": "Container"
+        },
+        {
+            "value": "active",
+            "display_name": "Active"
+        },
+        {
+            "value": "reserved",
+            "display_name": "Reserved"
+        },
+        {
+            "value": "deprecated",
+            "display_name": "Deprecated"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/racks.json
+++ b/tests/unit/module_utils/fixtures/choices/racks.json
@@ -1,0 +1,66 @@
+{
+    "status": [
+        {
+            "value": "reserved",
+            "display_name": "Reserved"
+        },
+        {
+            "value": "available",
+            "display_name": "Available"
+        },
+        {
+            "value": "planned",
+            "display_name": "Planned"
+        },
+        {
+            "value": "active",
+            "display_name": "Active"
+        },
+        {
+            "value": "deprecated",
+            "display_name": "Deprecated"
+        }
+    ],
+    "type": [
+        {
+            "value": "2-post-frame",
+            "display_name": "2-post frame"
+        },
+        {
+            "value": "4-post-frame",
+            "display_name": "4-post frame"
+        },
+        {
+            "value": "4-post-cabinet",
+            "display_name": "4-post cabinet"
+        },
+        {
+            "value": "wall-frame",
+            "display_name": "Wall-mounted frame"
+        },
+        {
+            "value": "wall-cabinet",
+            "display_name": "Wall-mounted cabinet"
+        }
+    ],
+    "width": [
+        {
+            "value": 19,
+            "display_name": "19 inches"
+        },
+        {
+            "value": 23,
+            "display_name": "23 inches"
+        }
+    ],
+    "outer_unit": [
+        {
+            "value": "mm",
+            "display_name": "Millimeters"
+        },
+        {
+            "value": "in",
+            "display_name": "Inches"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/services.json
+++ b/tests/unit/module_utils/fixtures/choices/services.json
@@ -1,0 +1,12 @@
+{
+    "protocol": [
+        {
+            "value": "tcp",
+            "display_name": "TCP"
+        },
+        {
+            "value": "udp",
+            "display_name": "UDP"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/sites.json
+++ b/tests/unit/module_utils/fixtures/choices/sites.json
@@ -1,0 +1,16 @@
+{
+    "status": [
+        {
+            "value": "active",
+            "display_name": "Active"
+        },
+        {
+            "value": "planned",
+            "display_name": "Planned"
+        },
+        {
+            "value": "retired",
+            "display_name": "Retired"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/virtual_machines.json
+++ b/tests/unit/module_utils/fixtures/choices/virtual_machines.json
@@ -1,0 +1,16 @@
+{
+    "status": [
+        {
+            "value": "active",
+            "display_name": "Active"
+        },
+        {
+            "value": "offline",
+            "display_name": "Offline"
+        },
+        {
+            "value": "staged",
+            "display_name": "Staged"
+        }
+    ]
+}

--- a/tests/unit/module_utils/fixtures/choices/vlans.json
+++ b/tests/unit/module_utils/fixtures/choices/vlans.json
@@ -1,0 +1,16 @@
+{
+    "status": [
+        {
+            "value": "active",
+            "display_name": "Active"
+        },
+        {
+            "value": "reserved",
+            "display_name": "Reserved"
+        },
+        {
+            "value": "deprecated",
+            "display_name": "Deprecated"
+        }
+    ]
+}

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -3,10 +3,6 @@
 # Copyright: (c) 2019, Mikhail Yohman (@FragmentedPacket) <mikhail.yohman@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# import unittest
-# from units.compat import unittest
-# from units.compat.mock import patch, MagicMock, Mock
-
 import pytest
 from unittest.mock import patch, MagicMock, Mock
 from ansible.module_utils.basic import AnsibleModule
@@ -46,6 +42,13 @@ def fixture_arg_spec():
         "state": "present",
         "validate_certs": False,
     }
+
+
+@pytest.fixture
+def choices_data(choice):
+    with open(f"{choice}.json", "r") as f:
+        choice_data = f.read()
+    return choice_data
 
 
 @pytest.fixture
@@ -364,183 +367,58 @@ def test_update_netbox_object_with_changes_check_mode_true(
     assert diff == on_update_diff
 
 
-# @pytest.mark.parametrize(
-#    "endpoint, data, expected",
-#    [
-#        (
-#            "circuits",
-#            {
-#                "status": "Active",
-#                "status": "Offline",
-#                "status": "Planned",
-#                "status": "Provisioning",
-#                "status": "Deprovisioning",
-#                "status": "Decommissioned",
-#                "status": 1,
-#            },
-#            {
-#                "status": 1,
-#                "status": 4,
-#                "status": 2,
-#                "status": 3,
-#                "status": 0,
-#                "status": 5,
-#                "status": 1,
-#            },
-#        ),
-#        (
-#            "devices",
-#            {
-#                "status": "Active",
-#                "status": "Offline",
-#                "status": "Planned",
-#                "status": "Staged",
-#                "status": "Failed",
-#                "status": "Inventory",
-#                "status": 5,
-#                "face": "Front",
-#                "face": "Rear",
-#                "face": 1,
-#            },
-#            {
-#                "status": 1,
-#                "status": 0,
-#                "status": 2,
-#                "status": 3,
-#                "status": 4,
-#                "status": 5,
-#                "face": 0,
-#                "face": 1,
-#                "face": 1,
-#            },
-#        ),
-#        (
-#            "device_types",
-#            {"subdevice_role": "Parent", "subdevice_role": "Child"},
-#            {"subdevice_role": True, "subdevice_role": False},
-#        ),
-#        (
-#            "interfaces",
-#            {
-#                "form_factor": "1000base-t (1ge)",
-#                "mode": "Access",
-#                "mode": "Tagged",
-#                "mode": "Tagged all",
-#                "mode": 100,
-#            },
-#            {"form_factor": 1000, "mode": 100, "mode": 200, "mode": 300, "mode": 100},
-#        ),
-#        (
-#            "ip_addresses",
-#            {
-#                "status": "Active",
-#                "status": "Reserved",
-#                "status": "Deprecated",
-#                "status": "DHCP",
-#                "status": 1,
-#                "role": "Loopback",
-#                "role": "Secondary",
-#                "role": "Anycast",
-#                "role": "VIP",
-#                "role": "VRRP",
-#                "role": "HSRP",
-#                "role": "GLBP",
-#                "role": "CARP",
-#                "role": 30,
-#            },
-#            {
-#                "status": 1,
-#                "status": 2,
-#                "status": 3,
-#                "status": 5,
-#                "status": 1,
-#                "role": 10,
-#                "role": 20,
-#                "role": 30,
-#                "role": 40,
-#                "role": 41,
-#                "role": 42,
-#                "role": 43,
-#                "role": 44,
-#                "role": 30,
-#            },
-#        ),
-#        (
-#            "prefixes",
-#            {
-#                "status": "Active",
-#                "status": "Container",
-#                "status": "Reserved",
-#                "status": "Deprecated",
-#                "status": 2,
-#            },
-#            {"status": 1, "status": 0, "status": 2, "status": 3, "status": 2},
-#        ),
-#        (
-#            "racks",
-#            {
-#                "status": "Active",
-#                "status": "Planned",
-#                "status": "Reserved",
-#                "status": "Available",
-#                "status": "Deprecated",
-#                "outer_unit": "Inches",
-#                "outer_unit": "Millimeters",
-#                "type": "2-post Frame",
-#                "type": "4-post Frame",
-#                "type": "4-post Cabinet",
-#                "type": "Wall-mounted Frame",
-#                "type": "Wall-mounted Cabinet",
-#                "type": 1100,
-#            },
-#            {
-#                "status": 3,
-#                "status": 2,
-#                "status": 0,
-#                "status": 1,
-#                "status": 4,
-#                "outer_unit": 2000,
-#                "outer_unit": 1000,
-#                "type": 100,
-#                "type": 200,
-#                "type": 300,
-#                "type": 1000,
-#                "type": 1100,
-#                "type": 1100,
-#            },
-#        ),
-#        (
-#            "sites",
-#            {"status": "Active", "status": "Planned", "status": "Retired", "status": 2},
-#            {"status": 1, "status": 2, "status": 4, "status": 2},
-#        ),
-#        (
-#            "virtual_machines",
-#            {
-#                "status": "Offline",
-#                "status": "Active",
-#                "status": "Staged",
-#                "face": "Front",
-#                "face": "Rear",
-#                "face": 0,
-#            },
-#            {"status": 0, "status": 1, "status": 3, "face": 0, "face": 1, "face": 0},
-#        ),
-#        (
-#            "vlans",
-#            {
-#                "status": "Active",
-#                "status": "Reserved",
-#                "status": "Deprecated",
-#                "status": 2,
-#            },
-#            {"status": 1, "status": 2, "status": 3, "status": 2},
-#        ),
-#    ],
-# )
-# def test_change_choices_id(mock_netbox_module, endpoint, data, expected):
-#    new_data = mock_netbox_module._change_choices_id(endpoint, data)
-#    assert new_data == expected
+@pytest.mark.parametrize(
+    "endpoint, data, expected",
+    [
+        ("circuits", {"status": "Active"}, {"status": "temp"},),
+        ("circuits", {"status": 1}, {"status": 1},),
+        (
+            "devices",
+            {"status": "Active", "face": "Front"},
+            {"status": "temp", "face": "temp"},
+        ),
+        ("devices", {"status": 5, "face": 1}, {"status": 5, "face": 1},),
+        ("device_types", {"subdevice_role": "Parent"}, {"subdevice_role": "temp"},),
+        ("device_types", {"subdevice_role": "Child"}, {"subdevice_role": "temp"},),
+        (
+            "interfaces",
+            {"form_factor": "1000base-t (1ge)", "mode": "Access"},
+            {"form_factor": "temp", "mode": "temp"},
+        ),
+        ("interfaces", {"mode": 100}, {"mode": 100},),
+        (
+            "ip_addresses",
+            {"status": "Active", "role": "Loopback"},
+            {"status": "temp", "role": "temp"},
+        ),
+        ("ip_addresses", {"status": 1, "role": 30}, {"status": 1, "role": 30},),
+        ("prefixes", {"status": "Active"}, {"status": "temp"},),
+        ("prefixes", {"status": 2}, {"status": 2},),
+        (
+            "racks",
+            {"status": "Active", "outer_unit": "Inches", "type": "2-post Frame",},
+            {"status": "temp", "outer_unit": "temp", "type": "temp",},
+        ),
+        ("racks", {"status": 0, "type": 1100,}, {"status": 0, "type": 1100,},),
+        ("sites", {"status": "Active"}, {"status": "temp"}),
+        ("sites", {"status": 2}, {"status": 2}),
+        (
+            "virtual_machines",
+            {"status": "Offline", "face": "Front"},
+            {"status": "temp", "face": "temp"},
+        ),
+        ("virtual_machines", {"status": 1, "face": 0}, {"status": 1, "face": 0},),
+        ("vlans", {"status": "Active"}, {"status": "temp"}),
+        ("vlans", {"status": 2}, {"status": 2}),
+    ],
+)
+def test_change_choices_id(mocker, mock_netbox_module, endpoint, data, expected):
+    fetch_choice_value = mocker.patch(
+        "%s%s" % (MOCKER_PATCH_PATH, "._fetch_choice_value")
+    )
+    fetch_choice_value.return_value = "temp"
+    new_data = mock_netbox_module._change_choices_id(endpoint, data)
+    assert new_data == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -118,11 +118,6 @@ def on_deletion_diff(mock_netbox_module):
 def mock_netbox_module(mocker, mock_ansible_module, find_ids_return):
     find_ids = mocker.patch("%s%s" % (MOCKER_PATCH_PATH, "._find_ids"))
     find_ids.return_value = find_ids_return
-    # The follow is just mocking the object so it doesn't try to make live calls and our nb_client is a boolean instead
-    # of an actual pynetbox.api object
-    get_application_choices = mocker.patch(
-        "%s%s" % (MOCKER_PATCH_PATH, "._get_application_choices")
-    )
     netbox = NetboxModule(mock_ansible_module, NB_DEVICES, nb_client=True)
 
     return netbox

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -118,6 +118,11 @@ def on_deletion_diff(mock_netbox_module):
 def mock_netbox_module(mocker, mock_ansible_module, find_ids_return):
     find_ids = mocker.patch("%s%s" % (MOCKER_PATCH_PATH, "._find_ids"))
     find_ids.return_value = find_ids_return
+    # The follow is just mocking the object so it doesn't try to make live calls and our nb_client is a boolean instead
+    # of an actual pynetbox.api object
+    get_application_choices = mocker.patch(
+        "%s%s" % (MOCKER_PATCH_PATH, "._get_application_choices")
+    )
     netbox = NetboxModule(mock_ansible_module, NB_DEVICES, nb_client=True)
 
     return netbox
@@ -364,183 +369,183 @@ def test_update_netbox_object_with_changes_check_mode_true(
     assert diff == on_update_diff
 
 
-@pytest.mark.parametrize(
-    "endpoint, data, expected",
-    [
-        (
-            "circuits",
-            {
-                "status": "Active",
-                "status": "Offline",
-                "status": "Planned",
-                "status": "Provisioning",
-                "status": "Deprovisioning",
-                "status": "Decommissioned",
-                "status": 1,
-            },
-            {
-                "status": 1,
-                "status": 4,
-                "status": 2,
-                "status": 3,
-                "status": 0,
-                "status": 5,
-                "status": 1,
-            },
-        ),
-        (
-            "devices",
-            {
-                "status": "Active",
-                "status": "Offline",
-                "status": "Planned",
-                "status": "Staged",
-                "status": "Failed",
-                "status": "Inventory",
-                "status": 5,
-                "face": "Front",
-                "face": "Rear",
-                "face": 1,
-            },
-            {
-                "status": 1,
-                "status": 0,
-                "status": 2,
-                "status": 3,
-                "status": 4,
-                "status": 5,
-                "face": 0,
-                "face": 1,
-                "face": 1,
-            },
-        ),
-        (
-            "device_types",
-            {"subdevice_role": "Parent", "subdevice_role": "Child"},
-            {"subdevice_role": True, "subdevice_role": False},
-        ),
-        (
-            "interfaces",
-            {
-                "form_factor": "1000base-t (1ge)",
-                "mode": "Access",
-                "mode": "Tagged",
-                "mode": "Tagged all",
-                "mode": 100,
-            },
-            {"form_factor": 1000, "mode": 100, "mode": 200, "mode": 300, "mode": 100},
-        ),
-        (
-            "ip_addresses",
-            {
-                "status": "Active",
-                "status": "Reserved",
-                "status": "Deprecated",
-                "status": "DHCP",
-                "status": 1,
-                "role": "Loopback",
-                "role": "Secondary",
-                "role": "Anycast",
-                "role": "VIP",
-                "role": "VRRP",
-                "role": "HSRP",
-                "role": "GLBP",
-                "role": "CARP",
-                "role": 30,
-            },
-            {
-                "status": 1,
-                "status": 2,
-                "status": 3,
-                "status": 5,
-                "status": 1,
-                "role": 10,
-                "role": 20,
-                "role": 30,
-                "role": 40,
-                "role": 41,
-                "role": 42,
-                "role": 43,
-                "role": 44,
-                "role": 30,
-            },
-        ),
-        (
-            "prefixes",
-            {
-                "status": "Active",
-                "status": "Container",
-                "status": "Reserved",
-                "status": "Deprecated",
-                "status": 2,
-            },
-            {"status": 1, "status": 0, "status": 2, "status": 3, "status": 2},
-        ),
-        (
-            "racks",
-            {
-                "status": "Active",
-                "status": "Planned",
-                "status": "Reserved",
-                "status": "Available",
-                "status": "Deprecated",
-                "outer_unit": "Inches",
-                "outer_unit": "Millimeters",
-                "type": "2-post Frame",
-                "type": "4-post Frame",
-                "type": "4-post Cabinet",
-                "type": "Wall-mounted Frame",
-                "type": "Wall-mounted Cabinet",
-                "type": 1100,
-            },
-            {
-                "status": 3,
-                "status": 2,
-                "status": 0,
-                "status": 1,
-                "status": 4,
-                "outer_unit": 2000,
-                "outer_unit": 1000,
-                "type": 100,
-                "type": 200,
-                "type": 300,
-                "type": 1000,
-                "type": 1100,
-                "type": 1100,
-            },
-        ),
-        (
-            "sites",
-            {"status": "Active", "status": "Planned", "status": "Retired", "status": 2},
-            {"status": 1, "status": 2, "status": 4, "status": 2},
-        ),
-        (
-            "virtual_machines",
-            {
-                "status": "Offline",
-                "status": "Active",
-                "status": "Staged",
-                "face": "Front",
-                "face": "Rear",
-                "face": 0,
-            },
-            {"status": 0, "status": 1, "status": 3, "face": 0, "face": 1, "face": 0},
-        ),
-        (
-            "vlans",
-            {
-                "status": "Active",
-                "status": "Reserved",
-                "status": "Deprecated",
-                "status": 2,
-            },
-            {"status": 1, "status": 2, "status": 3, "status": 2},
-        ),
-    ],
-)
-def test_change_choices_id(mock_netbox_module, endpoint, data, expected):
-    new_data = mock_netbox_module._change_choices_id(endpoint, data)
-    assert new_data == expected
+# @pytest.mark.parametrize(
+#    "endpoint, data, expected",
+#    [
+#        (
+#            "circuits",
+#            {
+#                "status": "Active",
+#                "status": "Offline",
+#                "status": "Planned",
+#                "status": "Provisioning",
+#                "status": "Deprovisioning",
+#                "status": "Decommissioned",
+#                "status": 1,
+#            },
+#            {
+#                "status": 1,
+#                "status": 4,
+#                "status": 2,
+#                "status": 3,
+#                "status": 0,
+#                "status": 5,
+#                "status": 1,
+#            },
+#        ),
+#        (
+#            "devices",
+#            {
+#                "status": "Active",
+#                "status": "Offline",
+#                "status": "Planned",
+#                "status": "Staged",
+#                "status": "Failed",
+#                "status": "Inventory",
+#                "status": 5,
+#                "face": "Front",
+#                "face": "Rear",
+#                "face": 1,
+#            },
+#            {
+#                "status": 1,
+#                "status": 0,
+#                "status": 2,
+#                "status": 3,
+#                "status": 4,
+#                "status": 5,
+#                "face": 0,
+#                "face": 1,
+#                "face": 1,
+#            },
+#        ),
+#        (
+#            "device_types",
+#            {"subdevice_role": "Parent", "subdevice_role": "Child"},
+#            {"subdevice_role": True, "subdevice_role": False},
+#        ),
+#        (
+#            "interfaces",
+#            {
+#                "form_factor": "1000base-t (1ge)",
+#                "mode": "Access",
+#                "mode": "Tagged",
+#                "mode": "Tagged all",
+#                "mode": 100,
+#            },
+#            {"form_factor": 1000, "mode": 100, "mode": 200, "mode": 300, "mode": 100},
+#        ),
+#        (
+#            "ip_addresses",
+#            {
+#                "status": "Active",
+#                "status": "Reserved",
+#                "status": "Deprecated",
+#                "status": "DHCP",
+#                "status": 1,
+#                "role": "Loopback",
+#                "role": "Secondary",
+#                "role": "Anycast",
+#                "role": "VIP",
+#                "role": "VRRP",
+#                "role": "HSRP",
+#                "role": "GLBP",
+#                "role": "CARP",
+#                "role": 30,
+#            },
+#            {
+#                "status": 1,
+#                "status": 2,
+#                "status": 3,
+#                "status": 5,
+#                "status": 1,
+#                "role": 10,
+#                "role": 20,
+#                "role": 30,
+#                "role": 40,
+#                "role": 41,
+#                "role": 42,
+#                "role": 43,
+#                "role": 44,
+#                "role": 30,
+#            },
+#        ),
+#        (
+#            "prefixes",
+#            {
+#                "status": "Active",
+#                "status": "Container",
+#                "status": "Reserved",
+#                "status": "Deprecated",
+#                "status": 2,
+#            },
+#            {"status": 1, "status": 0, "status": 2, "status": 3, "status": 2},
+#        ),
+#        (
+#            "racks",
+#            {
+#                "status": "Active",
+#                "status": "Planned",
+#                "status": "Reserved",
+#                "status": "Available",
+#                "status": "Deprecated",
+#                "outer_unit": "Inches",
+#                "outer_unit": "Millimeters",
+#                "type": "2-post Frame",
+#                "type": "4-post Frame",
+#                "type": "4-post Cabinet",
+#                "type": "Wall-mounted Frame",
+#                "type": "Wall-mounted Cabinet",
+#                "type": 1100,
+#            },
+#            {
+#                "status": 3,
+#                "status": 2,
+#                "status": 0,
+#                "status": 1,
+#                "status": 4,
+#                "outer_unit": 2000,
+#                "outer_unit": 1000,
+#                "type": 100,
+#                "type": 200,
+#                "type": 300,
+#                "type": 1000,
+#                "type": 1100,
+#                "type": 1100,
+#            },
+#        ),
+#        (
+#            "sites",
+#            {"status": "Active", "status": "Planned", "status": "Retired", "status": 2},
+#            {"status": 1, "status": 2, "status": 4, "status": 2},
+#        ),
+#        (
+#            "virtual_machines",
+#            {
+#                "status": "Offline",
+#                "status": "Active",
+#                "status": "Staged",
+#                "face": "Front",
+#                "face": "Rear",
+#                "face": 0,
+#            },
+#            {"status": 0, "status": 1, "status": 3, "face": 0, "face": 1, "face": 0},
+#        ),
+#        (
+#            "vlans",
+#            {
+#                "status": "Active",
+#                "status": "Reserved",
+#                "status": "Deprecated",
+#                "status": 2,
+#            },
+#            {"status": 1, "status": 2, "status": 3, "status": 2},
+#        ),
+#    ],
+# )
+# def test_change_choices_id(mock_netbox_module, endpoint, data, expected):
+#    new_data = mock_netbox_module._change_choices_id(endpoint, data)
+#    assert new_data == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #67 

This PR removes static choices that were defined in `plugins/module_utils/netbox_utils.py` and instead makes API calls to the appropriate endpoint to fetch the choices for the endpoint.

Updated unit testing a little bit, but they need more work. I will refactor those in a separate PR.