### PR TITLE
Update Travis test environments to Netbox 2.6, 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,13 @@ before_script:
   - ansible-galaxy collection install $COLLECTION_NAMESPACE-$COLLECTION_NAME-$COLLECTION_VERSION.tar.gz -p /home/travis/.ansible/collections
 
 script:
-  - ansible-test units --python $PYTHON_VER -v
-  - black . --check
+  # Perform tests on collection from within the installed directory, not the source directory
+  # Required for imports of other collections (ie. ansible.netcommon) to work correctly
+  - (cd /home/travis/.ansible/collections/ansible_collections/$COLLECTION_NAMESPACE/$COLLECTION_NAME && ansible-test units --python $PYTHON_VER -v)
+
+  # Check python syntax
+  - black . --check --diff
+
   - timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:32768)" != "200" ]]; do echo "waiting for Netbox"; sleep 5; done' || false
   - python tests/integration/netbox-deploy.py
   - ansible-playbook tests/integration/regression-tests.yml -vvvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ env:
 
 matrix:
   include:
-    - name: "Python 3.6 - Netbox 2.5 - Latest PyPi Ansible"
+    - name: "Python 3.6 - Netbox 2.6 - Latest PyPi Ansible"
       python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.5
+      env: PYTHON_VER=3.6 VERSION=v2.6
       install:
         - cd ..
         # Setup netbox container for integration testing
-        - git clone https://github.com/FragmentedPacket/netbox-docker.git
+        - git clone https://github.com/netbox-community/netbox-docker.git
         - cd netbox-docker
         - docker-compose pull
         - docker-compose up -d
@@ -29,13 +29,13 @@ matrix:
         - pip install pytest==4.6.5 pytest-mock pytest-xdist jinja2 PyYAML black==19.10b0
         - pip install pynetbox cryptography codecov jmespath ansible
 
-    - name: "Python 3.6 - Netbox 2.6 - Ansible Devel"
+    - name: "Python 3.6 - Netbox 2.7 - Ansible Devel"
       python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.6
+      env: PYTHON_VER=3.6 VERSION=v2.7
       install:
         - cd ..
         # Setup netbox container for integration testing
-        - git clone https://github.com/FragmentedPacket/netbox-docker.git
+        - git clone https://github.com/netbox-community/netbox-docker.git
         - cd netbox-docker
         - docker-compose pull
         - docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: python
 services:
   - docker
 
-sudo: false
+os: linux
+dist: bionic
 
 env:
   global:
@@ -12,7 +13,7 @@ env:
     - COLLECTION_VERSION: 0.1.10
     - secure: "tE6GtwrRU+Kjobx/94xqR2MqM20pHCnrLcHgPzIHA3npdwuA+GjCBiBLTkEEQM4fUWIfzUTyjSr9bZErm1PTI1GcIRdniTgJ3ZzSSkE7tgeYALB/7xsusB57SlmbBQm2SGwU558uWZ3NHEsi0WTgD8GKZo77OpGX72FZKsVXOz6k2wve51sOtoSVjgCsvWTmZHx4ynGdiA5wFkZfaEcjXECahKtunW+MlB5kpJzkVeLRUEXFMhWlsIYiA5nj8OI/X3Nk9ugh1ribENX9LrjpgrqQ9YariZ8G6py1ONuKZIn2g7xs5kNQ3qL6HL6N7SoUxiwH16CfSyugFaYiMfaxQ4NUVGGRHS4vSGbNIf+gLHcYvP40miI1f/+pntCzqygZMhW73FX2o+KH2OGv09khOl8k1nDg2/XvW0kCc/FU6l+Jp5wCC8H9X2uiULtQpRqts5TzIonlPEzGIpfGFgJ5m54Emhv9gjG1Z5OOyL/qae1Wr+L/uhiFafcglZYh8NHEMWCUCkeqFqR2kDmUMtdgYLD7Q7NdwlL/PSVVs1l7UPiQHlnecQKEHN7CvR3eKByTEmkCKafRYh/JQ9rBt9sZc7aAPVu+w3wWUwbHS4o4vVnmyXvJb1PeJSiuynF7CBo4Qd6qj4YwX8gLK6PylGyaMOp169u6xw1mo5/CX0pJ3x4="
 
-matrix:
+jobs:
   include:
     - name: "Python 3.6 - Netbox 2.6 - Latest PyPi Ansible"
       python: 3.6
@@ -66,7 +67,6 @@ script:
 
 deploy:
   provider: script
-  skip_cleanup: true
   script: ansible-galaxy collection publish $COLLECTION_NAMESPACE-$COLLECTION_NAME-$COLLECTION_VERSION.tar.gz --api-key="$GALAXY_API_TOKEN"
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,9 @@ jobs:
         - pip install pytest==4.6.5 pytest-mock pytest-xdist jinja2 PyYAML black==19.10b0
         - pip install pynetbox cryptography codecov jmespath ansible
 
-    # Latest development versions of Netbox and Ansible, newest Python - may be broken sometimes
+    # Latest development versions of Netbox and Ansible, newest Python
+    # This may be broken sometimes by changes in the netbox & ansible projects
+    # Failures will be allowed in this build
     - name: "Python 3.8 - Netbox develop-2.8 - Ansible Devel"
       python: 3.8
       env: PYTHON_VER=3.8 VERSION=develop-2.8
@@ -66,6 +68,9 @@ jobs:
         - cd ansible
         - source hacking/env-setup
         - cd  ..
+  allow_failures:
+    # When testing against dev netbox and dev ansible, allow failures
+    - env: PYTHON_VER=3.8 VERSION=develop-2.8
 
 before_script:
   - mkdir -p ~/ansible_collections/$COLLECTION_NAMESPACE

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ script:
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: ansible-galaxy collection publish $COLLECTION_NAMESPACE-$COLLECTION_NAME-$COLLECTION_VERSION.tar.gz --api-key="$GALAXY_API_TOKEN"
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,26 @@ env:
 
 jobs:
   include:
+    # Previous release of Netbox, latest release of Ansible
     - name: "Python 3.6 - Netbox 2.6 - Latest PyPi Ansible"
       python: 3.6
       env: PYTHON_VER=3.6 VERSION=v2.6
+      install:
+        - cd ..
+        # Setup netbox container for integration testing
+        - git clone https://github.com/FragmentedPacket/netbox-docker.git
+        - cd netbox-docker
+        - docker-compose pull
+        - docker-compose up -d
+        - cd ..
+        - pip install -U pip
+        - pip install pytest==4.6.5 pytest-mock pytest-xdist jinja2 PyYAML black==19.10b0
+        - pip install pynetbox cryptography codecov jmespath ansible
+
+    # Latest release of Netbox and Ansible
+    - name: "Python 3.6 - Netbox 2.7 - Latest PyPi Ansible"
+      python: 3.6
+      env: PYTHON_VER=3.6 VERSION=v2.7
       install:
         - cd ..
         # Setup netbox container for integration testing
@@ -30,9 +47,10 @@ jobs:
         - pip install pytest==4.6.5 pytest-mock pytest-xdist jinja2 PyYAML black==19.10b0
         - pip install pynetbox cryptography codecov jmespath ansible
 
-    - name: "Python 3.6 - Netbox 2.7 - Ansible Devel"
-      python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.7
+    # Latest development versions of Netbox and Ansible, newest Python - may be broken sometimes
+    - name: "Python 3.8 - Netbox develop-2.8 - Ansible Devel"
+      python: 3.8
+      env: PYTHON_VER=3.8 VERSION=develop-2.8
       install:
         - cd ..
         # Setup netbox container for integration testing
@@ -57,15 +75,20 @@ before_script:
   - ansible-galaxy collection install $COLLECTION_NAMESPACE-$COLLECTION_NAME-$COLLECTION_VERSION.tar.gz -p /home/travis/.ansible/collections
 
 script:
-  # Perform tests on collection from within the installed directory, not the source directory
+  # Perform unit tests on collection from within the installed directory, not the source directory
   # Required for imports of other collections (ie. ansible.netcommon) to work correctly
   - (cd /home/travis/.ansible/collections/ansible_collections/$COLLECTION_NAMESPACE/$COLLECTION_NAME && ansible-test units --python $PYTHON_VER -v)
 
   # Check python syntax
   - black . --check --diff
 
+  # Wait for Netbox containers to be running
   - timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:32768)" != "200" ]]; do echo "waiting for Netbox"; sleep 5; done' || false
+
+  # Prepare data in Netbox
   - python tests/integration/netbox-deploy.py
+
+  # Run regression and integration tests
   - ansible-playbook tests/integration/regression-tests.yml -vvvv
   - ansible-playbook tests/integration/integration-tests.yml -vvvv
   - ansible-inventory -i tests/integration/test-inventory.yml --list

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To keep the code simple, we only officially support the two latest releases of N
 
 ## Requirements
 
-- NetBox 2.5+ or the two latest NetBox releases
+- NetBox 2.6+ or the two latest NetBox releases
 - **pynetbox 4.2.5+**
 - Python 3.6+
 - Ansible 2.9+

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,7 +45,8 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+  ansible.netcommon: "*"
 
 # The URL of the originating SCM repository
 repository: https://github.com/netbox-community/ansible_modules

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -133,7 +133,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils.compat.ipaddress import ip_interface
+from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_interface
 
 ALLOWED_DEVICE_QUERY_PARAMETERS = (
     "asset_tag",

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -133,7 +133,9 @@ from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_interface
+from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import (
+    ip_interface,
+)
 
 ALLOWED_DEVICE_QUERY_PARAMETERS = (
     "asset_tag",

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 import traceback
 import re
 from itertools import chain
-from ansible.module_utils.compat import ipaddress
+from ansible_collections.ansible.netcommon.plugins.module_utils.compat import ipaddress
 from ansible.module_utils._text import to_text
 
 # from ._text import to_native

--- a/plugins/modules/netbox_interface.py
+++ b/plugins/modules/netbox_interface.py
@@ -222,7 +222,7 @@ from ansible.module_utils.net_tools.netbox.netbox_utils import (
     INTF_FORM_FACTOR,
     INTF_MODE,
 )
-from ansible.module_utils.compat import ipaddress
+from ansible_collections.ansible.netcommon.plugins.module_utils.compat import ipaddress
 from ansible.module_utils._text import to_text
 
 


### PR DESCRIPTION
Still a work in progress. Running into issues with Ansible 2.10 dev - ipaddress compat class for Python 2.7 hosts has been moved to the netcommon collection. Need to work out how this import should work now.