### PR TITLE
BugFix: Device name - empty string tests as well

### DIFF
--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -135,6 +135,17 @@ EXAMPLES = r"""
           site: Main
         state: present
 
+    - name: Create device within Netbox with empty string name to generate UUID
+      netbox_device:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: ""
+          device_type: C9410R
+          device_role: Core Switch
+          site: Main
+        state: present
+
     - name: Delete device within netbox
       netbox_device:
         netbox_url: http://netbox.local
@@ -187,6 +198,7 @@ from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.n
     NetboxDcimModule,
     NB_DEVICES,
 )
+import uuid
 
 
 def main():
@@ -244,6 +256,8 @@ def main():
     module = NetboxAnsibleModule(
         argument_spec=argument_spec, supports_check_mode=True, required_if=required_if
     )
+    if module.params["data"]["name"] == "":
+        module.params["data"]["name"] = str(uuid.uuid4())
 
     netbox_device = NetboxDcimModule(module, NB_DEVICES)
     netbox_device.run()

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -182,6 +182,32 @@
           - test_seven['device']['primary_ip6'] == 2
           - test_seven['msg'] == "device test100 updated"
 
+    - name: "8 - Device with empty string name"
+      netbox_device:
+        netbox_url: "http://localhost:32768"
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: ""
+          device_type: "Cisco Test"
+          device_role: "Core Switch"
+          site: "Test Site"
+          status: "Staged"
+        state: present
+      register: test_eight
+
+    - name: "8 - ASSERT"
+      assert:
+        that:
+          - test_eight is changed
+          - test_eight['diff']['before']['state'] == 'absent'
+          - test_eight['diff']['after']['state'] == 'present'
+          - test_eight['device']['device_role'] == 1
+          - test_eight['device']['device_type'] == 1
+          - test_eight['device']['site'] == 1
+          - test_eight['device']['status'] == 3
+          - "'-' in test_eight['device']['name']"
+          - "test_eight['device']['name'] | length == 36"
+
 ##
 ##
 ### NETBOX_DEVICE_INTERFACE


### PR DESCRIPTION
Fixes #108 

If name is empty string, set UUID

I'm not 100% sure if I like this way, but I think that at least gets us over this issue for now. Hopefully we receive more input from others since this is not something i've done and don't have any strong opinion or use case for it.