### PR TITLE
BugFix: netbox_device_interface: Lag defined as dict broke Netbox v2.7

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -462,7 +462,10 @@ class NetboxModule(object):
         if parent == "lag":
             if not child:
                 query_dict["name"] = module_data["lag"]
-            query_dict.update({"form_factor": 200})
+            intf_type = self._fetch_choice_value(
+                "Link Aggregation Group (LAG)", "interfaces"
+            )
+            query_dict.update({"form_factor": intf_type})
             if isinstance(module_data["device"], int):
                 query_dict.update({"device_id": module_data["device"]})
             else:

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -222,6 +222,12 @@ def test_build_query_params_child(
         "%s%s" % (MOCKER_PATCH_PATH, "._get_query_param_id")
     )
     get_query_param_id.return_value = 1
+    # This will need to be updated, but attempting to fix issue quickly
+    fetch_choice_value = mocker.patch(
+        "%s%s" % (MOCKER_PATCH_PATH, "._fetch_choice_value")
+    )
+    fetch_choice_value.return_value = 200
+
     query_params = mock_netbox_module._build_query_params(parent, module_data, child)
     assert query_params == expected
 


### PR DESCRIPTION
Fixes #106 

This removes the static finding of the lag choice when lag is defined as a dictionary and uses the new endpoints that collects the choices from the API, this should be backwards compatible as well.

