### PR TITLE
Inventory-Feature: Added services lookup

### DIFF
--- a/plugins/inventory/netbox.py
+++ b/plugins/inventory/netbox.py
@@ -248,6 +248,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
+            "services": self.extract_services,
             "config_context": self.extract_config_context,
             "manufacturers": self.extract_manufacturer,
         }
@@ -264,6 +265,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def extract_platform(self, host):
         try:
             return [self.platforms_lookup[host["platform"]["id"]]]
+        except Exception:
+            return
+
+    def extract_services(self, host):
+        try:
+            url = self.api_endpoint + "/api/ipam/services/?device=" + str(host["name"])
+            device_lookup = self._fetch_information(url)
+            return device_lookup["results"]
         except Exception:
             return
 


### PR DESCRIPTION
Fixes #58 

This just returns the raw output from the API call and doesn't include any doctoring. Below is an example:
```
"test100": {
    "device_roles": [
        "Core Switch"
    ],
    "device_types": [
        "Cisco Test"
    ],
    "manufacturers": [
        "Cisco"
    ],
    "services": [
        {
            "created": "2020-02-13",
            "custom_fields": {},
            "description": "",
            "device": {
                "display_name": "test100",
                "id": 1,
                "name": "test100",
                "url": "http://netbox-demo.org:32768/api/dcim/devices/1/"
            },
            "id": 1,
            "ipaddresses": [],
            "last_updated": "2020-02-13T19:36:08.076923Z",
            "name": "test",
            "port": 8080,
            "protocol": {
                "id": 6,
                "label": "TCP",
                "value": "tcp"
            },
            "tags": [],
            "virtual_machine": null
        }
    ],
    "sites": [
        "Test Site"
	],
}
```