### PR TITLE
Add slug key for sites, tenants and tenant_groups

### DIFF
--- a/plugins/module_utils/netbox_tenancy.py
+++ b/plugins/module_utils/netbox_tenancy.py
@@ -10,12 +10,13 @@ try:
     from ansible_collections.netbox_community.ansible_modules.plugins.module_utils.netbox_utils import (
         NetboxModule,
         ENDPOINT_NAME_MAPPING,
+        SLUG_REQUIRED,
     )
 except ImportError:
     import sys
 
     sys.path.append(".")
-    from netbox_utils import NetboxModule, ENDPOINT_NAME_MAPPING
+    from netbox_utils import NetboxModule, ENDPOINT_NAME_MAPPING, SLUG_REQUIRED
 
 
 NB_TENANTS = "tenants"
@@ -46,9 +47,14 @@ class NetboxTenancyModule(NetboxModule):
         data = self.data
 
         # Used for msg output
-        name = data.get("name")
+        if data.get("name"):
+            name = data["name"]
+        elif data.get("slug"):
+            name = data["slug"]
 
-        data["slug"] = self._to_slug(name)
+        if self.endpoint in SLUG_REQUIRED:
+            if not data.get("slug"):
+                data["slug"] = self._to_slug(name)
 
         object_query_params = self._build_query_params(endpoint_name, data)
         self.nb_object = self._nb_endpoint_get(nb_endpoint, object_query_params, name)

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -92,7 +92,7 @@ QUERY_TYPES = dict(
     rir="slug",
     slug="slug",
     site="slug",
-    tenant="name",
+    tenant="slug",
     tenant_group="slug",
     time_zone="timezone",
     virtual_machine="name",
@@ -217,8 +217,8 @@ ALLOWED_QUERY_PARAMS = {
     "services": set(["device", "virtual_machine", "name"]),
     "site": set(["slug"]),
     "tagged_vlans": set(["name", "site", "vlan_group", "tenant"]),
-    "tenant": set(["name"]),
-    "tenant_group": set(["name"]),
+    "tenant": set(["slug"]),
+    "tenant_group": set(["slug"]),
     "untagged_vlan": set(["name", "site", "vlan_group", "tenant"]),
     "virtual_machine": set(["name", "cluster"]),
     "vlan": set(["name", "site", "tenant", "vlan_group"]),
@@ -283,6 +283,9 @@ SLUG_REQUIRED = {
     "regions",
     "rirs",
     "roles",
+    "sites",
+    "tenants",
+    "tenant_groups",
     "manufacturers",
     "platforms",
     "providers",
@@ -609,9 +612,6 @@ class NetboxModule(object):
                 elif data_type == "timezone":
                     if " " in v:
                         data[k] = v.replace(" ", "_")
-        if self.endpoint == "sites":
-            site_slug = self._to_slug(data["name"])
-            data["slug"] = site_slug
 
         return data
 

--- a/plugins/modules/netbox_site.py
+++ b/plugins/modules/netbox_site.py
@@ -112,6 +112,10 @@ options:
         description:
           - Comments for the site. This can be markdown syntax
         type: str
+      slug:
+        description:
+          - URL-friendly unique shorthand
+        type: str
       tags:
         description:
           - Any tags that the prefix may need to be associated with
@@ -178,6 +182,7 @@ EXAMPLES = r"""
           contact_name: Jenny
           contact_phone: 867-5309
           contact_email: jenny@changednumber.com
+          slug: test-california
           comments: ### Placeholder
         state: present
 """
@@ -237,6 +242,7 @@ def main():
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type=list),
                     custom_fields=dict(required=False, type=dict),
+                    slug=dict(required=False, type="str"),
                 ),
             ),
         )

--- a/plugins/modules/netbox_tenant.py
+++ b/plugins/modules/netbox_tenant.py
@@ -60,6 +60,10 @@ options:
         description:
           - Comments for the tenant. This can be markdown syntax
         type: str
+      slug:
+        description:
+          - URL-friendly unique shorthand
+        type: str
       tags:
         description:
           - Any tags that the tenant may need to be associated with
@@ -115,6 +119,7 @@ EXAMPLES = r"""
           group: Very Special Tenants
           description: ABC Incorporated
           comments: '### This tenant is super cool'
+          slug: tenant_abc
           tags:
             - tagA
             - tagB
@@ -158,6 +163,7 @@ def main():
                     tenant_group=dict(required=False, type="raw"),
                     description=dict(required=False, type="str"),
                     comments=dict(required=False, type="str"),
+                    slug=dict(required=False, type="str"),
                     tags=dict(required=False, type=list),
                     custom_fields=dict(required=False, type=dict),
                 ),

--- a/plugins/modules/netbox_tenant_group.py
+++ b/plugins/modules/netbox_tenant_group.py
@@ -48,6 +48,10 @@ options:
           - Name of the tenant group to be created
         required: true
         type: str
+      slug:
+        description:
+          - URL-friendly unique shorthand
+        type: str
     required: true
   state:
     description:
@@ -75,7 +79,8 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          name: Tenant Group ABC 
+          name: Tenant Group ABC
+          slug: "tenant_group_abc"
         state: present
 
     - name: Delete tenant within netbox

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -1134,6 +1134,7 @@
           contact_phone: 867-5309
           contact_email: jenny@changednumber.com
           comments: "### Placeholder"
+          slug: "test_california"
         state: present
       register: test_four
 
@@ -1160,6 +1161,7 @@
           - test_four['site']['contact_phone'] == "867-5309"
           - test_four['site']['contact_email'] == "jenny@changednumber.com"
           - test_four['site']['comments'] == "### Placeholder"
+          - test_four['site']['slug'] == "test_california"
 
     - name: "5 - Delete site within netbox"
       netbox_site:
@@ -1271,6 +1273,7 @@
           description: "ABC Incorporated"
           comments: "### This tenant is super cool"
           tenant_group: "Test Tenant Group"
+          slug: "tenant_abc"
           tags:
             - tagA
             - tagB
@@ -1285,7 +1288,7 @@
           - test_five['diff']['before']['state'] == "absent"
           - test_five['diff']['after']['state'] == "present"
           - test_five['tenant']['name'] == "Tenant ABC"
-          - test_five['tenant']['slug'] == "tenant-abc"
+          - test_five['tenant']['slug'] == "tenant_abc"
           - test_five['tenant']['description'] == "ABC Incorporated"
           - test_five['tenant']['comments'] == "### This tenant is super cool"
           - test_five['tenant']['group'] == 1
@@ -1355,6 +1358,25 @@
           - test_three['diff']['before']['state'] == "present"
           - test_three['diff']['after']['state'] == "absent"
           - test_three['msg'] == "tenant_group Test Tenant Group Two deleted"
+
+    - name: "4 - Test another tenant group creation"
+      netbox_tenant_group:
+        netbox_url: http://localhost:32768
+        netbox_token: 0123456789abcdef0123456789abcdef01234567
+        data:
+          name: "Test Tenant Group ABC"
+          slug: "test_tenant_group_four"
+      register: test_four
+
+    - name: "4 - ASSERT"
+      assert:
+        that:
+          - test_four is changed
+          - test_four['diff']['before']['state'] == "absent"
+          - test_four['diff']['after']['state'] == "present"
+          - test_four['tenant_group']['name'] == "Test Tenant Group ABC"
+          - test_four['tenant_group']['slug'] == "test_tenant_group_four"
+          - test_four['msg'] == "tenant_group Test Tenant Group ABC created"
 
 ##
 ##

--- a/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
+++ b/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
@@ -289,20 +289,22 @@
         "parent": "tenant",
         "module_data": {
             "name": "Test Tenant",
-            "description": "Test Description"
+            "description": "Test Description",
+            "slug": "test-tenant"
         },
         "expected": {
-            "name": "Test Tenant"
+            "slug": "test-tenant"
         }
     },
     {
         "parent": "tenant_group",
         "module_data": {
             "name": "Test Tenant Group",
-            "description": "Test Description"
+            "description": "Test Description",
+            "slug": "test-tenant-group"
         },
         "expected": {
-            "name": "Test Tenant Group"
+            "slug": "test-tenant-group"
         }
     },
     {

--- a/tests/unit/module_utils/test_data/normalize_data/data.json
+++ b/tests/unit/module_utils/test_data/normalize_data/data.json
@@ -228,7 +228,7 @@
             "tenant": "Test Tenant"
         },
         "after": {
-            "tenant": "Test Tenant"
+            "tenant": "test-tenant"
         }
     },
     {


### PR DESCRIPTION
This change makes possible for deployers to define slug while site,
tenant or tenant_group creation.

Signed-off-by: Dmitriy Rabotyagov <drabotyagov@vexxhost.com>