### PR TITLE
Deploy: Attempting to fix Travis Deploy to Ansible Galaxy on Tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,6 @@ script:
   - ansible-playbook tests/integration/regression-tests.yml -vvvv
   - ansible-playbook tests/integration/integration-tests.yml -vvvv
 
-before_deploy:
-  - pip install ansible
-  - ansible-galaxy collection build .
-
 deploy:
   provider: script
   skip_cleanup: true


### PR DESCRIPTION
From the failed release job, it appears I don't need to install ansible or build the collection again and just publish on tag.