### PR TITLE
BugFix: Jinja template always passes in string, allowed find_ids method to account for that

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -567,13 +567,16 @@ class NetboxModule(object):
                     query_params = {QUERY_TYPES.get(k, "q"): search}
                     query_id = self._nb_endpoint_get(nb_endpoint, query_params, k)
 
+                # Code to work around Ansible templating converting all values to strings
+                # This should allow users to pass in IDs obtained from previous tasks
+                # without causing the module to fail
+                try:
+                    v = int(v)
+                except ValueError:
+                    pass
+
                 if isinstance(v, list):
                     data[k] = id_list
-                elif isinstance(v, str):
-                    try:
-                        int(v)
-                    except ValueError:
-                        pass
                 elif isinstance(v, int):
                     pass
                 elif query_id:

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -569,6 +569,11 @@ class NetboxModule(object):
 
                 if isinstance(v, list):
                     data[k] = id_list
+                elif isinstance(v, str):
+                    try:
+                        int(v)
+                    except ValueError:
+                        pass
                 elif isinstance(v, int):
                     pass
                 elif query_id:

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -570,10 +570,11 @@ class NetboxModule(object):
                 # Code to work around Ansible templating converting all values to strings
                 # This should allow users to pass in IDs obtained from previous tasks
                 # without causing the module to fail
-                try:
-                    v = int(v)
-                except ValueError:
-                    pass
+                if isinstance(v, str):
+                    try:
+                        v = int(v)
+                    except ValueError:
+                        pass
 
                 if isinstance(v, list):
                     data[k] = id_list


### PR DESCRIPTION
Fixes a reported issue in #45 

When using Jinja templating, Ansible converts to string. Added an attempt to convert the value passed in to an integer