### PR TITLE
BugFix: Corrected name of inventory plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - COLLECTION_NAMESPACE: netbox
     - COLLECTION_NAME: netbox
-    - COLLECTION_VERSION: 0.1.9
+    - COLLECTION_VERSION: 0.1.10
     - secure: "tE6GtwrRU+Kjobx/94xqR2MqM20pHCnrLcHgPzIHA3npdwuA+GjCBiBLTkEEQM4fUWIfzUTyjSr9bZErm1PTI1GcIRdniTgJ3ZzSSkE7tgeYALB/7xsusB57SlmbBQm2SGwU558uWZ3NHEsi0WTgD8GKZo77OpGX72FZKsVXOz6k2wve51sOtoSVjgCsvWTmZHx4ynGdiA5wFkZfaEcjXECahKtunW+MlB5kpJzkVeLRUEXFMhWlsIYiA5nj8OI/X3Nk9ugh1ribENX9LrjpgrqQ9YariZ8G6py1ONuKZIn2g7xs5kNQ3qL6HL6N7SoUxiwH16CfSyugFaYiMfaxQ4NUVGGRHS4vSGbNIf+gLHcYvP40miI1f/+pntCzqygZMhW73FX2o+KH2OGv09khOl8k1nDg2/XvW0kCc/FU6l+Jp5wCC8H9X2uiULtQpRqts5TzIonlPEzGIpfGFgJ5m54Emhv9gjG1Z5OOyL/qae1Wr+L/uhiFafcglZYh8NHEMWCUCkeqFqR2kDmUMtdgYLD7Q7NdwlL/PSVVs1l7UPiQHlnecQKEHN7CvR3eKByTEmkCKafRYh/JQ9rBt9sZc7aAPVu+w3wWUwbHS4o4vVnmyXvJb1PeJSiuynF7CBo4Qd6qj4YwX8gLK6PylGyaMOp169u6xw1mo5/CX0pJ3x4="
 
 matrix:
@@ -62,6 +62,8 @@ script:
   - python tests/integration/netbox-deploy.py
   - ansible-playbook tests/integration/regression-tests.yml -vvvv
   - ansible-playbook tests/integration/integration-tests.yml -vvvv
+  - cd tests/integration
+  - ansible-inventory -i test-inventory.yml --list
 
 deploy:
   provider: script

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: netbox
 name: netbox
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.9
+version: 0.1.10
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -198,7 +198,7 @@ ALLOWED_VM_QUERY_PARAMETERS = (
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
-    NAME = "netbox.netbox.netbox"
+    NAME = "netbox.netbox.nb_inventory"
 
     def _fetch_information(self, url):
         results = None

--- a/tests/integration/ansible.cfg
+++ b/tests/integration/ansible.cfg
@@ -1,0 +1,2 @@
+[inventory]
+enable_plugins =  netbox.netbox.nb_inventory

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -199,8 +199,8 @@ nb.dcim.interfaces.create({"device": 4, "name": "Ethernet1/1", "type": 1000})
 
 ## Create Interfaces
 dev_interfaces = [
-    {"name": "GigabitEthernet1", "device": test100.id, "form_factor": 1000},
-    {"name": "GigabitEthernet2", "device": test100.id, "form_factor": 1000},
+    {"name": "GigabitEthernet1", "device": test100.id, "type": 1000},
+    {"name": "GigabitEthernet2", "device": test100.id, "type": 1000},
 ]
 created_interfaces = nb.dcim.interfaces.create(dev_interfaces)
 ## Interface variables to be used later on

--- a/tests/integration/test-inventory.yml
+++ b/tests/integration/test-inventory.yml
@@ -1,0 +1,4 @@
+plugin: netbox.netbox.nb_inventory
+api_endpoint: "http://localhost:32768"
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false


### PR DESCRIPTION
I broke the inventory plugin by not changing the name of it in the actual file when moving namespaces for Ansible Galaxy

Correct and bumped version, added a quick inventory test to tests