### PR TITLE
Enhancement: Added option to not prepend group names with group_by option

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -606,7 +606,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 continue
 
             for sub_group in sub_groups:
-                sub_group = sub_group.replace('-', '_')
+                sub_group = sub_group.replace("-", "_")
                 if self.group_names_raw:
                     group_name = sub_group
                 else:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -606,6 +606,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 continue
 
             for sub_group in sub_groups:
+                sub_group = sub_group.replace('-', '_')
                 if self.group_names_raw:
                     group_name = sub_group
                 else:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -67,6 +67,11 @@ DOCUMENTATION = """
                 - manufacturers
                 - platforms
             default: []
+        group_names_raw:
+            description: Will not add the group_by choice name to the group names
+            default: False
+            type: boolean
+            version_added: "0.2.0"
         query_filters:
             description: List of parameters passed to the query string (Multiple values may be separated by commas)
             type: list
@@ -601,7 +606,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 continue
 
             for sub_group in sub_groups:
-                group_name = "_".join([group, sub_group])
+                if self.group_names_raw:
+                    group_name = sub_group
+                else:
+                    group_name = "_".join([group, sub_group])
                 self.inventory.add_group(group=group_name)
                 self.inventory.add_host(group=group_name, host=hostname)
 
@@ -675,5 +683,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # Filter and group_by options
         self.group_by = self.get_option("group_by")
+        self.group_names_raw = self.get_option("group_names_raw")
         self.query_filters = self.get_option("query_filters")
         self.main()

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -606,7 +606,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 continue
 
             for sub_group in sub_groups:
-                sub_group = sub_group.replace("-", "_")
                 if self.group_names_raw:
                     group_name = sub_group
                 else:


### PR DESCRIPTION
Fixes #138 

Added `group_names_raw` to provide the group name slug rather than prepending with the group_by option.

e.g. Before
```
group_by:
  - device_roles

device_roles_core-switch
```
e.g. After
```
group_by:
  - device_roles

core-switch
```

This also replaces any dash in the slug to an underscore since Ansible will be enforcing that moving from 2.10+. I'm open to keeping it as just returning the slug so please discuss what you guys think is the best approach.