### PR TITLE
Added flag for raw api output

### DIFF
--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -233,7 +233,7 @@ class LookupModule(LookupBase):
                     if netbox_raw_return:
                         results.append(dict(res))
 
-                    else: 
+                    else:
                         key = dict(res)["id"]
                         result = {key: dict(res)}
                         results.extend(self._flatten_hash_to_list(result))

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -52,6 +52,10 @@ DOCUMENTATION = """
             description:
                 - The location of the private key tied to user account.
             required: False
+        raw_data:
+            description:
+                - Whether to return raw API data with the lookup/query or whether to return a key/value dict
+            required: False
     requirements:
         - pynetbox
 """
@@ -187,6 +191,7 @@ class LookupModule(LookupBase):
         netbox_api_endpoint = kwargs.get("api_endpoint")
         netbox_private_key_file = kwargs.get("key_file")
         netbox_api_filter = kwargs.get("api_filter")
+        netbox_raw_return = kwargs.get("raw_data")
 
         if not isinstance(terms, list):
             terms = [terms]
@@ -225,19 +230,25 @@ class LookupModule(LookupBase):
 
                     Display().vvvvv(pformat(dict(res)))
 
-                    key = dict(res)["id"]
-                    result = {key: dict(res)}
+                    if netbox_raw_return:
+                        results.append(dict(res))
 
-                    results.extend(self._flatten_hash_to_list(result))
+                    else: 
+                        key = dict(res)["id"]
+                        result = {key: dict(res)}
+                        results.extend(self._flatten_hash_to_list(result))
 
             else:
                 for res in endpoint.all():
 
                     Display().vvvvv(pformat(dict(res)))
 
-                    key = dict(res)["id"]
-                    result = {key: dict(res)}
+                    if netbox_raw_return:
+                        results.append(dict(res))
 
-                    results.extend(self._flatten_hash_to_list(result))
+                    else:
+                        key = dict(res)["id"]
+                        result = {key: dict(res)}
+                        results.extend(self._flatten_hash_to_list(result))
 
         return results

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -4451,3 +4451,9 @@
         that: "{{ query_result|json_query('[?value.display_name==`L2`]')|count }} == 1"
       vars:
         query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+    - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
+      assert:
+        that: "{{ query_result|json_query('[?display_name==`L2`]')|count }} == 1"
+      vars:
+        query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567', raw_data=True) }}"


### PR DESCRIPTION
This PR adds the ability to return the raw data of the Netbox API. 

Currently when given the command `device: "{{ lookup('netbox.netbox.nb_lookup', 'devices', api_endpoint=api_url, token=api_token }}"` data is returned in the following format:

```
    "device": {
            "key": 7,
            "value": {
                "asset_tag": null,
                "cluster": null,
                "comments": "",
                <snipped for brevity>
      }
```
This adds an extra layer of complexity for usage as it increases the depth of the data structure behind a somewhat meaningless key/value construct where the Netbox object id becomes the key and the payload is hidden under value

This PR adds the option for the lookup plugin to return the raw Netbox API response in the following format

`device: "{{ lookup('netbox.netbox.nb_lookup', 'devices', api_endpoint=api_url, token=api_token, raw_data=True }}"`

```
    "device": {
        "asset_tag": null,
        "cluster": null,
        "comments": "",
        <snipped for brevity>
      }
```

Items with multiple returns will be available in a list format

```
    "interfaces": [
        {
            "cable": {
                "id": 1,
                "label": "",
                <snipped for brevity>
        },
        {
            "cable": {
                "id": 2,
                "label": "",
                <snipped for brevity>
         }
   ]
```