### PR TITLE
Testing: Change testing for different versions for time being

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
 
   # Run regression and integration tests
   - ansible-playbook tests/integration/regression-tests.yml -vvvv
-  - ansible-playbook tests/integration/integration-tests.yml -vvvv
+  - ansible-playbook tests/integration/$VERSION/main.yml -vvvv
   - ansible-inventory -i tests/integration/test-inventory.yml --list
 
 deploy:

--- a/tests/integration/v2.6/main.yml
+++ b/tests/integration/v2.6/main.yml
@@ -1,0 +1,109 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  collections:
+    - netbox.netbox
+
+  tasks:
+    - name: "NETBOX_DEVICE TESTS"
+      include_tasks: "tasks/netbox_device.yml"
+    
+    - name: "NETBOX_DEVICE_INTERFACE TESTS"
+      include_tasks: "tasks/netbox_device_interface.yml"
+    
+    - name: "NETBOX_IP_ADDRESS TESTS"
+      include_tasks: "tasks/netbox_ip_address.yml"
+    
+    - name: "NETBOX_PREFIX TESTS"
+      include_tasks: "tasks/netbox_prefix.yml"
+    
+    - name: "NETBOX_SITE TESTS"
+      include_tasks: "tasks/netbox_site.yml"
+    
+    - name: "NETBOX_TENTANT TESTS"
+      include_tasks: "tasks/netbox_tenant.yml"
+    
+    - name: "NETBOX_TENTANT_GROUP TESTS"
+      include_tasks: "tasks/netbox_tenant_group.yml"
+    
+    - name: "NETBOX_RACK TESTS"
+      include_tasks: "tasks/netbox_rack.yml"
+    
+    - name: "NETBOX_RACK_ROLE TESTS"
+      include_tasks: "tasks/netbox_rack_role.yml"
+    
+    - name: "NETBOX_RACK_GROUP TESTS"
+      include_tasks: "tasks/netbox_rack_group.yml"
+    
+    - name: "NETBOX_MANUFACTURER TESTS"
+      include_tasks: "tasks/netbox_manufacturer.yml"
+    
+    - name: "NETBOX_PLATFORM TESTS"
+      include_tasks: "tasks/netbox_platform.yml"
+    
+    - name: "NETBOX_DEVICE_TYPE TESTS"
+      include_tasks: "tasks/netbox_device_type.yml"
+    
+    - name: "NETBOX_DEVICE_ROLE TESTS"
+      include_tasks: "tasks/netbox_device_role.yml"
+    
+    - name: "NETBOX_IPAM_ROLE TESTS"
+      include_tasks: "tasks/netbox_ipam_role.yml"
+    
+    - name: "NETBOX_VLAN_GROUP TESTS"
+      include_tasks: "tasks/netbox_vlan_group.yml"
+    
+    - name: "NETBOX_VLAN TESTS"
+      include_tasks: "tasks/netbox_vlan.yml"
+    
+    - name: "NETBOX_VRF TESTS"
+      include_tasks: "tasks/netbox_vrf.yml"
+    
+    - name: "NETBOX_RIR TESTS"
+      include_tasks: "tasks/netbox_rir.yml"
+    
+    - name: "NETBOX_AGGREGATE TESTS"
+      include_tasks: "tasks/netbox_aggregate.yml"
+    
+    - name: "NETBOX_REGION TESTS"
+      include_tasks: "tasks/netbox_region.yml"
+    
+    - name: "NETBOX_DEVICE_BAY TESTS"
+      include_tasks: "tasks/netbox_device_bay.yml"
+    
+    - name: "NETBOX_INVENTORY_ITEM TESTS"
+      include_tasks: "tasks/netbox_inventory_item.yml"
+    
+    - name: "NETBOX_VIRTUAL_MACHINE TESTS"
+      include_tasks: "tasks/netbox_virtual_machine.yml"
+    
+    - name: "NETBOX_CLUSTER TESTS"
+      include_tasks: "tasks/netbox_cluster.yml"
+    
+    - name: "NETBOX_CLUSTER_GROUP TESTS"
+      include_tasks: "tasks/netbox_cluster_group.yml"
+    
+    - name: "NETBOX_CLUSTER_TYPE TESTS"
+      include_tasks: "tasks/netbox_cluster_type.yml"
+    
+    - name: "NETBOX_VM_INTERFACE TESTS"
+      include_tasks: "tasks/netbox_vm_interface.yml"
+    
+    - name: "NETBOX_PROVIDER TESTS"
+      include_tasks: "tasks/netbox_provider.yml"
+    
+    - name: "NETBOX_CIRCUIT_TYPE TESTS"
+      include_tasks: "tasks/netbox_circuit_type.yml"
+    
+    - name: "NETBOX_CIRCUIT TESTS"
+      include_tasks: "tasks/netbox_circuit.yml"
+    
+    - name: "NETBOX_CIRCUIT_TERMINATION TESTS"
+      include_tasks: "tasks/netbox_circuit_termination.yml"
+    
+    - name: "NETBOX_SERVICE TESTS"
+      include_tasks: "tasks/netbox_service.yml"
+    
+    - name: "NETBOX_LOOKUP TESTS"
+      include_tasks: "tasks/netbox_lookup.yml"

--- a/tests/integration/v2.6/tasks/netbox_aggregate.yml
+++ b/tests/integration/v2.6/tasks/netbox_aggregate.yml
@@ -1,0 +1,115 @@
+---
+##
+##
+### NETBOX_AGGEGATE
+##
+##
+- name: "AGGREGATE 1: Necessary info creation"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+      rir: "Example RIR"
+    state: present
+  register: test_one
+
+- name: "AGGREGATE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_one['aggregate']['family'] == 4
+      - test_one['aggregate']['rir'] == 1
+      - test_one['msg'] == "aggregate 10.0.0.0/8 created"
+
+- name: "AGGREGATE 2: Create duplicate"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+    state: present
+  register: test_two
+
+- name: "AGGREGATE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_two['aggregate']['family'] == 4
+      - test_two['aggregate']['rir'] == 1
+      - test_two['msg'] == "aggregate 10.0.0.0/8 already exists"
+
+- name: "AGGREGATE 3: ASSERT - Update"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+      rir: "Example RIR"
+      date_added: "1989-01-18"
+      description: "Test Description"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "AGGREGATE 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['date_added'] == "1989-01-18"
+      - test_three['diff']['after']['description'] == "Test Description"
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_three['aggregate']['family'] == 4
+      - test_three['aggregate']['rir'] == 1
+      - test_three['aggregate']['date_added'] == "1989-01-18"
+      - test_three['aggregate']['description'] == "Test Description"
+      - test_three['aggregate']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "aggregate 10.0.0.0/8 updated"
+
+- name: "AGGREGATE 4: ASSERT - Delete"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+    state: absent
+  register: test_four
+
+- name: "AGGREGATE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_four['aggregate']['family'] == 4
+      - test_four['aggregate']['rir'] == 1
+      - test_four['aggregate']['date_added'] == "1989-01-18"
+      - test_four['aggregate']['description'] == "Test Description"
+      - test_four['aggregate']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "aggregate 10.0.0.0/8 deleted"
+
+- name: "AGGREGATE 5: Necessary info creation"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "2001::/32"
+      rir: "Example RIR"
+    state: present
+  register: test_five
+
+- name: "AGGREGATE 5: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['aggregate']['prefix'] == "2001::/32"
+      - test_five['aggregate']['family'] == 6
+      - test_five['aggregate']['rir'] == 1
+      - test_five['msg'] == "aggregate 2001::/32 created"

--- a/tests/integration/v2.6/tasks/netbox_circuit.yml
+++ b/tests/integration/v2.6/tasks/netbox_circuit.yml
@@ -1,0 +1,109 @@
+---
+##
+##
+### NETBOX_CIRCUIT
+##
+##
+- name: "NETBOX_CIRCUIT 1: Create provider within Netbox with only required information"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+    state: present
+  register: test_one
+
+- name: "NETBOX_CIRCUIT 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit']['cid'] == "Test Circuit One"
+      - test_one['circuit']['provider'] == 1
+      - test_one['circuit']['type'] == 1
+      - test_one['msg'] == "circuit Test Circuit One created"
+
+- name: "NETBOX_CIRCUIT 2: Duplicate"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+    state: present
+  register: test_two
+
+- name: "NETBOX_CIRCUIT 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit']['cid'] == "Test Circuit One"
+      - test_two['circuit']['provider'] == 1
+      - test_two['circuit']['type'] == 1
+      - test_two['msg'] == "circuit Test Circuit One already exists"
+
+- name: "NETBOX_CIRCUIT 3: Update provider with other fields"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+      status: Planned
+      tenant: Test Tenant
+      install_date: "2018-12-25"
+      commit_rate: 10000
+      description: Test circuit
+      comments: "FAST CIRCUIT"
+    state: present
+  register: test_three
+
+- name: "NETBOX_CIRCUIT 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == 2
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['diff']['after']['install_date'] == "2018-12-25"
+      - test_three['diff']['after']['commit_rate'] == 10000
+      - test_three['diff']['after']['description'] == "Test circuit"
+      - test_three['diff']['after']['comments'] == "FAST CIRCUIT"
+      - test_three['circuit']['cid'] == "Test Circuit One"
+      - test_three['circuit']['provider'] == 1
+      - test_three['circuit']['type'] == 1
+      - test_three['circuit']['status'] == 2
+      - test_three['circuit']['tenant'] == 1
+      - test_three['circuit']['install_date'] == "2018-12-25"
+      - test_three['circuit']['commit_rate'] == 10000
+      - test_three['circuit']['description'] == "Test circuit"
+      - test_three['circuit']['comments'] == "FAST CIRCUIT"
+      - test_three['msg'] == "circuit Test Circuit One updated"
+
+- name: "NETBOX_CIRCUIT 4: Delete provider within netbox"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+    state: absent
+  register: test_four
+
+- name: "NETBOX_CIRCUIT 4 : ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['circuit']['cid'] == "Test Circuit One"
+      - test_four['circuit']['provider'] == 1
+      - test_four['circuit']['type'] == 1
+      - test_four['circuit']['status'] == 2
+      - test_four['circuit']['tenant'] == 1
+      - test_four['circuit']['install_date'] == "2018-12-25"
+      - test_four['circuit']['commit_rate'] == 10000
+      - test_four['circuit']['description'] == "Test circuit"
+      - test_four['circuit']['comments'] == "FAST CIRCUIT"
+      - test_four['msg'] == "circuit Test Circuit One deleted"

--- a/tests/integration/v2.6/tasks/netbox_circuit_termination.yml
+++ b/tests/integration/v2.6/tasks/netbox_circuit_termination.yml
@@ -1,0 +1,129 @@
+---
+##
+##
+### NETBOX_CIRCUIT_TERMINATION
+##
+##
+- name: "NETBOX_CIRCUIT_TERMINATION 1: Create provider within Netbox with only required information"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+      site: "Test Site"
+      port_speed: 10000
+    state: present
+  register: test_one
+
+- name: "NETBOX_CIRCUIT_TERMINATION 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit_termination']['circuit'] == 1
+      - test_one['circuit_termination']['term_side'] == "A"
+      - test_one['circuit_termination']['site'] == 1
+      - test_one['circuit_termination']['port_speed'] == 10000
+      - test_one['msg'] == "circuit_termination test_circuit_a created"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 2: Duplicate"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+    state: present
+  register: test_two
+
+- name: "NETBOX_CIRCUIT_TERMINATION 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit_termination']['circuit'] == 1
+      - test_two['circuit_termination']['term_side'] == "A"
+      - test_two['circuit_termination']['site'] == 1
+      - test_two['circuit_termination']['port_speed'] == 10000
+      - test_two['msg'] == "circuit_termination test_circuit_a already exists"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 3: Update provider with other fields"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+      upstream_speed: 1000
+      xconnect_id: 10X100
+      pp_info: PP10-24
+      description: "Test description"
+    state: present
+  register: test_three
+
+- name: "NETBOX_CIRCUIT_TERMINATION 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['upstream_speed'] == 1000
+      - test_three['diff']['after']['xconnect_id'] == "10X100"
+      - test_three['diff']['after']['pp_info'] == "PP10-24"
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['circuit_termination']['circuit'] == 1
+      - test_three['circuit_termination']['term_side'] == "A"
+      - test_three['circuit_termination']['site'] == 1
+      - test_three['circuit_termination']['port_speed'] == 10000
+      - test_three['circuit_termination']['upstream_speed'] == 1000
+      - test_three['circuit_termination']['xconnect_id'] == "10X100"
+      - test_three['circuit_termination']['pp_info'] == "PP10-24"
+      - test_three['circuit_termination']['description'] == "Test description"
+      - test_three['msg'] == "circuit_termination test_circuit_a updated"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 4: Create Z Side"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: Z
+      site: "Test Site"
+      port_speed: 10000
+    state: present
+  register: test_four
+
+- name: "NETBOX_CIRCUIT_TERMINATION 4: ASSERT - Create Z Side"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['circuit_termination']['circuit'] == 1
+      - test_four['circuit_termination']['term_side'] == "Z"
+      - test_four['circuit_termination']['site'] == 1
+      - test_four['circuit_termination']['port_speed'] == 10000
+      - test_four['msg'] == "circuit_termination test_circuit_z created"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 5: Delete provider within netbox"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+    state: absent
+  register: test_five
+
+- name: "NETBOX_CIRCUIT_TERMINATION 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['circuit_termination']['circuit'] == 1
+      - test_five['circuit_termination']['term_side'] == "A"
+      - test_five['circuit_termination']['site'] == 1
+      - test_five['circuit_termination']['port_speed'] == 10000
+      - test_five['circuit_termination']['upstream_speed'] == 1000
+      - test_five['circuit_termination']['xconnect_id'] == "10X100"
+      - test_five['circuit_termination']['pp_info'] == "PP10-24"
+      - test_five['circuit_termination']['description'] == "Test description"
+      - test_five['msg'] == "circuit_termination test_circuit_a deleted"

--- a/tests/integration/v2.6/tasks/netbox_circuit_type.yml
+++ b/tests/integration/v2.6/tasks/netbox_circuit_type.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_CIRCUIT_TYPE
+##
+##
+- name: "CIRCUIT_TYPE 1: Necessary info creation"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type One"
+    state: present
+  register: test_one
+
+- name: "CIRCUIT_TYPE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit_type']['name'] == "Test Circuit Type One"
+      - test_one['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_one['msg'] == "circuit_type Test Circuit Type One created"
+
+- name: "CIRCUIT_TYPE 2: Create duplicate"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type One"
+    state: present
+  register: test_two
+
+- name: "CIRCUIT_TYPE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit_type']['name'] == "Test Circuit Type One"
+      - test_two['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_two['msg'] == "circuit_type Test Circuit Type One already exists"
+
+- name: "CIRCUIT_TYPE 3: User specified slug"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type Two"
+      slug: "test-circuit-type-2"
+    state: present
+  register: test_three
+
+- name: "CIRCUIT_TYPE 3: ASSERT - User specified slug"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['circuit_type']['name'] == "Test Circuit Type Two"
+      - test_three['circuit_type']['slug'] == "test-circuit-type-2"
+      - test_three['msg'] == "circuit_type Test Circuit Type Two created"
+
+- name: "CIRCUIT_TYPE 4: ASSERT - Delete"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type One"
+    state: absent
+  register: test_four
+
+- name: "CIRCUIT_TYPE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['circuit_type']['name'] == "Test Circuit Type One"
+      - test_four['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_four['msg'] == "circuit_type Test Circuit Type One deleted"
+
+- name: "CIRCUIT_TYPE 5: ASSERT - Delete"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type Two"
+      slug: "test-circuit-type-2"
+    state: absent
+  register: test_five
+
+- name: "CIRCUIT_TYPE 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['circuit_type']['name'] == "Test Circuit Type Two"
+      - test_five['circuit_type']['slug'] == "test-circuit-type-2"
+      - test_five['msg'] == "circuit_type Test Circuit Type Two deleted"

--- a/tests/integration/v2.6/tasks/netbox_cluster.yml
+++ b/tests/integration/v2.6/tasks/netbox_cluster.yml
@@ -1,0 +1,95 @@
+---
+##
+##
+### NETBOX_CLUSTER
+##
+##
+- name: "CLUSTER 1: Necessary info creation"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+      cluster_type: "Test Cluster Type"
+    state: present
+  register: test_one
+
+- name: "CLUSTER 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster']['name'] == "Test Cluster One"
+      - test_one['cluster']['type'] == 1
+      - test_one['msg'] == "cluster Test Cluster One created"
+
+- name: "CLUSTER 2: Create duplicate"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+      cluster_type: "Test Cluster Type"
+    state: present
+  register: test_two
+
+- name: "CLUSTER 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster']['name'] == "Test Cluster One"
+      - test_two['cluster']['type'] == 1
+      - test_two['msg'] == "cluster Test Cluster One already exists"
+
+- name: "CLUSTER 3: Update"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+      cluster_type: "Test Cluster Type"
+      cluster_group: "Test Cluster Group"
+      site: "Test Site"
+      comments: "Updated cluster"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "CLUSTER 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['group'] == 1
+      - test_three['diff']['after']['site'] == 1
+      - test_three['diff']['after']['comments'] == "Updated cluster"
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['cluster']['name'] == "Test Cluster One"
+      - test_three['cluster']['type'] == 1
+      - test_three['cluster']['group'] == 1
+      - test_three['cluster']['site'] == 1
+      - test_three['cluster']['comments'] == "Updated cluster"
+      - test_three['cluster']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "cluster Test Cluster One updated"
+
+- name: "CLUSTER 4: ASSERT - Delete"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+    state: absent
+  register: test_four
+
+- name: "CLUSTER 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['cluster']['name'] == "Test Cluster One"
+      - test_four['cluster']['type'] == 1
+      - test_four['cluster']['group'] == 1
+      - test_four['cluster']['site'] == 1
+      - test_four['cluster']['comments'] == "Updated cluster"
+      - test_four['cluster']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "cluster Test Cluster One deleted"

--- a/tests/integration/v2.6/tasks/netbox_cluster_group.yml
+++ b/tests/integration/v2.6/tasks/netbox_cluster_group.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_CLUSTER_GROUP
+##
+##
+- name: "CLUSTER_GROUP 1: Necessary info creation"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group One"
+    state: present
+  register: test_one
+
+- name: "CLUSTER_GROUP 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster_group']['name'] == "Test Cluster Group One"
+      - test_one['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_one['msg'] == "cluster_group Test Cluster Group One created"
+
+- name: "CLUSTER_GROUP 2: Create duplicate"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group One"
+    state: present
+  register: test_two
+
+- name: "CLUSTER_GROUP 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster_group']['name'] == "Test Cluster Group One"
+      - test_two['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_two['msg'] == "cluster_group Test Cluster Group One already exists"
+
+- name: "CLUSTER_GROUP 3: User specified slug"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group Two"
+      slug: "test-cluster-group-2"
+    state: present
+  register: test_three
+
+- name: "CLUSTER_GROUP 3: ASSERT - User specified slug"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['cluster_group']['name'] == "Test Cluster Group Two"
+      - test_three['cluster_group']['slug'] == "test-cluster-group-2"
+      - test_three['msg'] == "cluster_group Test Cluster Group Two created"
+
+- name: "CLUSTER_GROUP 4: ASSERT - Delete"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group One"
+    state: absent
+  register: test_four
+
+- name: "CLUSTER_GROUP 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['cluster_group']['name'] == "Test Cluster Group One"
+      - test_four['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_four['msg'] == "cluster_group Test Cluster Group One deleted"
+
+- name: "CLUSTER_GROUP 5: ASSERT - Delete"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group Two"
+      slug: "test-cluster-group-2"
+    state: absent
+  register: test_five
+
+- name: "CLUSTER_GROUP 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['cluster_group']['name'] == "Test Cluster Group Two"
+      - test_five['cluster_group']['slug'] == "test-cluster-group-2"
+      - test_five['msg'] == "cluster_group Test Cluster Group Two deleted"

--- a/tests/integration/v2.6/tasks/netbox_cluster_type.yml
+++ b/tests/integration/v2.6/tasks/netbox_cluster_type.yml
@@ -1,0 +1,95 @@
+##
+##
+### NETBOX_CLUSTER_TYPE
+##
+##
+- name: "CLUSTER_TYPE 1: Necessary info creation"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type One"
+    state: present
+  register: test_one
+
+- name: "CLUSTER_TYPE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster_type']['name'] == "Test Cluster Type One"
+      - test_one['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_one['msg'] == "cluster_type Test Cluster Type One created"
+
+- name: "CLUSTER_TYPE 2: Create duplicate"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type One"
+    state: present
+  register: test_two
+
+- name: "CLUSTER_TYPE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster_type']['name'] == "Test Cluster Type One"
+      - test_two['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_two['msg'] == "cluster_type Test Cluster Type One already exists"
+
+- name: "CLUSTER_TYPE 3: User specified slug"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type Two"
+      slug: "test-cluster-type-2"
+    state: present
+  register: test_three
+
+- name: "CLUSTER_TYPE 3: ASSERT - User specified slug"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['cluster_type']['name'] == "Test Cluster Type Two"
+      - test_three['cluster_type']['slug'] == "test-cluster-type-2"
+      - test_three['msg'] == "cluster_type Test Cluster Type Two created"
+
+- name: "CLUSTER_TYPE 4: ASSERT - Delete"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type One"
+    state: absent
+  register: test_four
+
+- name: "CLUSTER_TYPE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['cluster_type']['name'] == "Test Cluster Type One"
+      - test_four['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_four['msg'] == "cluster_type Test Cluster Type One deleted"
+
+- name: "CLUSTER_TYPE 5: ASSERT - Delete"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type Two"
+      slug: "test-cluster-type-2"
+    state: absent
+  register: test_five
+
+- name: "CLUSTER_TYPE 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['cluster_type']['name'] == "Test Cluster Type Two"
+      - test_five['cluster_type']['slug'] == "test-cluster-type-2"
+      - test_five['msg'] == "cluster_type Test Cluster Type Two deleted"

--- a/tests/integration/v2.6/tasks/netbox_device.yml
+++ b/tests/integration/v2.6/tasks/netbox_device.yml
@@ -1,0 +1,201 @@
+---
+##
+##
+### NETBOX_DEVICE
+##
+##
+- name: "1 - Device with required information"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == 'absent'
+      - test_one['diff']['after']['state'] == 'present'
+      - test_one['device']['name'] == "R1"
+      - test_one['device']['device_role'] == 1
+      - test_one['device']['device_type'] == 1
+      - test_one['device']['site'] == 1
+      - test_one['device']['status'] == 3
+      - test_one['device']['name'] == "R1"
+      - test_one['msg'] == "device R1 created"
+
+- name: "2 - Duplicate device"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['device']['name'] == "R1"
+      - test_two['device']['device_role'] == 1
+      - test_two['device']['device_type'] == 1
+      - test_two['device']['site'] == 1
+      - test_two['device']['status'] == 3
+      - test_two['msg'] == "device R1 already exists"
+
+- name: "3 - Update device"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+      serial: "FXS1001"
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['serial'] == "FXS1001"
+      - test_three['device']['name'] == "R1"
+      - test_three['device']['device_role'] == 1
+      - test_three['device']['device_type'] == 1
+      - test_three['device']['site'] == 1
+      - test_three['device']['status'] == 3
+      - test_three['device']['serial'] == "FXS1001"
+      - test_three['msg'] == "device R1 updated"
+
+- name: "4 - Create device with tags and assign to rack"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "TestR1"
+      device_type: "Arista Test"
+      device_role: "Core Switch"
+      site: "Test Site2"
+      rack: "Test Rack"
+      position: 35
+      face: "Front"
+      tags:
+        - "Schnozzberry"
+      tenant: "Test Tenant"
+      asset_tag: "1234"
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['device']['name'] == "TestR1"
+      - test_four['device']['device_role'] == 1
+      - test_four['device']['device_type'] == 2
+      - test_four['device']['site'] == 2
+      - test_four['device']['status'] == 1
+      - test_four['device']['rack'] == 1
+      - test_four['device']['tags'][0] == 'Schnozzberry'
+      - test_four['device']['tenant'] == 1
+      - test_four['device']['asset_tag'] == '1234'
+      - test_four['msg'] == "device TestR1 created"
+
+- name: "5 - Delete previous device"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "TestR1"
+    state: absent
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "device TestR1 deleted"
+
+- name: "6 - Delete R1"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+    state: absent
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "present"
+      - test_six['diff']['after']['state'] == "absent"
+      - test_six['msg'] == "device R1 deleted"
+
+- name: "7 - Add primary_ip4/6 to test100"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "test100"
+      primary_ip4: "172.16.180.1/24"
+      primary_ip6: "2001::1:1/64"
+    state: present
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['after']['primary_ip4'] == 1
+      - test_seven['diff']['after']['primary_ip6'] == 2
+      - test_seven['device']['name'] == "test100"
+      - test_seven['device']['device_role'] == 1
+      - test_seven['device']['device_type'] == 1
+      - test_seven['device']['site'] == 1
+      - test_seven['device']['status'] == 1
+      - test_seven['device']['primary_ip4'] == 1
+      - test_seven['device']['primary_ip6'] == 2
+      - test_seven['msg'] == "device test100 updated"
+
+- name: "8 - Device with empty string name"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: ""
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == 'absent'
+      - test_eight['diff']['after']['state'] == 'present'
+      - test_eight['device']['device_role'] == 1
+      - test_eight['device']['device_type'] == 1
+      - test_eight['device']['site'] == 1
+      - test_eight['device']['status'] == 3
+      - "'-' in test_eight['device']['name']"
+      - "test_eight['device']['name'] | length == 36"

--- a/tests/integration/v2.6/tasks/netbox_device_bay.yml
+++ b/tests/integration/v2.6/tasks/netbox_device_bay.yml
@@ -1,0 +1,87 @@
+---
+##
+##
+### NETBOX_DEVICE_BAY
+##
+##
+- name: "DEVICE_BAY 1: Necessary info creation"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "Test Nexus One"
+      name: "Device Bay One"
+    state: present
+  register: test_one
+
+- name: "DEVICE_BAY 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_bay']['name'] == "Device Bay One"
+      - test_one['device_bay']['device'] == 4
+      - test_one['msg'] == "device_bay Device Bay One created"
+
+- name: "DEVICE_BAY 2: Create duplicate"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "Test Nexus One"
+      name: "Device Bay One"
+    state: present
+  register: test_two
+
+- name: "DEVICE_BAY 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['device_bay']['name'] == "Device Bay One"
+      - test_two['device_bay']['device'] == 4
+      - test_two['msg'] == "device_bay Device Bay One already exists"
+
+- name: "DEVICE_BAY 3: ASSERT - Update"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "Test Nexus One"
+      name: "Device Bay One"
+      installed_device: "Test Nexus Child One"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "DEVICE_BAY 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['installed_device'] == 5
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['device_bay']['name'] == "Device Bay One"
+      - test_three['device_bay']['device'] == 4
+      - test_three['device_bay']['installed_device'] == 5
+      - test_three['device_bay']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "device_bay Device Bay One updated"
+
+- name: "DEVICE_BAY 4: ASSERT - Delete"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Device Bay One"
+    state: absent
+  register: test_four
+
+- name: "DEVICE_BAY 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['device_bay']['name'] == "Device Bay One"
+      - test_four['device_bay']['device'] == 4
+      - test_four['device_bay']['installed_device'] == 5
+      - test_four['device_bay']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "device_bay Device Bay One deleted"

--- a/tests/integration/v2.6/tasks/netbox_device_interface.yml
+++ b/tests/integration/v2.6/tasks/netbox_device_interface.yml
@@ -1,0 +1,281 @@
+---
+##
+##
+### NETBOX_DEVICE_INTERFACE
+##
+##
+- name: "1 - Interface with required information"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['msg'] == "interface GigabitEthernet3 created"
+      - test_one['diff']['before']['state'] == 'absent'
+      - test_one['diff']['after']['state'] == 'present'
+      - test_one['interface']['name'] == "GigabitEthernet3"
+      - test_one['interface']['device'] == 1
+
+- name: "2 - Update test100 - GigabitEthernet3"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      mtu: 1600
+      enabled: false
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - test_two is changed
+      - test_two['msg'] == "interface GigabitEthernet3 updated"
+      - test_two['diff']['after']['enabled'] == false
+      - test_two['diff']['after']['mtu'] == 1600
+      - test_two['interface']['name'] == "GigabitEthernet3"
+      - test_two['interface']['device'] == 1
+      - test_two['interface']['enabled'] == false
+      - test_two['interface']['mtu'] == 1600
+
+- name: "3 - Delete interface test100 - GigabitEthernet3"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+    state: absent
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['msg'] == "interface GigabitEthernet3 deleted"
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+
+- name: "4 - Create LAG with several specified options"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: port-channel1
+      form_factor: Link Aggregation Group (LAG)
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['msg'] == "interface port-channel1 created"
+      - test_four['diff']['before']['state'] == 'absent'
+      - test_four['diff']['after']['state'] == 'present'
+      - test_four['interface']['name'] == "port-channel1"
+      - test_four['interface']['device'] == 1
+      - test_four['interface']['enabled'] == true
+      - test_four['interface']['form_factor'] == 200
+      - test_four['interface']['mgmt_only'] == false
+      - test_four['interface']['mode'] == 100
+      - test_four['interface']['mtu'] == 1600
+
+- name: "5 - Create interface and assign it to parent LAG"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      enabled: false
+      form_factor: 1000Base-T (1GE)
+      lag:
+        name: port-channel1
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['msg'] == "interface GigabitEthernet3 created"
+      - test_five['diff']['before']['state'] == 'absent'
+      - test_five['diff']['after']['state'] == 'present'
+      - test_five['interface']['name'] == "GigabitEthernet3"
+      - test_five['interface']['device'] == 1
+      - test_five['interface']['enabled'] == false
+      - test_five['interface']['form_factor'] == 1000
+      - test_five['interface']['mgmt_only'] == false
+      - test_five['interface']['lag'] == 15
+      - test_five['interface']['mode'] == 100
+      - test_five['interface']['mtu'] == 1600
+
+- name: "6 - Create interface as trunk port"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet21
+      enabled: false
+      form_factor: 1000Base-T (1GE)
+      untagged_vlan:
+        name: Wireless
+        site: Test Site
+      tagged_vlans:
+        - name: Data
+          site: Test Site
+        - name: VoIP
+          site: Test Site
+      mtu: 1600
+      mgmt_only: true
+      mode: Tagged
+    state: present
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['msg'] == "interface GigabitEthernet21 created"
+      - test_six['diff']['before']['state'] == 'absent'
+      - test_six['diff']['after']['state'] == 'present'
+      - test_six['interface']['name'] == "GigabitEthernet21"
+      - test_six['interface']['device'] == 1
+      - test_six['interface']['enabled'] == false
+      - test_six['interface']['form_factor'] == 1000
+      - test_six['interface']['mgmt_only'] == true
+      - test_six['interface']['mode'] == 200
+      - test_six['interface']['mtu'] == 1600
+      - test_six['interface']['tagged_vlans'] == [2, 3]
+      - test_six['interface']['untagged_vlan'] == 1
+
+- name: "7 - Duplicate Interface"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet1
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['msg'] == "interface GigabitEthernet1 already exists"
+      - test_seven['interface']['name'] == "GigabitEthernet1"
+      - test_seven['interface']['device'] == 1
+
+- name: "8 - Create interface and assign it to parent LAG - non dict"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet4
+      enabled: false
+      form_factor: 1000Base-T (1GE)
+      lag: "port-channel1"
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['msg'] == "interface GigabitEthernet4 created"
+      - test_eight['diff']['before']['state'] == 'absent'
+      - test_eight['diff']['after']['state'] == 'present'
+      - test_eight['interface']['name'] == "GigabitEthernet4"
+      - test_eight['interface']['device'] == 1
+      - test_eight['interface']['enabled'] == false
+      - test_eight['interface']['form_factor'] == 1000
+      - test_eight['interface']['mgmt_only'] == false
+      - test_eight['interface']['lag'] == 15
+      - test_eight['interface']['mode'] == 100
+      - test_eight['interface']['mtu'] == 1600
+
+- name: "9 - Create interface on VC child"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus Child One
+      name: Ethernet2/1
+      form_factor: 1000Base-T (1GE)
+    state: present
+  register: test_nine
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['msg'] == "interface Ethernet2/1 created"
+      - test_nine['diff']['before']['state'] == 'absent'
+      - test_nine['diff']['after']['state'] == 'present'
+      - test_nine['interface']['name'] == "Ethernet2/1"
+      - test_nine['interface']['device'] == 5
+      - test_nine['interface']['enabled'] == true
+      - test_nine['interface']['form_factor'] == 1000
+
+- name: "10 - Update interface on VC child"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Ethernet2/1
+      description: "Updated child interface from parent device"
+    update_vc_child: True
+    state: present
+  register: test_ten
+
+- name: "10 - ASSERT"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['msg'] == "interface Ethernet2/1 updated"
+      - test_ten['diff']['after']['description'] == 'Updated child interface from parent device'
+      - test_ten['interface']['name'] == "Ethernet2/1"
+      - test_ten['interface']['device'] == 5
+      - test_ten['interface']['enabled'] == true
+      - test_ten['interface']['form_factor'] == 1000
+      - test_ten['interface']['description'] == 'Updated child interface from parent device'
+
+- name: "11 - Update interface on VC child w/o update_vc_child"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Ethernet2/1
+      description: "Updated child interface from parent device - test"
+    state: present
+  ignore_errors: yes
+  register: test_eleven
+
+- name: "11 - ASSERT"
+  assert:
+    that:
+      - test_eleven is failed
+      - test_eleven['msg'] == "Must set update_vc_child to True to allow child device interface modification"

--- a/tests/integration/v2.6/tasks/netbox_device_role.yml
+++ b/tests/integration/v2.6/tasks/netbox_device_role.yml
@@ -1,0 +1,101 @@
+---
+##
+##
+### NETBOX_DEVICE_ROLE
+##
+##
+- name: "DEVICE_ROLE 1: Necessary info creation"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Device Role"
+      color: "FFFFFF"
+    state: present
+  register: test_one
+
+- name: "DEVICE_ROLE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_role']['name'] == "Test Device Role"
+      - test_one['device_role']['slug'] == "test-device-role"
+      - test_one['device_role']['color'] == "ffffff"
+      - test_one['msg'] == "device_role Test Device Role created"
+
+- name: "DEVICE_ROLE 2: Create duplicate"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Device Role"
+      color: "FFFFFF"
+    state: present
+  register: test_two
+
+- name: "DEVICE_ROLE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['device_role']['name'] == "Test Device Role"
+      - test_two['device_role']['slug'] == "test-device-role"
+      - test_two['device_role']['color'] == "ffffff"
+      - test_two['msg'] == "device_role Test Device Role already exists"
+
+- name: "DEVICE_ROLE 3: ASSERT - Update"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Device Role"
+      color: "003EFF"
+      vm_role: false
+    state: present
+  register: test_three
+
+- name: "DEVICE_ROLE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "003eff"
+      - test_three['diff']['after']['vm_role'] == false
+      - test_three['device_role']['name'] == "Test Device Role"
+      - test_three['device_role']['slug'] == "test-device-role"
+      - test_three['device_role']['color'] == "003eff"
+      - test_three['device_role']['vm_role'] == false
+      - test_three['msg'] == "device_role Test Device Role updated"
+
+- name: "DEVICE_ROLE 4: ASSERT - Delete"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Device Role
+    state: absent
+  register: test_four
+
+- name: "DEVICE_ROLE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "device_role Test Device Role deleted"
+
+- name: "DEVICE_ROLE 5: ASSERT - Delete non existing"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Device Role
+    state: absent
+  register: test_five
+
+- name: "DEVICE_ROLE 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['device_role'] == None
+      - test_five['msg'] == "device_role Test Device Role already absent"

--- a/tests/integration/v2.6/tasks/netbox_device_type.yml
+++ b/tests/integration/v2.6/tasks/netbox_device_type.yml
@@ -1,0 +1,131 @@
+---
+##
+##
+### NETBOX_DEVICE_TYPE
+##
+##
+- name: "DEVICE_TYPE 1: Necessary info creation"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      slug: test-device-type
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_one
+
+- name: "DEVICE_TYPE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_type']['slug'] == "test-device-type"
+      - test_one['device_type']['model'] == "ws-test-3750"
+      - test_one['device_type']['manufacturer'] == 3
+      - test_one['msg'] == "device_type test-device-type created"
+
+- name: "DEVICE_TYPE 2: Create duplicate"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      slug: test-device-type
+      model: "ws-test-3750"
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_two
+
+- name: "DEVICE_TYPE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_one['device_type']['slug'] == "test-device-type"
+      - test_one['device_type']['model'] == "ws-test-3750"
+      - test_one['device_type']['manufacturer'] == 3
+      - test_two['msg'] == "device_type test-device-type already exists"
+
+- name: "DEVICE_TYPE 3: ASSERT - Update"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      slug: test-device-type
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+      part_number: ws-3750g-v2
+      u_height: 1
+      is_full_depth: false
+      subdevice_role: parent
+    state: present
+  register: test_three
+
+- name: "DEVICE_TYPE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['is_full_depth'] == false
+      - test_three['diff']['after']['part_number'] == "ws-3750g-v2"
+      - test_three['diff']['after']['subdevice_role'] == true
+      - test_three['device_type']['slug'] == "test-device-type"
+      - test_three['device_type']['model'] == "ws-test-3750"
+      - test_three['device_type']['manufacturer'] == 3
+      - test_three['device_type']['is_full_depth'] == false
+      - test_three['device_type']['part_number'] == "ws-3750g-v2"
+      - test_three['device_type']['subdevice_role'] == true
+      - test_three['msg'] == "device_type test-device-type updated"
+
+- name: "DEVICE_TYPE 4: ASSERT - Delete"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: test-device-type
+    state: absent
+  register: test_four
+
+- name: "DEVICE_TYPE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "device_type test-device-type deleted"
+
+- name: "DEVICE_TYPE 5: ASSERT - Delete non existing"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: "Test Device Type"
+    state: absent
+  register: test_five
+
+- name: "DEVICE_TYPE 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['device_type'] == None
+      - test_five['msg'] == "device_type Test Device Type already absent"
+
+- name: "DEVICE_TYPE 6: Without Slug"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: "WS Test 3850"
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_six
+
+- name: "DEVICE_TYPE 6: ASSERT - Without Slug"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['device_type']['slug'] == "ws-test-3850"
+      - test_six['device_type']['model'] == "WS Test 3850"
+      - test_six['device_type']['manufacturer'] == 3
+      - test_six['msg'] == "device_type WS Test 3850 created"

--- a/tests/integration/v2.6/tasks/netbox_inventory_item.yml
+++ b/tests/integration/v2.6/tasks/netbox_inventory_item.yml
@@ -1,0 +1,104 @@
+---
+##
+##
+### NETBOX_INVENTORY_ITEM
+##
+##
+- name: "INVENTORY_ITEM 1: Necessary info creation"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+    state: present
+  register: test_one
+
+- name: "INVENTORY_ITEM 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['inventory_item']['name'] == "10G-SFP+"
+      - test_one['inventory_item']['device'] == 1
+      - test_one['msg'] == "inventory_item 10G-SFP+ created"
+
+- name: "INVENTORY_ITEM 2: Create duplicate"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+    state: present
+  register: test_two
+
+- name: "INVENTORY_ITEM 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['inventory_item']['name'] == "10G-SFP+"
+      - test_two['inventory_item']['device'] == 1
+      - test_two['msg'] == "inventory_item 10G-SFP+ already exists"
+
+- name: "INVENTORY_ITEM 3: ASSERT - Update"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+      manufacturer: "Cisco"
+      part_id: "10G-SFP+"
+      serial: "1234"
+      asset_tag: "1234"
+      description: "New SFP"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "INVENTORY_ITEM 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['asset_tag'] == "1234"
+      - test_three['diff']['after']['serial'] == "1234"
+      - test_three['diff']['after']['description'] == "New SFP"
+      - test_three['diff']['after']['manufacturer'] == 1
+      - test_three['diff']['after']['part_id'] == "10G-SFP+"
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['inventory_item']['name'] == "10G-SFP+"
+      - test_three['inventory_item']['device'] == 1
+      - test_three['inventory_item']['asset_tag'] == "1234"
+      - test_three['inventory_item']['serial'] == "1234"
+      - test_three['inventory_item']['description'] == "New SFP"
+      - test_three['inventory_item']['manufacturer'] == 1
+      - test_three['inventory_item']['part_id'] == "10G-SFP+"
+      - test_three['inventory_item']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "inventory_item 10G-SFP+ updated"
+
+- name: "INVENTORY_ITEM 4: ASSERT - Delete"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+    state: absent
+  register: test_four
+
+- name: "INVENTORY_ITEM 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['inventory_item']['name'] == "10G-SFP+"
+      - test_four['inventory_item']['device'] == 1
+      - test_four['inventory_item']['asset_tag'] == "1234"
+      - test_four['inventory_item']['serial'] == "1234"
+      - test_four['inventory_item']['description'] == "New SFP"
+      - test_four['inventory_item']['manufacturer'] == 1
+      - test_four['inventory_item']['part_id'] == "10G-SFP+"
+      - test_four['inventory_item']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "inventory_item 10G-SFP+ deleted"

--- a/tests/integration/v2.6/tasks/netbox_ip_address.yml
+++ b/tests/integration/v2.6/tasks/netbox_ip_address.yml
@@ -1,0 +1,325 @@
+---
+##
+##
+### NETBOX_IP_ADDRESS
+##
+##
+- name: "1 - Create IP address within Netbox with only required information - State: Present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.10/30
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['msg'] == "ip_address 192.168.1.10/30 created"
+      - test_one['ip_address']['address'] == "192.168.1.10/30"
+
+- name: "2 - Update 192.168.1.10/30"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.10/30
+      description: "Updated ip address"
+      tags:
+        - Updated
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - test_two is changed
+      - test_two['diff']['after']['description'] == "Updated ip address"
+      - test_two['diff']['after']['tags'][0] == "Updated"
+      - test_two['msg'] == "ip_address 192.168.1.10/30 updated"
+      - test_two['ip_address']['address'] == "192.168.1.10/30"
+      - test_two['ip_address']['tags'][0] == "Updated"
+      - test_two['ip_address']['description'] == "Updated ip address"
+
+- name: "3 - Delete IP - 192.168.1.10 - State: Absent"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.10/30
+    state: absent
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "ip_address 192.168.1.10/30 deleted"
+
+- name: "4 - Create IP in global VRF - 192.168.1.20/30 - State: Present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.20/30
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['msg'] == "ip_address 192.168.1.20/30 created"
+      - test_four['ip_address']['address'] == "192.168.1.20/30"
+
+- name: "5 - Create IP in global VRF - 192.168.1.20/30 - State: New"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.20/30
+    state: new
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['msg'] == "ip_address 192.168.1.20/30 created"
+      - test_five['ip_address']['address'] == "192.168.1.20/30"
+
+- name: "6 - Create new address with only prefix specified - State: new"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 192.168.100.0/24
+    state: new
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['msg'] == "ip_address 192.168.100.1/24 created"
+      - test_six['ip_address']['address'] == "192.168.100.1/24"
+
+- name: "7 - Create IP address with several specified"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 172.16.1.20/24
+      vrf: Test VRF
+      tenant: Test Tenant
+      status: Reserved
+      role: Loopback
+      description: Test description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['msg'] == "ip_address 172.16.1.20/24 created"
+      - test_seven['ip_address']['address'] == "172.16.1.20/24"
+      - test_seven['ip_address']['description'] == "Test description"
+      - test_seven['ip_address']['family'] == 4
+      - test_seven['ip_address']['role'] == 10
+      - test_seven['ip_address']['status'] == 2
+      - test_seven['ip_address']['tags'][0] == "Schnozzberry"
+      - test_seven['ip_address']['tenant'] == 1
+      - test_seven['ip_address']['vrf'] == 1
+
+- name: "8 - Create IP address and assign a nat_inside IP"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 10.10.1.30/16
+      vrf: Test VRF
+      nat_inside:
+        address: 172.16.1.20
+        vrf: Test VRF
+      interface:
+        name: GigabitEthernet1
+        device: test100
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "absent"
+      - test_eight['diff']['after']['state'] == "present"
+      - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
+      - test_eight['ip_address']['address'] == "10.10.1.30/16"
+      - test_eight['ip_address']['family'] == 4
+      - test_eight['ip_address']['interface'] == 2
+      - test_eight['ip_address']['nat_inside'] == 7
+      - test_eight['ip_address']['vrf'] == 1
+
+- name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 10.10.200.30/16
+      interface:
+        name: GigabitEthernet2
+        device: test100
+  register: test_nine
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['msg'] == "ip_address 10.10.200.30/16 created"
+      - test_nine['ip_address']['address'] == "10.10.200.30/16"
+      - test_nine['ip_address']['family'] == 4
+      - test_nine['ip_address']['interface'] == 3
+
+- name: "10 - Create IP address on GigabitEthernet2 - test100 - State: new"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      prefix: 10.10.0.0/16
+      interface:
+        name: GigabitEthernet2
+        device: test100
+    state: new
+  register: test_ten
+
+- name: "10 - ASSERT"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['msg'] == "ip_address 10.10.0.1/16 created"
+      - test_ten['ip_address']['address'] == "10.10.0.1/16"
+      - test_ten['ip_address']['family']['value'] == 4
+      - test_ten['ip_address']['interface']['id'] == 3
+
+- name: "11 - Create IP address on GigabitEthernet2 - test100 - State: present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      prefix: 192.168.100.0/24
+      interface:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  register: test_eleven
+
+- name: "11 - ASSERT"
+  assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "absent"
+      - test_eleven['diff']['after']['state'] == "present"
+      - test_eleven['msg'] == "ip_address 192.168.100.2/24 created"
+      - test_eleven['ip_address']['address'] == "192.168.100.2/24"
+
+- name: "12 - Duplicate - 192.168.100.2/24 on interface"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.100.2/24
+      interface:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  register: test_twelve
+
+- name: "12 - ASSERT"
+  assert:
+    that:
+      - not test_twelve['changed']
+      - test_twelve['msg'] == "ip_address 192.168.100.2/24 already exists"
+      - test_twelve['ip_address']['address'] == "192.168.100.2/24"
+      - test_twelve['ip_address']['interface'] == 3
+
+- name: "13 - Duplicate - 192.168.100.2/24"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.100.2/24
+    state: present
+  register: test_thirteen
+
+- name: "13 - ASSERT"
+  assert:
+    that:
+      - not test_thirteen['changed']
+      - test_thirteen['msg'] == "ip_address 192.168.100.2/24 already exists"
+      - test_thirteen['ip_address']['address'] == "192.168.100.2/24"
+
+- name: "14 - Create IP address on Eth0 - test100-vm - State: present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 10.188.1.100/24
+      interface:
+        name: Eth0
+        virtual_machine: test100-vm
+  register: test_fourteen
+
+- name: "14 - ASSERT"
+  assert:
+    that:
+      - test_fourteen is changed
+      - test_fourteen['diff']['before']['state'] == "absent"
+      - test_fourteen['diff']['after']['state'] == "present"
+      - test_fourteen['msg'] == "ip_address 10.188.1.100/24 created"
+      - test_fourteen['ip_address']['address'] == "10.188.1.100/24"
+      - test_fourteen['ip_address']['family'] == 4
+      - test_fourteen['ip_address']['interface'] == 4
+
+- name: "15 - Create IP address with no mask - State: Present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 10.120.10.1
+    state: present
+  register: test_fifteen
+
+- name: "15 - ASSERT"
+  assert:
+    that:
+      - test_fifteen is changed
+      - test_fifteen['diff']['before']['state'] == "absent"
+      - test_fifteen['diff']['after']['state'] == "present"
+      - test_fifteen['msg'] == "ip_address 10.120.10.1/32 created"
+      - test_fifteen['ip_address']['address'] == "10.120.10.1/32"

--- a/tests/integration/v2.6/tasks/netbox_ipam_role.yml
+++ b/tests/integration/v2.6/tasks/netbox_ipam_role.yml
@@ -1,0 +1,94 @@
+---
+##
+##
+### NETBOX_IPAM_ROLE
+##
+##
+- name: "IPAM_ROLE 1: Necessary info creation"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test IPAM Role"
+    state: present
+  register: test_one
+
+- name: "IPAM_ROLE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['role']['name'] == "Test IPAM Role"
+      - test_one['role']['slug'] == "test-ipam-role"
+      - test_one['msg'] == "role Test IPAM Role created"
+
+- name: "IPAM_ROLE 2: Create duplicate"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test IPAM Role"
+    state: present
+  register: test_two
+
+- name: "IPAM_ROLE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['role']['name'] == "Test IPAM Role"
+      - test_two['role']['slug'] == "test-ipam-role"
+      - test_two['msg'] == "role Test IPAM Role already exists"
+
+- name: "IPAM_ROLE 3: ASSERT - Update"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test IPAM Role"
+      weight: 4096
+    state: present
+  register: test_three
+
+- name: "IPAM_ROLE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['weight'] == 4096
+      - test_three['role']['name'] == "Test IPAM Role"
+      - test_three['role']['slug'] == "test-ipam-role"
+      - test_three['role']['weight'] == 4096
+      - test_three['msg'] == "role Test IPAM Role updated"
+
+- name: "IPAM_ROLE 4: ASSERT - Delete"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test IPAM Role
+    state: absent
+  register: test_four
+
+- name: "IPAM_ROLE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "role Test IPAM Role deleted"
+
+- name: "IPAM_ROLE 5: ASSERT - Delete non existing"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test IPAM Role
+    state: absent
+  register: test_five
+
+- name: "IPAM_ROLE 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['role'] == None
+      - test_five['msg'] == "role Test IPAM Role already absent"

--- a/tests/integration/v2.6/tasks/netbox_lookup.yml
+++ b/tests/integration/v2.6/tasks/netbox_lookup.yml
@@ -1,0 +1,69 @@
+---
+##
+##
+### NETBOX_LOOKUP
+##
+##
+- name: "NETBOX_LOOKUP 1: Lookup returns exactly two sites"
+  assert:
+    that: "{{ query_result|count }} == 3"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
+  assert:
+    that: "{{ query_result|json_query('[?value.display_name==`Wibble`]')|count }} == 0"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
+  assert:
+    that: "{{ query_result|json_query('[?value.display_name==`TestDeviceR1`]')|count }} == 1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 4: VLAN ID 400 can be queried and is named 'Test VLAN'"
+  assert:
+    that: "{{ (query_result|json_query('[?value.vid==`400`].value.name'))[0] == 'Test VLAN' }}"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'vlans', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 5: Add one of two devices for lookup filter test."
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "L1"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+      tags:
+        - "nolookup"
+    state: present
+
+- name: "NETBOX_LOOKUP 6: Add two of two devices for lookup filter test."
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "L2"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+      tags:
+        - "lookup"
+    state: present
+
+- name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
+  assert:
+    that: "{{ query_result|json_query('[?value.display_name==`L2`]')|count }} == 1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
+  assert:
+    that: "{{ query_result|json_query('[?display_name==`L2`]')|count }} == 1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567', raw_data=True) }}"

--- a/tests/integration/v2.6/tasks/netbox_manufacturer.yml
+++ b/tests/integration/v2.6/tasks/netbox_manufacturer.yml
@@ -1,0 +1,91 @@
+---
+##
+##
+### NETBOX_MANUFACTURER
+##
+##
+- name: "MANUFACTURER 1: Necessary info creation"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Manufacturer Two
+    state: present
+  register: test_one
+
+- name: "MANUFACTURER 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['manufacturer']['name'] == "Test Manufacturer Two"
+      - test_one['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_one['msg'] == "manufacturer Test Manufacturer Two created"
+
+- name: "MANUFACTURER 2: Create duplicate"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Manufacturer Two
+    state: present
+  register: test_two
+
+- name: "MANUFACTURER 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['manufacturer']['name'] == "Test Manufacturer Two"
+      - test_two['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_two['msg'] == "manufacturer Test Manufacturer Two already exists"
+
+- name: "MANUFACTURER 3: Update"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: test manufacturer two
+    state: present
+  register: test_three
+
+- name: "MANUFACTURER 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three['changed']
+      - test_three['manufacturer']['name'] == "test manufacturer two"
+      - test_three['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_three['msg'] == "manufacturer test manufacturer two updated"
+
+- name: "MANUFACTURER 4: ASSERT - Delete"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: test manufacturer two
+    state: absent
+  register: test_four
+
+- name: "MANUFACTURER 3: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "manufacturer test manufacturer two deleted"
+
+- name: "MANUFACTURER 5: ASSERT - Delete non existing"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Manufacturer Two
+    state: absent
+  register: test_five
+
+- name: "MANUFACTURER 5: ASSERT - Delete non existing"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['manufacturer'] == None
+      - test_five['msg'] == "manufacturer Test Manufacturer Two already absent"

--- a/tests/integration/v2.6/tasks/netbox_platform.yml
+++ b/tests/integration/v2.6/tasks/netbox_platform.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_PLATFORM
+##
+##
+- name: "PLATFORM 1: Necessary info creation"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: present
+  register: test_one
+
+- name: "PLATFORM 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['platform']['name'] == "Test Platform"
+      - test_one['platform']['slug'] == "test-platform"
+      - test_one['msg'] == "platform Test Platform created"
+
+- name: "PLATFORM 2: Create duplicate"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: present
+  register: test_two
+
+- name: "PLATFORM 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['platform']['name'] == "Test Platform"
+      - test_two['platform']['slug'] == "test-platform"
+      - test_two['msg'] == "platform Test Platform already exists"
+
+- name: "PLATFORM 3: ASSERT - Update"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+      manufacturer: Test Manufacturer
+      napalm_driver: ios
+      napalm_args:
+        global_delay_factor: 2
+    state: present
+  register: test_three
+
+- name: "PLATFORM 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['manufacturer'] == 3
+      - test_three['diff']['after']['napalm_args']['global_delay_factor'] == 2
+      - test_three['diff']['after']['napalm_driver'] == "ios"
+      - test_three['platform']['manufacturer'] == 3
+      - test_three['platform']['napalm_args']['global_delay_factor'] == 2
+      - test_three['platform']['napalm_driver'] == "ios"
+      - test_three['msg'] == "platform Test Platform updated"
+
+- name: "PLATFORM 4: ASSERT - Delete"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: absent
+  register: test_four
+
+- name: "PLATFORM 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "platform Test Platform deleted"
+
+- name: "PLATFORM 5: ASSERT - Delete non existing"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: absent
+  register: test_five
+
+- name: "PLATFORM 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['platform'] == None
+      - test_five['msg'] == "platform Test Platform already absent"

--- a/tests/integration/v2.6/tasks/netbox_prefix.yml
+++ b/tests/integration/v2.6/tasks/netbox_prefix.yml
@@ -1,0 +1,245 @@
+---
+##
+##
+### NETBOX_PREFIX
+##
+##
+- name: "1 - Create prefix within Netbox with only required information"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['msg'] == "prefix 10.156.0.0/19 created"
+      - test_one['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: "2 - Duplicate"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "prefix 10.156.0.0/19 already exists"
+      - test_two['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: "3 - Update 10.156.0.0/19"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+      site: Test Site
+      status: Reserved
+      description: "This prefix has been updated"
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['site'] == 1
+      - test_three['diff']['after']['status'] == 2
+      - test_three['diff']['after']['description'] == "This prefix has been updated"
+      - test_three['msg'] == "prefix 10.156.0.0/19 updated"
+      - test_three['prefix']['prefix'] == "10.156.0.0/19"
+      - test_three['prefix']['site'] == 1
+      - test_three['prefix']['status'] == 2
+      - test_three['prefix']['description'] == "This prefix has been updated"
+
+- name: "4 - Delete prefix within netbox"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: absent
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "prefix 10.156.0.0/19 deleted"
+
+- name: "5 - Create prefix with several specified options"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      prefix: 10.156.32.0/19
+      site: Test Site
+      vrf: Test VRF
+      tenant: Test Tenant
+      vlan:
+        name: Test VLAN
+        site: Test Site
+        tenant: Test Tenant
+        vlan_group: Test Vlan Group
+      status: Reserved
+      prefix_role: Network of care
+      description: Test description
+      is_pool: true
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['msg'] == "prefix 10.156.32.0/19 created"
+      - test_five['prefix']['prefix'] == "10.156.32.0/19"
+      - test_five['prefix']['family'] == 4
+      - test_five['prefix']['site'] == 1
+      - test_five['prefix']['vrf'] == 1
+      - test_five['prefix']['tenant'] == 1
+      - test_five['prefix']['vlan'] == 4
+      - test_five['prefix']['status'] == 2
+      - test_five['prefix']['role'] == 1
+      - test_five['prefix']['description'] == "Test description"
+      - test_five['prefix']['is_pool'] == true
+      - test_five['prefix']['tags'][0] == "Schnozzberry"
+
+- name: "6 - Get a new /24 inside 10.156.0.0/19 within Netbox - Parent doesn't exist"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: yes
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - not test_six['changed']
+      - test_six['msg'] == "Parent prefix does not exist - 10.156.0.0/19"
+
+- name: "7 - Create prefix within Netbox with only required information"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['msg'] == "prefix 10.156.0.0/19 created"
+      - test_seven['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: "8 - Get a new /24 inside 10.156.0.0/19 within Netbox"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: yes
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "absent"
+      - test_eight['diff']['after']['state'] == "present"
+      - test_eight['msg'] == "prefix 10.156.0.0/24 created"
+      - test_eight['prefix']['prefix'] == "10.156.0.0/24"
+
+- name: "9 - Create 10.157.0.0/19"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.157.0.0/19
+      vrf: Test VRF
+      site: Test Site
+    state: present
+  register: test_nine
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['msg'] == "prefix 10.157.0.0/19 created"
+      - test_nine['prefix']['prefix'] == "10.157.0.0/19"
+      - test_nine['prefix']['site'] == 1
+      - test_nine['prefix']['vrf'] == 1
+
+- name: "10 - Get a new /24 inside 10.157.0.0/19 within Netbox with additional values"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.157.0.0/19
+      prefix_length: 24
+      vrf: Test VRF
+      site: Test Site
+    state: present
+    first_available: yes
+  register: test_ten
+
+- name: "10 - ASSERT"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['msg'] == "prefix 10.157.0.0/24 created"
+      - test_ten['prefix']['prefix'] == "10.157.0.0/24"
+      - test_ten['prefix']['site']['id'] == 1
+      - test_ten['prefix']['vrf']['id'] == 1
+
+- name: "11 - Get a new /24 inside 10.156.0.0/19 within Netbox"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: yes
+  register: test_eleven
+
+- name: "11 - ASSERT"
+  assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "absent"
+      - test_eleven['diff']['after']['state'] == "present"
+      - test_eleven['msg'] == "prefix 10.156.1.0/24 created"
+      - test_eleven['prefix']['prefix'] == "10.156.1.0/24"

--- a/tests/integration/v2.6/tasks/netbox_provider.yml
+++ b/tests/integration/v2.6/tasks/netbox_provider.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_PROVIDER
+##
+##
+- name: "NETBOX_PROVIDER 1: Create provider within Netbox with only required information"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+    state: present
+  register: test_one
+
+- name: "NETBOX_PROVIDER 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['provider']['name'] == "Test Provider One"
+      - test_one['provider']['slug'] == "test-provider-one"
+      - test_one['msg'] == "provider Test Provider One created"
+
+- name: "NETBOX_PROVIDER 2: Duplicate"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+    state: present
+  register: test_two
+
+- name: "NETBOX_PROVIDER 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['provider']['name'] == "Test Provider One"
+      - test_two['provider']['slug'] == "test-provider-one"
+      - test_two['msg'] == "provider Test Provider One already exists"
+
+- name: "NETBOX_PROVIDER 3: Update provider with other fields"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+      asn: 65001
+      account: "200129104"
+      portal_url: http://provider.net
+      noc_contact: noc@provider.net
+      admin_contact: admin@provider.net
+      comments: "BAD PROVIDER"
+    state: present
+  register: test_three
+
+- name: "NETBOX_PROVIDER 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['asn'] == 65001
+      - test_three['diff']['after']['account'] == "200129104"
+      - test_three['diff']['after']['portal_url'] == "http://provider.net"
+      - test_three['diff']['after']['noc_contact'] == "noc@provider.net"
+      - test_three['diff']['after']['admin_contact'] == "admin@provider.net"
+      - test_three['diff']['after']['comments'] == "BAD PROVIDER"
+      - test_three['provider']['name'] == "Test Provider One"
+      - test_three['provider']['slug'] == "test-provider-one"
+      - test_three['provider']['asn'] == 65001
+      - test_three['provider']['account'] == "200129104"
+      - test_three['provider']['portal_url'] == "http://provider.net"
+      - test_three['provider']['noc_contact'] == "noc@provider.net"
+      - test_three['provider']['admin_contact'] == "admin@provider.net"
+      - test_three['provider']['comments'] == "BAD PROVIDER"
+      - test_three['msg'] == "provider Test Provider One updated"
+
+- name: "NETBOX_PROVIDER 4: Delete provider within netbox"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+    state: absent
+  register: test_four
+
+- name: "NETBOX_PROVIDER 4 : ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['provider']['name'] == "Test Provider One"
+      - test_four['provider']['slug'] == "test-provider-one"
+      - test_four['provider']['asn'] == 65001
+      - test_four['provider']['account'] == "200129104"
+      - test_four['provider']['portal_url'] == "http://provider.net"
+      - test_four['provider']['noc_contact'] == "noc@provider.net"
+      - test_four['provider']['admin_contact'] == "admin@provider.net"
+      - test_four['provider']['comments'] == "BAD PROVIDER"
+      - test_four['msg'] == "provider Test Provider One deleted"

--- a/tests/integration/v2.6/tasks/netbox_rack.yml
+++ b/tests/integration/v2.6/tasks/netbox_rack.yml
@@ -1,0 +1,177 @@
+---
+##
+##
+### NETBOX_RACK
+##
+##
+- name: "1 - Test rack creation"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test rack one"
+      site: "Test Site"
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack']['name'] == "Test rack one"
+      - test_one['rack']['site'] == 1
+
+- name: "Test duplicate rack"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test rack one"
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack']['name'] == "Test rack one"
+      - test_two['rack']['site'] == 1
+      - test_two['msg'] == "rack Test rack one already exists"
+
+- name: "3 - Create new rack with similar name"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack - Test Site
+      site: Test Site
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['rack']['name'] == "Test rack - Test Site"
+      - test_three['rack']['site'] == 1
+      - test_three['msg'] == "rack Test rack - Test Site created"
+
+- name: "4 - Attempt to create Test rack one again"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack one
+      site: Test Site
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - not test_four['changed']
+      - test_four['rack']['name'] == "Test rack one"
+      - test_four['rack']['site'] == 1
+      - test_four['msg'] == "rack Test rack one already exists"
+
+- name: "5 - Update Test rack one with more options"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack one
+      site: Test Site
+      rack_role: "Test Rack Role"
+      rack_group: "Test Rack Group"
+      facility_id: "EQUI10291"
+      tenant: "Test Tenant"
+      status: Available
+      serial: "FXS10001"
+      asset_tag: "1234"
+      width: 23
+      u_height: 48
+      type: "2-post frame"
+      outer_width: 32
+      outer_depth: 24
+      outer_unit: "Inches"
+      comments: "Just testing rack module"
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['asset_tag'] == "1234"
+      - test_five['diff']['after']['comments'] == "Just testing rack module"
+      - test_five['diff']['after']['facility_id'] == "EQUI10291"
+      - test_five['diff']['after']['group'] == 1
+      - test_five['diff']['after']['outer_depth'] == 24
+      - test_five['diff']['after']['outer_unit'] == 2000
+      - test_five['diff']['after']['outer_width'] == 32
+      - test_five['diff']['after']['role'] == 1
+      - test_five['diff']['after']['serial'] == "FXS10001"
+      - test_five['diff']['after']['status'] == 1
+      - test_five['diff']['after']['tenant'] == 1
+      - test_five['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_five['diff']['after']['type'] == 100
+      - test_five['diff']['after']['u_height'] == 48
+      - test_five['diff']['after']['width'] == "23"
+      - test_five['rack']['name'] == "Test rack one"
+      - test_five['rack']['site'] == 1
+      - test_five['rack']['asset_tag'] == "1234"
+      - test_five['rack']['comments'] == "Just testing rack module"
+      - test_five['rack']['facility_id'] == "EQUI10291"
+      - test_five['rack']['group'] == 1
+      - test_five['rack']['outer_depth'] == 24
+      - test_five['rack']['outer_unit'] == 2000
+      - test_five['rack']['outer_width'] == 32
+      - test_five['rack']['role'] == 1
+      - test_five['rack']['serial'] == "FXS10001"
+      - test_five['rack']['status'] == 1
+      - test_five['rack']['tenant'] == 1
+      - test_five['rack']['tags'][0] == "Schnozzberry"
+      - test_five['rack']['type'] == 100
+      - test_five['rack']['u_height'] == 48
+      - test_five['rack']['width'] == "23"
+      - test_five['msg'] == "rack Test rack one updated"
+
+- name: "6 - Create rack with same asset tag and serial number"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack two
+      site: Test Site
+      serial: "FXS10001"
+      asset_tag: "1234"
+    state: present
+  ignore_errors: yes
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is failed
+      - "'Asset tag already exists' in test_six['msg']"
+
+- name: "7 - Test delete"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test rack one"
+    state: "absent"
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "present"
+      - test_seven['diff']['after']['state'] == "absent"
+      - test_seven['msg'] == "rack Test rack one deleted"

--- a/tests/integration/v2.6/tasks/netbox_rack_group.yml
+++ b/tests/integration/v2.6/tasks/netbox_rack_group.yml
@@ -1,0 +1,62 @@
+---
+##
+##
+### NETBOX_RACK_GROUP
+##
+##
+- name: "RACK_GROUP 1: Necessary info creation"
+  netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Group
+      site: Test Site
+    state: present
+  register: test_one
+
+- name: "RACK_GROUP 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack_group']['name'] == "Rack Group"
+      - test_one['rack_group']['slug'] == "rack-group"
+      - test_one['rack_group']['site'] == 1
+      - test_one['msg'] == "rack_group Rack Group created"
+
+- name: "RACK_GROUP 2: Create duplicate"
+  netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Group
+      site: Test Site
+    state: present
+  register: test_two
+
+- name: "RACK_GROUP 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack_group']['name'] == "Rack Group"
+      - test_two['rack_group']['slug'] == "rack-group"
+      - test_two['rack_group']['site'] == 1
+      - test_two['msg'] == "rack_group Rack Group already exists"
+
+- name: "RACK_GROUP 3: ASSERT - Delete"
+  netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Group
+    state: absent
+  register: test_three
+
+- name: "RACK_GROUP 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "rack_group Rack Group deleted"

--- a/tests/integration/v2.6/tasks/netbox_rack_role.yml
+++ b/tests/integration/v2.6/tasks/netbox_rack_role.yml
@@ -1,0 +1,81 @@
+---
+##
+##
+### NETBOX_RACK_ROLE
+##
+##
+- name: "RACK_ROLE 1: Necessary info creation"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+      color: "ffffff"
+    state: present
+  register: test_one
+
+- name: "RACK_ROLE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack_role']['name'] == "Rack Role"
+      - test_one['rack_role']['slug'] == "rack-role"
+      - test_one['rack_role']['color'] == "ffffff"
+      - test_one['msg'] == "rack_role Rack Role created"
+
+- name: "RACK_ROLE 2: Create duplicate"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+    state: present
+  register: test_two
+
+- name: "RACK_ROLE 1: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack_role']['name'] == "Rack Role"
+      - test_two['rack_role']['slug'] == "rack-role"
+      - test_two['rack_role']['color'] == "ffffff"
+      - test_two['msg'] == "rack_role Rack Role already exists"
+
+- name: "RACK_ROLE 3: Update"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+      color: "003EFF"
+    state: present
+  register: test_three
+
+- name: "RACK_ROLE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "003eff"
+      - test_three['rack_role']['name'] == "Rack Role"
+      - test_three['rack_role']['slug'] == "rack-role"
+      - test_three['rack_role']['color'] == "003eff"
+      - test_three['msg'] == "rack_role Rack Role updated"
+
+- name: "RACK_ROLE 4: Delete"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+    state: absent
+  register: test_four
+
+- name: "RACK_ROLE 4: ASSERT - Update"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "rack_role Rack Role deleted"

--- a/tests/integration/v2.6/tasks/netbox_region.yml
+++ b/tests/integration/v2.6/tasks/netbox_region.yml
@@ -1,0 +1,79 @@
+---
+##
+##
+### NETBOX_REGION
+##
+##
+- name: "REGION 1: Necessary info creation"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+    state: present
+  register: test_one
+
+- name: "REGION 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['region']['name'] == "Test Region One"
+      - test_one['region']['slug'] == "test-region-one"
+      - test_one['msg'] == "region Test Region One created"
+
+- name: "REGION 2: Create duplicate"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+    state: present
+  register: test_two
+
+- name: "REGION 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['region']['name'] == "Test Region One"
+      - test_two['region']['slug'] == "test-region-one"
+      - test_two['msg'] == "region Test Region One already exists"
+
+- name: "REGION 3: ASSERT - Update"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+      parent_region: "Test Region"
+    state: present
+  register: test_three
+
+- name: "REGION 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['parent'] == 1
+      - test_three['region']['name'] == "Test Region One"
+      - test_three['region']['slug'] == "test-region-one"
+      - test_three['region']['parent'] == 1
+      - test_three['msg'] == "region Test Region One updated"
+
+- name: "REGION 4: ASSERT - Delete"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+    state: absent
+  register: test_four
+
+- name: "REGION 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['region']['name'] == "Test Region One"
+      - test_four['region']['slug'] == "test-region-one"
+      - test_four['region']['parent'] == 1
+      - test_four['msg'] == "region Test Region One deleted"

--- a/tests/integration/v2.6/tasks/netbox_rir.yml
+++ b/tests/integration/v2.6/tasks/netbox_rir.yml
@@ -1,0 +1,79 @@
+---
+##
+##
+### NETBOX_RIR
+##
+##
+- name: "RIR 1: Necessary info creation"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test RIR One
+    state: present
+  register: test_one
+
+- name: "RIR 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rir']['name'] == "Test RIR One"
+      - test_one['rir']['slug'] == "test-rir-one"
+      - test_one['msg'] == "rir Test RIR One created"
+
+- name: "RIR 2: Create duplicate"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test RIR One
+    state: present
+  register: test_two
+
+- name: "RIR 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rir']['name'] == "Test RIR One"
+      - test_two['rir']['slug'] == "test-rir-one"
+      - test_two['msg'] == "rir Test RIR One already exists"
+
+- name: "RIR 3: ASSERT - Update"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test RIR One"
+      is_private: true
+    state: present
+  register: test_three
+
+- name: "RIR 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['is_private'] == true
+      - test_three['rir']['name'] == "Test RIR One"
+      - test_three['rir']['slug'] == "test-rir-one"
+      - test_three['rir']['is_private'] == true
+      - test_three['msg'] == "rir Test RIR One updated"
+
+- name: "RIR 4: ASSERT - Delete"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test RIR One"
+    state: absent
+  register: test_four
+
+- name: "RIR 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['rir']['name'] == "Test RIR One"
+      - test_four['rir']['slug'] == "test-rir-one"
+      - test_four['rir']['is_private'] == true
+      - test_four['msg'] == "rir Test RIR One deleted"

--- a/tests/integration/v2.6/tasks/netbox_service.yml
+++ b/tests/integration/v2.6/tasks/netbox_service.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_SERVICE
+##
+##
+- name: "1 - Device with required information needs to add new service"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "FOR_SERVICE"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+
+- name: "NETBOX_SERVICE: Create new service"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: TCP
+    state: present
+  register: test_service_create
+
+- name: "NETBOX_SERVICE ASSERT - Create"
+  assert:
+    that:
+      - test_service_create is changed
+      - test_service_create['services']['name'] == "node-exporter"
+      - test_service_create['services']['port'] == 9100
+      - test_service_create['services']['protocol'] == 6
+      - test_service_create['diff']['after']['state'] == "present"
+      - test_service_create['diff']['before']['state'] == "absent"
+      - test_service_create['msg'] == "services node-exporter created"
+
+- name: "NETBOX_SERVICE: Test idempotence"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: TCP
+    state: present
+  register: test_service_idempotence
+
+- name: "NETBOX_SERVICE ASSERT - Not changed"
+  assert:
+    that:
+      - test_service_idempotence['services']['name'] == "node-exporter"
+      - test_service_idempotence['services']['port'] == 9100
+      - test_service_idempotence['services']['protocol'] == 6
+      - test_service_idempotence['msg'] == "services node-exporter already exists"
+- name: "NETBOX_SERVICE: Test update"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: UDP
+    state: present
+  register: test_service_update
+
+- name: "NETBOX_SERVICE ASSERT - Service has been updated"
+  assert:
+    that:
+      - test_service_update is changed
+      - test_service_update['diff']['before']['protocol'] == 6
+      - test_service_update['diff']['after']['protocol'] == 17
+      - test_service_update['msg'] == "services node-exporter updated"
+
+- name: "NETBOX_SERVICE: Test service deletion"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: UDP
+    state: absent
+  register: test_service_delete
+
+- name: "NETBOX_SERVICE ASSERT - Service has been deleted"
+  assert:
+    that:
+      - test_service_delete is changed
+      - test_service_delete['diff']['after']['state'] == "absent"
+      - test_service_delete['diff']['before']['state'] == "present"
+      - test_service_delete['msg'] == "services node-exporter deleted"

--- a/tests/integration/v2.6/tasks/netbox_site.yml
+++ b/tests/integration/v2.6/tasks/netbox_site.yml
@@ -1,0 +1,132 @@
+---
+##
+##
+### NETBOX_SITE
+##
+##
+- name: "1 - Create site within Netbox with only required information"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['site']['name'] == "Test - Colorado"
+      - test_one['msg'] == "site Test - Colorado created"
+
+- name: "2 - Duplicate"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "site Test - Colorado already exists"
+      - test_two['site']['name'] == "Test - Colorado"
+
+- name: "3 - Update Test - Colorado"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+      status: Planned
+      region: Test Region
+      contact_name: Mikhail
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == 2
+      - test_three['diff']['after']['contact_name'] == "Mikhail"
+      - test_three['diff']['after']['region'] == 1
+      - test_three['msg'] == "site Test - Colorado updated"
+      - test_three['site']['name'] == "Test - Colorado"
+      - test_three['site']['status'] == 2
+      - test_three['site']['contact_name'] == "Mikhail"
+      - test_three['site']['region'] == 1
+
+- name: "4 - Create site with all parameters"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - California
+      status: Planned
+      region: Test Region
+      tenant: Test Tenant
+      facility: EquinoxCA7
+      asn: 65001
+      time_zone: America/Los Angeles
+      description: This is a test description
+      physical_address: Hollywood, CA, 90210
+      shipping_address: Hollywood, CA, 90210
+      latitude: 10.1
+      longitude: 12.2
+      contact_name: Jenny
+      contact_phone: 867-5309
+      contact_email: jenny@changednumber.com
+      comments: "### Placeholder"
+      slug: "test_california"
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['site']['name'] == "Test - California"
+      - test_four['msg'] == "site Test - California created"
+      - test_four['site']['status'] == 2
+      - test_four['site']['region'] == 1
+      - test_four['site']['tenant'] == 1
+      - test_four['site']['facility'] == "EquinoxCA7"
+      - test_four['site']['asn'] == 65001
+      - test_four['site']['time_zone'] == "America/Los_Angeles"
+      - test_four['site']['description'] == "This is a test description"
+      - test_four['site']['physical_address'] == "Hollywood, CA, 90210"
+      - test_four['site']['shipping_address'] == "Hollywood, CA, 90210"
+      - test_four['site']['latitude'] == "10.100000"
+      - test_four['site']['longitude'] == "12.200000"
+      - test_four['site']['contact_name'] == "Jenny"
+      - test_four['site']['contact_phone'] == "867-5309"
+      - test_four['site']['contact_email'] == "jenny@changednumber.com"
+      - test_four['site']['comments'] == "### Placeholder"
+      - test_four['site']['slug'] == "test_california"
+
+- name: "5 - Delete site within netbox"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+    state: absent
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['site']['name'] == "Test - Colorado"
+      - test_five['msg'] == "site Test - Colorado deleted"

--- a/tests/integration/v2.6/tasks/netbox_tenant.yml
+++ b/tests/integration/v2.6/tasks/netbox_tenant.yml
@@ -1,0 +1,106 @@
+---
+##
+##
+### NETBOX_TENANT
+##
+##
+- name: "1 - Test tenant creation"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tenant']['name'] == "Tenant ABC"
+      - test_one['tenant']['slug'] == "tenant-abc"
+      - test_one['msg'] == "tenant Tenant ABC created"
+
+- name: "Test duplicate tenant"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['tenant']['name'] == "Tenant ABC"
+      - test_two['tenant']['slug'] == "tenant-abc"
+      - test_two['msg'] == "tenant Tenant ABC already exists"
+
+- name: "3 - Test update"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+      description: "Updated description"
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Updated description"
+      - test_three['tenant']['name'] == "Tenant ABC"
+      - test_three['tenant']['slug'] == "tenant-abc"
+      - test_three['tenant']['description'] == "Updated description"
+      - test_three['msg'] == "tenant Tenant ABC updated"
+
+- name: "4 - Test delete"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+    state: "absent"
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "tenant Tenant ABC deleted"
+
+- name: "5 - Create tenant with all parameters"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+      description: "ABC Incorporated"
+      comments: "### This tenant is super cool"
+      tenant_group: "Test Tenant Group"
+      slug: "tenant_abc"
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['tenant']['name'] == "Tenant ABC"
+      - test_five['tenant']['slug'] == "tenant_abc"
+      - test_five['tenant']['description'] == "ABC Incorporated"
+      - test_five['tenant']['comments'] == "### This tenant is super cool"
+      - test_five['tenant']['group'] == 1
+      - test_five['tenant']['tags'] | length == 3
+      - test_five['msg'] == "tenant Tenant ABC created"

--- a/tests/integration/v2.6/tasks/netbox_tenant_group.yml
+++ b/tests/integration/v2.6/tasks/netbox_tenant_group.yml
@@ -1,0 +1,75 @@
+---
+##
+##
+### NETBOX_TENANT_GROUP
+##
+##
+- name: "1 - Test tenant group creation"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group Two"
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tenant_group']['name'] == "Test Tenant Group Two"
+      - test_one['tenant_group']['slug'] == "test-tenant-group-two"
+      - test_one['msg'] == "tenant_group Test Tenant Group Two created"
+
+- name: "Test duplicate tenant group"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group Two"
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['tenant_group']['name'] == "Test Tenant Group Two"
+      - test_two['tenant_group']['slug'] == "test-tenant-group-two"
+      - test_two['msg'] == "tenant_group Test Tenant Group Two already exists"
+
+- name: "3 - Test delete"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group Two"
+    state: "absent"
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "tenant_group Test Tenant Group Two deleted"
+
+- name: "4 - Test another tenant group creation"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group ABC"
+      slug: "test_tenant_group_four"
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['tenant_group']['name'] == "Test Tenant Group ABC"
+      - test_four['tenant_group']['slug'] == "test_tenant_group_four"
+      - test_four['msg'] == "tenant_group Test Tenant Group ABC created"

--- a/tests/integration/v2.6/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/v2.6/tasks/netbox_virtual_machine.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_VIRTUAL_MACHINES
+##
+##
+- name: "VIRTUAL_MACHINE 1: Necessary info creation"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+    state: present
+  register: test_one
+
+- name: "VIRTUAL_MACHINE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['virtual_machine']['name'] == "Test VM One"
+      - test_one['virtual_machine']['cluster'] == 1
+      - test_one['msg'] == "virtual_machine Test VM One created"
+
+- name: "VIRTUAL_MACHINE 2: Create duplicate"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+    state: present
+  register: test_two
+
+- name: "VIRTUAL_MACHINE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['virtual_machine']['name'] == "Test VM One"
+      - test_two['virtual_machine']['cluster'] == 1
+      - test_two['msg'] == "virtual_machine Test VM One already exists"
+
+- name: "VIRTUAL_MACHINE 3: Update"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+      vcpus: 8
+      memory: 8
+      status: 0
+      virtual_machine_role: "Test VM Role"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "VIRTUAL_MACHINE 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['vcpus'] == 8
+      - test_three['diff']['after']['memory'] == 8
+      - test_three['diff']['after']['status'] == 0
+      - test_three['diff']['after']['role'] == 2
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['virtual_machine']['name'] == "Test VM One"
+      - test_three['virtual_machine']['cluster'] == 1
+      - test_three['virtual_machine']['vcpus'] == 8
+      - test_three['virtual_machine']['memory'] == 8
+      - test_three['virtual_machine']['status'] == 0
+      - test_three['virtual_machine']['role'] == 2
+      - test_three['virtual_machine']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "virtual_machine Test VM One updated"
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+    state: absent
+  register: test_four
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['virtual_machine']['name'] == "Test VM One"
+      - test_four['virtual_machine']['cluster'] == 1
+      - test_four['virtual_machine']['vcpus'] == 8
+      - test_four['virtual_machine']['memory'] == 8
+      - test_four['virtual_machine']['status'] == 0
+      - test_four['virtual_machine']['role'] == 2
+      - test_four['virtual_machine']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "virtual_machine Test VM One deleted"

--- a/tests/integration/v2.6/tasks/netbox_vlan.yml
+++ b/tests/integration/v2.6/tasks/netbox_vlan.yml
@@ -1,0 +1,143 @@
+---
+##
+##
+### NETBOX_VLAN
+##
+##
+- name: "VLAN 1: Necessary info creation"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VLAN 500
+      vid: 500
+    state: present
+  register: test_one
+
+- name: "VLAN 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vlan']['name'] == "Test VLAN 500"
+      - test_one['vlan']['vid'] == 500
+      - test_one['msg'] == "vlan Test VLAN 500 created"
+
+- name: "VLAN 2: Create duplicate"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VLAN 500
+      vid: 500
+    state: present
+  register: test_two
+
+- name: "VLAN 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['vlan']['name'] == "Test VLAN 500"
+      - test_two['vlan']['vid'] == 500
+      - test_two['msg'] == "vlan Test VLAN 500 already exists"
+
+- name: "VLAN 3: Create VLAN with same name, but different site"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VLAN 500
+      vid: 500
+      site: Test Site
+      tenant: Test Tenant
+    state: present
+  register: test_three
+
+- name: "VLAN 3: ASSERT - Create VLAN with same name, but different site"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['vlan']['name'] == "Test VLAN 500"
+      - test_three['vlan']['vid'] == 500
+      - test_three['vlan']['site'] == 1
+      - test_three['msg'] == "vlan Test VLAN 500 created"
+
+- name: "VLAN 4: ASSERT - Update"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VLAN 500"
+      vid: 500
+      tenant: "Test Tenant"
+      vlan_group: "Test VLAN Group"
+      status: Reserved
+      vlan_role: Network of care
+      description: Updated description
+      site: "Test Site"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four
+
+- name: "VLAN 4: ASSERT - Updated"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['group'] == 1
+      - test_four['diff']['after']['status'] == 2
+      - test_four['diff']['after']['role'] == 1
+      - test_four['diff']['after']['description'] == "Updated description"
+      - test_four['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_four['vlan']['name'] == "Test VLAN 500"
+      - test_four['vlan']['tenant'] == 1
+      - test_four['vlan']['site'] == 1
+      - test_four['vlan']['group'] == 1
+      - test_four['vlan']['status'] == 2
+      - test_four['vlan']['role'] == 1
+      - test_four['vlan']['description'] == "Updated description"
+      - test_four['vlan']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "vlan Test VLAN 500 updated"
+
+- name: "VLAN 5: ASSERT - Delete more than one result"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VLAN 500"
+    state: absent
+  ignore_errors: yes
+  register: test_five
+
+- name: "VLAN 5: ASSERT - Delete more than one result"
+  assert:
+    that:
+      - test_five is failed
+      - test_five['msg'] == "More than one result returned for Test VLAN 500"
+
+- name: "VLAN 6: ASSERT - Delete"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VLAN 500"
+      site: Test Site
+    state: absent
+  register: test_six
+
+- name: "VLAN 6: ASSERT - Delete"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['vlan']['name'] == "Test VLAN 500"
+      - test_six['vlan']['tenant'] == 1
+      - test_six['vlan']['site'] == 1
+      - test_six['vlan']['group'] == 1
+      - test_six['vlan']['status'] == 2
+      - test_six['vlan']['role'] == 1
+      - test_six['vlan']['description'] == "Updated description"
+      - test_six['vlan']['tags'][0] == "Schnozzberry"
+      - test_six['msg'] == "vlan Test VLAN 500 deleted"

--- a/tests/integration/v2.6/tasks/netbox_vlan_group.yml
+++ b/tests/integration/v2.6/tasks/netbox_vlan_group.yml
@@ -1,0 +1,118 @@
+---
+##
+##
+### NETBOX_VLAN_GROUP
+##
+##
+- name: "VLAN_GROUP 1: Necessary info creation"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+      site: Test Site
+    state: present
+  register: test_one
+
+- name: "VLAN_GROUP 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vlan_group']['name'] == "VLAN Group One"
+      - test_one['vlan_group']['slug'] == "vlan-group-one"
+      - test_one['vlan_group']['site'] == 1
+      - test_one['msg'] == "vlan_group VLAN Group One created"
+
+- name: "VLAN_GROUP 2: Create duplicate"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+      site: Test Site
+    state: present
+  register: test_two
+
+- name: "VLAN_GROUP 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['vlan_group']['name'] == "VLAN Group One"
+      - test_two['vlan_group']['slug'] == "vlan-group-one"
+      - test_two['vlan_group']['site'] == 1
+      - test_two['msg'] == "vlan_group VLAN Group One already exists"
+
+- name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+      site: "Test Site2"
+    state: present
+  register: test_three
+
+- name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['vlan_group']['name'] == "VLAN Group One"
+      - test_three['vlan_group']['slug'] == "vlan-group-one"
+      - test_three['vlan_group']['site'] == 2
+      - test_three['msg'] == "vlan_group VLAN Group One created"
+
+- name: "VLAN_GROUP 4: ASSERT - Create vlan group, no site"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+    state: present
+  ignore_errors: yes
+  register: test_four
+
+- name: "VLAN_GROUP 4: ASSERT - Create with same name, different site"
+  assert:
+    that:
+      - test_four is failed
+      - test_four['msg'] == "More than one result returned for VLAN Group One"
+
+- name: "VLAN_GROUP 5: ASSERT - Delete"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: VLAN Group One
+      site: Test Site2
+    state: absent
+  register: test_five
+
+- name: "VLAN_GROUP 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['vlan_group']['name'] == "VLAN Group One"
+      - test_five['vlan_group']['slug'] == "vlan-group-one"
+      - test_five['vlan_group']['site'] == 2
+      - test_five['msg'] == "vlan_group VLAN Group One deleted"
+
+- name: "VLAN_GROUP 6: ASSERT - Delete non existing"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: VLAN Group One
+      site: Test Site2
+    state: absent
+  register: test_six
+
+- name: "VLAN_GROUP 6: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_six['changed']
+      - test_six['vlan_group'] == None
+      - test_six['msg'] == "vlan_group VLAN Group One already absent"

--- a/tests/integration/v2.6/tasks/netbox_vm_interface.yml
+++ b/tests/integration/v2.6/tasks/netbox_vm_interface.yml
@@ -1,0 +1,159 @@
+---
+##
+##
+### NETBOX_VM_INTERFACE
+##
+##
+- name: "NETBOX_VM_INTERFACE 1: Necessary info creation"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth10"
+    state: present
+  register: test_one
+
+- name: "NETBOX_VM_INTERFACE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['interface']['name'] == "Eth10"
+      - test_one['interface']['virtual_machine'] == 1
+      - test_one['msg'] == "interface Eth10 created"
+
+- name: "NETBOX_VM_INTERFACE 2: Create duplicate"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth10"
+    state: present
+  register: test_two
+
+- name: "NETBOX_VM_INTERFACE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['interface']['name'] == "Eth10"
+      - test_two['interface']['virtual_machine'] == 1
+      - test_two['msg'] == "interface Eth10 already exists"
+
+- name: "NETBOX_VM_INTERFACE 3: Updated"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth10"
+      enabled: false
+      mtu: 9000
+      mac_address: "00:00:00:AA:AA:01"
+      description: "Updated test100-vm"
+      mode: Tagged
+      untagged_vlan:
+        name: Wireless
+        site: Test Site
+      tagged_vlans:
+        - name: Data
+          site: Test Site
+        - name: VoIP
+          site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['enabled'] == false
+      - test_three['diff']['after']['mtu'] == 9000
+      - test_three['diff']['after']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_three['diff']['after']['description'] == "Updated test100-vm"
+      - test_three['diff']['after']['mode'] == 200
+      - test_three['diff']['after']['untagged_vlan'] == 1
+      - test_three['diff']['after']['tagged_vlans'] == [2, 3]
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['interface']['name'] == "Eth10"
+      - test_three['interface']['virtual_machine'] == 1
+      - test_three['interface']['enabled'] == false
+      - test_three['interface']['mtu'] == 9000
+      - test_three['interface']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_three['interface']['description'] == "Updated test100-vm"
+      - test_three['interface']['mode'] == 200
+      - test_three['interface']['untagged_vlan'] == 1
+      - test_three['interface']['tagged_vlans'] == [2, 3]
+      - test_three['interface']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "interface Eth10 updated"
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Eth10"
+      virtual_machine: "test100-vm"
+    state: absent
+  register: test_four
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['interface']['name'] == "Eth10"
+      - test_four['interface']['virtual_machine'] == 1
+      - test_four['msg'] == "interface Eth10 deleted"
+
+- name: "NETBOX_VM_INTERFACE 5: Attempt to update interface with same name on other VMs"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth0"
+      enabled: false
+      mtu: 9000
+      mac_address: "00:00:00:AA:AA:01"
+      description: "Updated test100-vm Eth0 intf"
+      mode: Tagged
+      untagged_vlan:
+        name: Wireless
+        site: Test Site
+      tagged_vlans:
+        - name: Data
+          site: Test Site
+        - name: VoIP
+          site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: "NETBOX_VM_INTERFACE 5: ASSERT - Updated"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['enabled'] == false
+      - test_five['diff']['after']['mtu'] == 9000
+      - test_five['diff']['after']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_five['diff']['after']['description'] == "Updated test100-vm Eth0 intf"
+      - test_five['diff']['after']['mode'] == 200
+      - test_five['diff']['after']['untagged_vlan'] == 1
+      - test_five['diff']['after']['tagged_vlans'] == [2, 3]
+      - test_five['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_five['interface']['name'] == "Eth0"
+      - test_five['interface']['virtual_machine'] == 1
+      - test_five['interface']['enabled'] == false
+      - test_five['interface']['mtu'] == 9000
+      - test_five['interface']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_five['interface']['description'] == "Updated test100-vm Eth0 intf"
+      - test_five['interface']['mode'] == 200
+      - test_five['interface']['untagged_vlan'] == 1
+      - test_five['interface']['tagged_vlans'] == [2, 3]
+      - test_five['interface']['tags'][0] == "Schnozzberry"
+      - test_five['msg'] == "interface Eth0 updated"

--- a/tests/integration/v2.6/tasks/netbox_vrf.yml
+++ b/tests/integration/v2.6/tasks/netbox_vrf.yml
@@ -1,0 +1,128 @@
+---
+##
+##
+### NETBOX_VRF
+##
+##
+- name: "VRF 1: Necessary info creation"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VRF One
+    state: present
+  register: test_one
+
+- name: "VRF 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vrf']['name'] == "Test VRF One"
+      - test_one['msg'] == "vrf Test VRF One created"
+
+- name: "VRF 2: Create duplicate"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VRF One
+    state: present
+  register: test_two
+
+- name: "VRF 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['vrf']['name'] == "Test VRF One"
+      - test_two['msg'] == "vrf Test VRF One already exists"
+
+- name: "VRF 3: Create VRF with same name, but different tenant"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VRF One
+      tenant: Test Tenant
+    state: present
+  register: test_three
+
+- name: "VRF 3: ASSERT - Create VRF with same name, but different site"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['vrf']['name'] == "Test VRF One"
+      - test_three['vrf']['tenant'] == 1
+      - test_three['msg'] == "vrf Test VRF One created"
+
+- name: "VRF 4: ASSERT - Update"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VRF One"
+      rd: "65001:1"
+      enforce_unique: False
+      tenant: "Test Tenant"
+      description: Updated description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four
+
+- name: "VRF 4: ASSERT - Updated"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['rd'] == "65001:1"
+      - test_four['diff']['after']['enforce_unique'] == false
+      - test_four['diff']['after']['description'] == "Updated description"
+      - test_four['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_four['vrf']['name'] == "Test VRF One"
+      - test_four['vrf']['tenant'] == 1
+      - test_four['vrf']['rd'] == "65001:1"
+      - test_four['vrf']['enforce_unique'] == false
+      - test_four['vrf']['description'] == "Updated description"
+      - test_four['vrf']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "vrf Test VRF One updated"
+
+- name: "VRF 5: ASSERT - Delete more than one result"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VRF One"
+    state: absent
+  ignore_errors: yes
+  register: test_five
+
+- name: "VRF 5: ASSERT - Delete more than one result"
+  assert:
+    that:
+      - test_five is failed
+      - test_five['msg'] == "More than one result returned for Test VRF One"
+
+- name: "VRF 6: ASSERT - Delete"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VRF One"
+      tenant: Test Tenant
+    state: absent
+  register: test_six
+
+- name: "VRF 6: ASSERT - Delete"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['vrf']['name'] == "Test VRF One"
+      - test_six['vrf']['tenant'] == 1
+      - test_six['vrf']['rd'] == "65001:1"
+      - test_six['vrf']['enforce_unique'] == false
+      - test_six['vrf']['description'] == "Updated description"
+      - test_six['vrf']['tags'][0] == "Schnozzberry"
+      - test_six['msg'] == "vrf Test VRF One deleted"

--- a/tests/integration/v2.7/main.yml
+++ b/tests/integration/v2.7/main.yml
@@ -1,0 +1,109 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  collections:
+    - netbox.netbox
+
+  tasks:
+    - name: "NETBOX_DEVICE TESTS"
+      include_tasks: "tasks/netbox_device.yml"
+    
+    - name: "NETBOX_DEVICE_INTERFACE TESTS"
+      include_tasks: "tasks/netbox_device_interface.yml"
+    
+    - name: "NETBOX_IP_ADDRESS TESTS"
+      include_tasks: "tasks/netbox_ip_address.yml"
+    
+    - name: "NETBOX_PREFIX TESTS"
+      include_tasks: "tasks/netbox_prefix.yml"
+    
+    - name: "NETBOX_SITE TESTS"
+      include_tasks: "tasks/netbox_site.yml"
+    
+    - name: "NETBOX_TENTANT TESTS"
+      include_tasks: "tasks/netbox_tenant.yml"
+    
+    - name: "NETBOX_TENTANT_GROUP TESTS"
+      include_tasks: "tasks/netbox_tenant_group.yml"
+    
+    - name: "NETBOX_RACK TESTS"
+      include_tasks: "tasks/netbox_rack.yml"
+    
+    - name: "NETBOX_RACK_ROLE TESTS"
+      include_tasks: "tasks/netbox_rack_role.yml"
+    
+    - name: "NETBOX_RACK_GROUP TESTS"
+      include_tasks: "tasks/netbox_rack_group.yml"
+    
+    - name: "NETBOX_MANUFACTURER TESTS"
+      include_tasks: "tasks/netbox_manufacturer.yml"
+    
+    - name: "NETBOX_PLATFORM TESTS"
+      include_tasks: "tasks/netbox_platform.yml"
+    
+    - name: "NETBOX_DEVICE_TYPE TESTS"
+      include_tasks: "tasks/netbox_device_type.yml"
+    
+    - name: "NETBOX_DEVICE_ROLE TESTS"
+      include_tasks: "tasks/netbox_device_role.yml"
+    
+    - name: "NETBOX_IPAM_ROLE TESTS"
+      include_tasks: "tasks/netbox_ipam_role.yml"
+    
+    - name: "NETBOX_VLAN_GROUP TESTS"
+      include_tasks: "tasks/netbox_vlan_group.yml"
+    
+    - name: "NETBOX_VLAN TESTS"
+      include_tasks: "tasks/netbox_vlan.yml"
+    
+    - name: "NETBOX_VRF TESTS"
+      include_tasks: "tasks/netbox_vrf.yml"
+    
+    - name: "NETBOX_RIR TESTS"
+      include_tasks: "tasks/netbox_rir.yml"
+    
+    - name: "NETBOX_AGGREGATE TESTS"
+      include_tasks: "tasks/netbox_aggregate.yml"
+    
+    - name: "NETBOX_REGION TESTS"
+      include_tasks: "tasks/netbox_region.yml"
+    
+    - name: "NETBOX_DEVICE_BAY TESTS"
+      include_tasks: "tasks/netbox_device_bay.yml"
+    
+    - name: "NETBOX_INVENTORY_ITEM TESTS"
+      include_tasks: "tasks/netbox_inventory_item.yml"
+    
+    - name: "NETBOX_VIRTUAL_MACHINE TESTS"
+      include_tasks: "tasks/netbox_virtual_machine.yml"
+    
+    - name: "NETBOX_CLUSTER TESTS"
+      include_tasks: "tasks/netbox_cluster.yml"
+    
+    - name: "NETBOX_CLUSTER_GROUP TESTS"
+      include_tasks: "tasks/netbox_cluster_group.yml"
+    
+    - name: "NETBOX_CLUSTER_TYPE TESTS"
+      include_tasks: "tasks/netbox_cluster_type.yml"
+    
+    - name: "NETBOX_VM_INTERFACE TESTS"
+      include_tasks: "tasks/netbox_vm_interface.yml"
+    
+    - name: "NETBOX_PROVIDER TESTS"
+      include_tasks: "tasks/netbox_provider.yml"
+    
+    - name: "NETBOX_CIRCUIT_TYPE TESTS"
+      include_tasks: "tasks/netbox_circuit_type.yml"
+    
+    - name: "NETBOX_CIRCUIT TESTS"
+      include_tasks: "tasks/netbox_circuit.yml"
+    
+    - name: "NETBOX_CIRCUIT_TERMINATION TESTS"
+      include_tasks: "tasks/netbox_circuit_termination.yml"
+    
+    - name: "NETBOX_SERVICE TESTS"
+      include_tasks: "tasks/netbox_service.yml"
+    
+    - name: "NETBOX_LOOKUP TESTS"
+      include_tasks: "tasks/netbox_lookup.yml"

--- a/tests/integration/v2.7/tasks/netbox_aggregate.yml
+++ b/tests/integration/v2.7/tasks/netbox_aggregate.yml
@@ -1,0 +1,115 @@
+---
+##
+##
+### NETBOX_AGGEGATE
+##
+##
+- name: "AGGREGATE 1: Necessary info creation"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+      rir: "Example RIR"
+    state: present
+  register: test_one
+
+- name: "AGGREGATE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_one['aggregate']['family'] == 4
+      - test_one['aggregate']['rir'] == 1
+      - test_one['msg'] == "aggregate 10.0.0.0/8 created"
+
+- name: "AGGREGATE 2: Create duplicate"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+    state: present
+  register: test_two
+
+- name: "AGGREGATE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_two['aggregate']['family'] == 4
+      - test_two['aggregate']['rir'] == 1
+      - test_two['msg'] == "aggregate 10.0.0.0/8 already exists"
+
+- name: "AGGREGATE 3: ASSERT - Update"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+      rir: "Example RIR"
+      date_added: "1989-01-18"
+      description: "Test Description"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "AGGREGATE 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['date_added'] == "1989-01-18"
+      - test_three['diff']['after']['description'] == "Test Description"
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_three['aggregate']['family'] == 4
+      - test_three['aggregate']['rir'] == 1
+      - test_three['aggregate']['date_added'] == "1989-01-18"
+      - test_three['aggregate']['description'] == "Test Description"
+      - test_three['aggregate']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "aggregate 10.0.0.0/8 updated"
+
+- name: "AGGREGATE 4: ASSERT - Delete"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "10.0.0.0/8"
+    state: absent
+  register: test_four
+
+- name: "AGGREGATE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_four['aggregate']['family'] == 4
+      - test_four['aggregate']['rir'] == 1
+      - test_four['aggregate']['date_added'] == "1989-01-18"
+      - test_four['aggregate']['description'] == "Test Description"
+      - test_four['aggregate']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "aggregate 10.0.0.0/8 deleted"
+
+- name: "AGGREGATE 5: Necessary info creation"
+  netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: "2001::/32"
+      rir: "Example RIR"
+    state: present
+  register: test_five
+
+- name: "AGGREGATE 5: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['aggregate']['prefix'] == "2001::/32"
+      - test_five['aggregate']['family'] == 6
+      - test_five['aggregate']['rir'] == 1
+      - test_five['msg'] == "aggregate 2001::/32 created"

--- a/tests/integration/v2.7/tasks/netbox_circuit.yml
+++ b/tests/integration/v2.7/tasks/netbox_circuit.yml
@@ -1,0 +1,109 @@
+---
+##
+##
+### NETBOX_CIRCUIT
+##
+##
+- name: "NETBOX_CIRCUIT 1: Create provider within Netbox with only required information"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+    state: present
+  register: test_one
+
+- name: "NETBOX_CIRCUIT 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit']['cid'] == "Test Circuit One"
+      - test_one['circuit']['provider'] == 1
+      - test_one['circuit']['type'] == 1
+      - test_one['msg'] == "circuit Test Circuit One created"
+
+- name: "NETBOX_CIRCUIT 2: Duplicate"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+    state: present
+  register: test_two
+
+- name: "NETBOX_CIRCUIT 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit']['cid'] == "Test Circuit One"
+      - test_two['circuit']['provider'] == 1
+      - test_two['circuit']['type'] == 1
+      - test_two['msg'] == "circuit Test Circuit One already exists"
+
+- name: "NETBOX_CIRCUIT 3: Update provider with other fields"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+      status: Planned
+      tenant: Test Tenant
+      install_date: "2018-12-25"
+      commit_rate: 10000
+      description: Test circuit
+      comments: "FAST CIRCUIT"
+    state: present
+  register: test_three
+
+- name: "NETBOX_CIRCUIT 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['diff']['after']['install_date'] == "2018-12-25"
+      - test_three['diff']['after']['commit_rate'] == 10000
+      - test_three['diff']['after']['description'] == "Test circuit"
+      - test_three['diff']['after']['comments'] == "FAST CIRCUIT"
+      - test_three['circuit']['cid'] == "Test Circuit One"
+      - test_three['circuit']['provider'] == 1
+      - test_three['circuit']['type'] == 1
+      - test_three['circuit']['status'] == "planned"
+      - test_three['circuit']['tenant'] == 1
+      - test_three['circuit']['install_date'] == "2018-12-25"
+      - test_three['circuit']['commit_rate'] == 10000
+      - test_three['circuit']['description'] == "Test circuit"
+      - test_three['circuit']['comments'] == "FAST CIRCUIT"
+      - test_three['msg'] == "circuit Test Circuit One updated"
+
+- name: "NETBOX_CIRCUIT 4: Delete provider within netbox"
+  netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      cid: Test Circuit One
+    state: absent
+  register: test_four
+
+- name: "NETBOX_CIRCUIT 4 : ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['circuit']['cid'] == "Test Circuit One"
+      - test_four['circuit']['provider'] == 1
+      - test_four['circuit']['type'] == 1
+      - test_four['circuit']['status'] == "planned"
+      - test_four['circuit']['tenant'] == 1
+      - test_four['circuit']['install_date'] == "2018-12-25"
+      - test_four['circuit']['commit_rate'] == 10000
+      - test_four['circuit']['description'] == "Test circuit"
+      - test_four['circuit']['comments'] == "FAST CIRCUIT"
+      - test_four['msg'] == "circuit Test Circuit One deleted"

--- a/tests/integration/v2.7/tasks/netbox_circuit_termination.yml
+++ b/tests/integration/v2.7/tasks/netbox_circuit_termination.yml
@@ -1,0 +1,129 @@
+---
+##
+##
+### NETBOX_CIRCUIT_TERMINATION
+##
+##
+- name: "NETBOX_CIRCUIT_TERMINATION 1: Create provider within Netbox with only required information"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+      site: "Test Site"
+      port_speed: 10000
+    state: present
+  register: test_one
+
+- name: "NETBOX_CIRCUIT_TERMINATION 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit_termination']['circuit'] == 1
+      - test_one['circuit_termination']['term_side'] == "A"
+      - test_one['circuit_termination']['site'] == 1
+      - test_one['circuit_termination']['port_speed'] == 10000
+      - test_one['msg'] == "circuit_termination test_circuit_a created"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 2: Duplicate"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+    state: present
+  register: test_two
+
+- name: "NETBOX_CIRCUIT_TERMINATION 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit_termination']['circuit'] == 1
+      - test_two['circuit_termination']['term_side'] == "A"
+      - test_two['circuit_termination']['site'] == 1
+      - test_two['circuit_termination']['port_speed'] == 10000
+      - test_two['msg'] == "circuit_termination test_circuit_a already exists"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 3: Update provider with other fields"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+      upstream_speed: 1000
+      xconnect_id: 10X100
+      pp_info: PP10-24
+      description: "Test description"
+    state: present
+  register: test_three
+
+- name: "NETBOX_CIRCUIT_TERMINATION 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['upstream_speed'] == 1000
+      - test_three['diff']['after']['xconnect_id'] == "10X100"
+      - test_three['diff']['after']['pp_info'] == "PP10-24"
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['circuit_termination']['circuit'] == 1
+      - test_three['circuit_termination']['term_side'] == "A"
+      - test_three['circuit_termination']['site'] == 1
+      - test_three['circuit_termination']['port_speed'] == 10000
+      - test_three['circuit_termination']['upstream_speed'] == 1000
+      - test_three['circuit_termination']['xconnect_id'] == "10X100"
+      - test_three['circuit_termination']['pp_info'] == "PP10-24"
+      - test_three['circuit_termination']['description'] == "Test description"
+      - test_three['msg'] == "circuit_termination test_circuit_a updated"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 4: Create Z Side"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: Z
+      site: "Test Site"
+      port_speed: 10000
+    state: present
+  register: test_four
+
+- name: "NETBOX_CIRCUIT_TERMINATION 4: ASSERT - Create Z Side"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['circuit_termination']['circuit'] == 1
+      - test_four['circuit_termination']['term_side'] == "Z"
+      - test_four['circuit_termination']['site'] == 1
+      - test_four['circuit_termination']['port_speed'] == 10000
+      - test_four['msg'] == "circuit_termination test_circuit_z created"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 5: Delete provider within netbox"
+  netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      circuit: Test Circuit
+      term_side: A
+    state: absent
+  register: test_five
+
+- name: "NETBOX_CIRCUIT_TERMINATION 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['circuit_termination']['circuit'] == 1
+      - test_five['circuit_termination']['term_side'] == "A"
+      - test_five['circuit_termination']['site'] == 1
+      - test_five['circuit_termination']['port_speed'] == 10000
+      - test_five['circuit_termination']['upstream_speed'] == 1000
+      - test_five['circuit_termination']['xconnect_id'] == "10X100"
+      - test_five['circuit_termination']['pp_info'] == "PP10-24"
+      - test_five['circuit_termination']['description'] == "Test description"
+      - test_five['msg'] == "circuit_termination test_circuit_a deleted"

--- a/tests/integration/v2.7/tasks/netbox_circuit_type.yml
+++ b/tests/integration/v2.7/tasks/netbox_circuit_type.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_CIRCUIT_TYPE
+##
+##
+- name: "CIRCUIT_TYPE 1: Necessary info creation"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type One"
+    state: present
+  register: test_one
+
+- name: "CIRCUIT_TYPE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit_type']['name'] == "Test Circuit Type One"
+      - test_one['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_one['msg'] == "circuit_type Test Circuit Type One created"
+
+- name: "CIRCUIT_TYPE 2: Create duplicate"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type One"
+    state: present
+  register: test_two
+
+- name: "CIRCUIT_TYPE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit_type']['name'] == "Test Circuit Type One"
+      - test_two['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_two['msg'] == "circuit_type Test Circuit Type One already exists"
+
+- name: "CIRCUIT_TYPE 3: User specified slug"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type Two"
+      slug: "test-circuit-type-2"
+    state: present
+  register: test_three
+
+- name: "CIRCUIT_TYPE 3: ASSERT - User specified slug"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['circuit_type']['name'] == "Test Circuit Type Two"
+      - test_three['circuit_type']['slug'] == "test-circuit-type-2"
+      - test_three['msg'] == "circuit_type Test Circuit Type Two created"
+
+- name: "CIRCUIT_TYPE 4: ASSERT - Delete"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type One"
+    state: absent
+  register: test_four
+
+- name: "CIRCUIT_TYPE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['circuit_type']['name'] == "Test Circuit Type One"
+      - test_four['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_four['msg'] == "circuit_type Test Circuit Type One deleted"
+
+- name: "CIRCUIT_TYPE 5: ASSERT - Delete"
+  netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Circuit Type Two"
+      slug: "test-circuit-type-2"
+    state: absent
+  register: test_five
+
+- name: "CIRCUIT_TYPE 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['circuit_type']['name'] == "Test Circuit Type Two"
+      - test_five['circuit_type']['slug'] == "test-circuit-type-2"
+      - test_five['msg'] == "circuit_type Test Circuit Type Two deleted"

--- a/tests/integration/v2.7/tasks/netbox_cluster.yml
+++ b/tests/integration/v2.7/tasks/netbox_cluster.yml
@@ -1,0 +1,95 @@
+---
+##
+##
+### NETBOX_CLUSTER
+##
+##
+- name: "CLUSTER 1: Necessary info creation"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+      cluster_type: "Test Cluster Type"
+    state: present
+  register: test_one
+
+- name: "CLUSTER 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster']['name'] == "Test Cluster One"
+      - test_one['cluster']['type'] == 1
+      - test_one['msg'] == "cluster Test Cluster One created"
+
+- name: "CLUSTER 2: Create duplicate"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+      cluster_type: "Test Cluster Type"
+    state: present
+  register: test_two
+
+- name: "CLUSTER 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster']['name'] == "Test Cluster One"
+      - test_two['cluster']['type'] == 1
+      - test_two['msg'] == "cluster Test Cluster One already exists"
+
+- name: "CLUSTER 3: Update"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+      cluster_type: "Test Cluster Type"
+      cluster_group: "Test Cluster Group"
+      site: "Test Site"
+      comments: "Updated cluster"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "CLUSTER 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['group'] == 1
+      - test_three['diff']['after']['site'] == 1
+      - test_three['diff']['after']['comments'] == "Updated cluster"
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['cluster']['name'] == "Test Cluster One"
+      - test_three['cluster']['type'] == 1
+      - test_three['cluster']['group'] == 1
+      - test_three['cluster']['site'] == 1
+      - test_three['cluster']['comments'] == "Updated cluster"
+      - test_three['cluster']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "cluster Test Cluster One updated"
+
+- name: "CLUSTER 4: ASSERT - Delete"
+  netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster One"
+    state: absent
+  register: test_four
+
+- name: "CLUSTER 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['cluster']['name'] == "Test Cluster One"
+      - test_four['cluster']['type'] == 1
+      - test_four['cluster']['group'] == 1
+      - test_four['cluster']['site'] == 1
+      - test_four['cluster']['comments'] == "Updated cluster"
+      - test_four['cluster']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "cluster Test Cluster One deleted"

--- a/tests/integration/v2.7/tasks/netbox_cluster_group.yml
+++ b/tests/integration/v2.7/tasks/netbox_cluster_group.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_CLUSTER_GROUP
+##
+##
+- name: "CLUSTER_GROUP 1: Necessary info creation"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group One"
+    state: present
+  register: test_one
+
+- name: "CLUSTER_GROUP 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster_group']['name'] == "Test Cluster Group One"
+      - test_one['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_one['msg'] == "cluster_group Test Cluster Group One created"
+
+- name: "CLUSTER_GROUP 2: Create duplicate"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group One"
+    state: present
+  register: test_two
+
+- name: "CLUSTER_GROUP 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster_group']['name'] == "Test Cluster Group One"
+      - test_two['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_two['msg'] == "cluster_group Test Cluster Group One already exists"
+
+- name: "CLUSTER_GROUP 3: User specified slug"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group Two"
+      slug: "test-cluster-group-2"
+    state: present
+  register: test_three
+
+- name: "CLUSTER_GROUP 3: ASSERT - User specified slug"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['cluster_group']['name'] == "Test Cluster Group Two"
+      - test_three['cluster_group']['slug'] == "test-cluster-group-2"
+      - test_three['msg'] == "cluster_group Test Cluster Group Two created"
+
+- name: "CLUSTER_GROUP 4: ASSERT - Delete"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group One"
+    state: absent
+  register: test_four
+
+- name: "CLUSTER_GROUP 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['cluster_group']['name'] == "Test Cluster Group One"
+      - test_four['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_four['msg'] == "cluster_group Test Cluster Group One deleted"
+
+- name: "CLUSTER_GROUP 5: ASSERT - Delete"
+  netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Group Two"
+      slug: "test-cluster-group-2"
+    state: absent
+  register: test_five
+
+- name: "CLUSTER_GROUP 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['cluster_group']['name'] == "Test Cluster Group Two"
+      - test_five['cluster_group']['slug'] == "test-cluster-group-2"
+      - test_five['msg'] == "cluster_group Test Cluster Group Two deleted"

--- a/tests/integration/v2.7/tasks/netbox_cluster_type.yml
+++ b/tests/integration/v2.7/tasks/netbox_cluster_type.yml
@@ -1,0 +1,95 @@
+##
+##
+### NETBOX_CLUSTER_TYPE
+##
+##
+- name: "CLUSTER_TYPE 1: Necessary info creation"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type One"
+    state: present
+  register: test_one
+
+- name: "CLUSTER_TYPE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster_type']['name'] == "Test Cluster Type One"
+      - test_one['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_one['msg'] == "cluster_type Test Cluster Type One created"
+
+- name: "CLUSTER_TYPE 2: Create duplicate"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type One"
+    state: present
+  register: test_two
+
+- name: "CLUSTER_TYPE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster_type']['name'] == "Test Cluster Type One"
+      - test_two['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_two['msg'] == "cluster_type Test Cluster Type One already exists"
+
+- name: "CLUSTER_TYPE 3: User specified slug"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type Two"
+      slug: "test-cluster-type-2"
+    state: present
+  register: test_three
+
+- name: "CLUSTER_TYPE 3: ASSERT - User specified slug"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['cluster_type']['name'] == "Test Cluster Type Two"
+      - test_three['cluster_type']['slug'] == "test-cluster-type-2"
+      - test_three['msg'] == "cluster_type Test Cluster Type Two created"
+
+- name: "CLUSTER_TYPE 4: ASSERT - Delete"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type One"
+    state: absent
+  register: test_four
+
+- name: "CLUSTER_TYPE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['cluster_type']['name'] == "Test Cluster Type One"
+      - test_four['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_four['msg'] == "cluster_type Test Cluster Type One deleted"
+
+- name: "CLUSTER_TYPE 5: ASSERT - Delete"
+  netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Cluster Type Two"
+      slug: "test-cluster-type-2"
+    state: absent
+  register: test_five
+
+- name: "CLUSTER_TYPE 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['cluster_type']['name'] == "Test Cluster Type Two"
+      - test_five['cluster_type']['slug'] == "test-cluster-type-2"
+      - test_five['msg'] == "cluster_type Test Cluster Type Two deleted"

--- a/tests/integration/v2.7/tasks/netbox_device.yml
+++ b/tests/integration/v2.7/tasks/netbox_device.yml
@@ -1,0 +1,201 @@
+---
+##
+##
+### NETBOX_DEVICE
+##
+##
+- name: "1 - Device with required information"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == 'absent'
+      - test_one['diff']['after']['state'] == 'present'
+      - test_one['device']['name'] == "R1"
+      - test_one['device']['device_role'] == 1
+      - test_one['device']['device_type'] == 1
+      - test_one['device']['site'] == 1
+      - test_one['device']['status'] == "staged"
+      - test_one['device']['name'] == "R1"
+      - test_one['msg'] == "device R1 created"
+
+- name: "2 - Duplicate device"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['device']['name'] == "R1"
+      - test_two['device']['device_role'] == 1
+      - test_two['device']['device_type'] == 1
+      - test_two['device']['site'] == 1
+      - test_two['device']['status'] == "staged"
+      - test_two['msg'] == "device R1 already exists"
+
+- name: "3 - Update device"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+      serial: "FXS1001"
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['serial'] == "FXS1001"
+      - test_three['device']['name'] == "R1"
+      - test_three['device']['device_role'] == 1
+      - test_three['device']['device_type'] == 1
+      - test_three['device']['site'] == 1
+      - test_three['device']['status'] == "staged"
+      - test_three['device']['serial'] == "FXS1001"
+      - test_three['msg'] == "device R1 updated"
+
+- name: "4 - Create device with tags and assign to rack"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "TestR1"
+      device_type: "Arista Test"
+      device_role: "Core Switch"
+      site: "Test Site2"
+      rack: "Test Rack"
+      position: 35
+      face: "Front"
+      tags:
+        - "Schnozzberry"
+      tenant: "Test Tenant"
+      asset_tag: "1234"
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['device']['name'] == "TestR1"
+      - test_four['device']['device_role'] == 1
+      - test_four['device']['device_type'] == 2
+      - test_four['device']['site'] == 2
+      - test_four['device']['status'] == "active"
+      - test_four['device']['rack'] == 1
+      - test_four['device']['tags'][0] == 'Schnozzberry'
+      - test_four['device']['tenant'] == 1
+      - test_four['device']['asset_tag'] == '1234'
+      - test_four['msg'] == "device TestR1 created"
+
+- name: "5 - Delete previous device"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "TestR1"
+    state: absent
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "device TestR1 deleted"
+
+- name: "6 - Delete R1"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "R1"
+    state: absent
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "present"
+      - test_six['diff']['after']['state'] == "absent"
+      - test_six['msg'] == "device R1 deleted"
+
+- name: "7 - Add primary_ip4/6 to test100"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "test100"
+      primary_ip4: "172.16.180.1/24"
+      primary_ip6: "2001::1:1/64"
+    state: present
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['after']['primary_ip4'] == 1
+      - test_seven['diff']['after']['primary_ip6'] == 2
+      - test_seven['device']['name'] == "test100"
+      - test_seven['device']['device_role'] == 1
+      - test_seven['device']['device_type'] == 1
+      - test_seven['device']['site'] == 1
+      - test_seven['device']['status'] == "active"
+      - test_seven['device']['primary_ip4'] == 1
+      - test_seven['device']['primary_ip6'] == 2
+      - test_seven['msg'] == "device test100 updated"
+
+- name: "8 - Device with empty string name"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: ""
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == 'absent'
+      - test_eight['diff']['after']['state'] == 'present'
+      - test_eight['device']['device_role'] == 1
+      - test_eight['device']['device_type'] == 1
+      - test_eight['device']['site'] == 1
+      - test_eight['device']['status'] == "staged"
+      - "'-' in test_eight['device']['name']"
+      - "test_eight['device']['name'] | length == 36"

--- a/tests/integration/v2.7/tasks/netbox_device_bay.yml
+++ b/tests/integration/v2.7/tasks/netbox_device_bay.yml
@@ -1,0 +1,87 @@
+---
+##
+##
+### NETBOX_DEVICE_BAY
+##
+##
+- name: "DEVICE_BAY 1: Necessary info creation"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "Test Nexus One"
+      name: "Device Bay One"
+    state: present
+  register: test_one
+
+- name: "DEVICE_BAY 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_bay']['name'] == "Device Bay One"
+      - test_one['device_bay']['device'] == 4
+      - test_one['msg'] == "device_bay Device Bay One created"
+
+- name: "DEVICE_BAY 2: Create duplicate"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "Test Nexus One"
+      name: "Device Bay One"
+    state: present
+  register: test_two
+
+- name: "DEVICE_BAY 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['device_bay']['name'] == "Device Bay One"
+      - test_two['device_bay']['device'] == 4
+      - test_two['msg'] == "device_bay Device Bay One already exists"
+
+- name: "DEVICE_BAY 3: ASSERT - Update"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "Test Nexus One"
+      name: "Device Bay One"
+      installed_device: "Test Nexus Child One"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "DEVICE_BAY 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['installed_device'] == 5
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['device_bay']['name'] == "Device Bay One"
+      - test_three['device_bay']['device'] == 4
+      - test_three['device_bay']['installed_device'] == 5
+      - test_three['device_bay']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "device_bay Device Bay One updated"
+
+- name: "DEVICE_BAY 4: ASSERT - Delete"
+  netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Device Bay One"
+    state: absent
+  register: test_four
+
+- name: "DEVICE_BAY 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['device_bay']['name'] == "Device Bay One"
+      - test_four['device_bay']['device'] == 4
+      - test_four['device_bay']['installed_device'] == 5
+      - test_four['device_bay']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "device_bay Device Bay One deleted"

--- a/tests/integration/v2.7/tasks/netbox_device_interface.yml
+++ b/tests/integration/v2.7/tasks/netbox_device_interface.yml
@@ -1,0 +1,282 @@
+---
+##
+##
+### NETBOX_DEVICE_INTERFACE
+##
+##
+- name: "1 - Interface with required information"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      form_factor: "1000Base-T (1GE)"
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['msg'] == "interface GigabitEthernet3 created"
+      - test_one['diff']['before']['state'] == 'absent'
+      - test_one['diff']['after']['state'] == 'present'
+      - test_one['interface']['name'] == "GigabitEthernet3"
+      - test_one['interface']['device'] == 1
+
+- name: "2 - Update test100 - GigabitEthernet3"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      mtu: 1600
+      enabled: false
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - test_two is changed
+      - test_two['msg'] == "interface GigabitEthernet3 updated"
+      - test_two['diff']['after']['enabled'] == false
+      - test_two['diff']['after']['mtu'] == 1600
+      - test_two['interface']['name'] == "GigabitEthernet3"
+      - test_two['interface']['device'] == 1
+      - test_two['interface']['enabled'] == false
+      - test_two['interface']['mtu'] == 1600
+
+- name: "3 - Delete interface test100 - GigabitEthernet3"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+    state: absent
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['msg'] == "interface GigabitEthernet3 deleted"
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+
+- name: "4 - Create LAG with several specified options"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: port-channel1
+      form_factor: Link Aggregation Group (LAG)
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['msg'] == "interface port-channel1 created"
+      - test_four['diff']['before']['state'] == 'absent'
+      - test_four['diff']['after']['state'] == 'present'
+      - test_four['interface']['name'] == "port-channel1"
+      - test_four['interface']['device'] == 1
+      - test_four['interface']['enabled'] == true
+      - test_four['interface']['type'] == "lag"
+      - test_four['interface']['mgmt_only'] == false
+      - test_four['interface']['mode'] == "access"
+      - test_four['interface']['mtu'] == 1600
+
+- name: "5 - Create interface and assign it to parent LAG"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      enabled: false
+      form_factor: 1000Base-T (1GE)
+      lag:
+        name: port-channel1
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['msg'] == "interface GigabitEthernet3 created"
+      - test_five['diff']['before']['state'] == 'absent'
+      - test_five['diff']['after']['state'] == 'present'
+      - test_five['interface']['name'] == "GigabitEthernet3"
+      - test_five['interface']['device'] == 1
+      - test_five['interface']['enabled'] == false
+      - test_five['interface']['type'] == "1000base-t"
+      - test_five['interface']['mgmt_only'] == false
+      - test_five['interface']['lag'] == 15
+      - test_five['interface']['mode'] == "access"
+      - test_five['interface']['mtu'] == 1600
+
+- name: "6 - Create interface as trunk port"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet21
+      enabled: false
+      form_factor: 1000Base-T (1GE)
+      untagged_vlan:
+        name: Wireless
+        site: Test Site
+      tagged_vlans:
+        - name: Data
+          site: Test Site
+        - name: VoIP
+          site: Test Site
+      mtu: 1600
+      mgmt_only: true
+      mode: Tagged
+    state: present
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['msg'] == "interface GigabitEthernet21 created"
+      - test_six['diff']['before']['state'] == 'absent'
+      - test_six['diff']['after']['state'] == 'present'
+      - test_six['interface']['name'] == "GigabitEthernet21"
+      - test_six['interface']['device'] == 1
+      - test_six['interface']['enabled'] == false
+      - test_six['interface']['type'] == "1000base-t"
+      - test_six['interface']['mgmt_only'] == true
+      - test_six['interface']['mode'] == "tagged"
+      - test_six['interface']['mtu'] == 1600
+      - test_six['interface']['tagged_vlans'] == [2, 3]
+      - test_six['interface']['untagged_vlan'] == 1
+
+- name: "7 - Duplicate Interface"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet1
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['msg'] == "interface GigabitEthernet1 already exists"
+      - test_seven['interface']['name'] == "GigabitEthernet1"
+      - test_seven['interface']['device'] == 1
+
+- name: "8 - Create interface and assign it to parent LAG - non dict"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet4
+      enabled: false
+      form_factor: 1000Base-T (1GE)
+      lag: "port-channel1"
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['msg'] == "interface GigabitEthernet4 created"
+      - test_eight['diff']['before']['state'] == 'absent'
+      - test_eight['diff']['after']['state'] == 'present'
+      - test_eight['interface']['name'] == "GigabitEthernet4"
+      - test_eight['interface']['device'] == 1
+      - test_eight['interface']['enabled'] == false
+      - test_eight['interface']['type'] == "1000base-t"
+      - test_eight['interface']['mgmt_only'] == false
+      - test_eight['interface']['lag'] == 15
+      - test_eight['interface']['mode'] == "access"
+      - test_eight['interface']['mtu'] == 1600
+
+- name: "9 - Create interface on VC child"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus Child One
+      name: Ethernet2/1
+      form_factor: 1000Base-T (1GE)
+    state: present
+  register: test_nine
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['msg'] == "interface Ethernet2/1 created"
+      - test_nine['diff']['before']['state'] == 'absent'
+      - test_nine['diff']['after']['state'] == 'present'
+      - test_nine['interface']['name'] == "Ethernet2/1"
+      - test_nine['interface']['device'] == 5
+      - test_nine['interface']['enabled'] == true
+      - test_nine['interface']['type'] == "1000base-t"
+
+- name: "10 - Update interface on VC child"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Ethernet2/1
+      description: "Updated child interface from parent device"
+    update_vc_child: True
+    state: present
+  register: test_ten
+
+- name: "10 - ASSERT"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['msg'] == "interface Ethernet2/1 updated"
+      - test_ten['diff']['after']['description'] == 'Updated child interface from parent device'
+      - test_ten['interface']['name'] == "Ethernet2/1"
+      - test_ten['interface']['device'] == 5
+      - test_ten['interface']['enabled'] == true
+      - test_ten['interface']['type'] == "1000base-t"
+      - test_ten['interface']['description'] == 'Updated child interface from parent device'
+
+- name: "11 - Update interface on VC child w/o update_vc_child"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Ethernet2/1
+      description: "Updated child interface from parent device - test"
+    state: present
+  ignore_errors: yes
+  register: test_eleven
+
+- name: "11 - ASSERT"
+  assert:
+    that:
+      - test_eleven is failed
+      - test_eleven['msg'] == "Must set update_vc_child to True to allow child device interface modification"

--- a/tests/integration/v2.7/tasks/netbox_device_role.yml
+++ b/tests/integration/v2.7/tasks/netbox_device_role.yml
@@ -1,0 +1,101 @@
+---
+##
+##
+### NETBOX_DEVICE_ROLE
+##
+##
+- name: "DEVICE_ROLE 1: Necessary info creation"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Device Role"
+      color: "FFFFFF"
+    state: present
+  register: test_one
+
+- name: "DEVICE_ROLE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_role']['name'] == "Test Device Role"
+      - test_one['device_role']['slug'] == "test-device-role"
+      - test_one['device_role']['color'] == "ffffff"
+      - test_one['msg'] == "device_role Test Device Role created"
+
+- name: "DEVICE_ROLE 2: Create duplicate"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Device Role"
+      color: "FFFFFF"
+    state: present
+  register: test_two
+
+- name: "DEVICE_ROLE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['device_role']['name'] == "Test Device Role"
+      - test_two['device_role']['slug'] == "test-device-role"
+      - test_two['device_role']['color'] == "ffffff"
+      - test_two['msg'] == "device_role Test Device Role already exists"
+
+- name: "DEVICE_ROLE 3: ASSERT - Update"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Device Role"
+      color: "003EFF"
+      vm_role: false
+    state: present
+  register: test_three
+
+- name: "DEVICE_ROLE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "003eff"
+      - test_three['diff']['after']['vm_role'] == false
+      - test_three['device_role']['name'] == "Test Device Role"
+      - test_three['device_role']['slug'] == "test-device-role"
+      - test_three['device_role']['color'] == "003eff"
+      - test_three['device_role']['vm_role'] == false
+      - test_three['msg'] == "device_role Test Device Role updated"
+
+- name: "DEVICE_ROLE 4: ASSERT - Delete"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Device Role
+    state: absent
+  register: test_four
+
+- name: "DEVICE_ROLE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "device_role Test Device Role deleted"
+
+- name: "DEVICE_ROLE 5: ASSERT - Delete non existing"
+  netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Device Role
+    state: absent
+  register: test_five
+
+- name: "DEVICE_ROLE 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['device_role'] == None
+      - test_five['msg'] == "device_role Test Device Role already absent"

--- a/tests/integration/v2.7/tasks/netbox_device_type.yml
+++ b/tests/integration/v2.7/tasks/netbox_device_type.yml
@@ -1,0 +1,131 @@
+---
+##
+##
+### NETBOX_DEVICE_TYPE
+##
+##
+- name: "DEVICE_TYPE 1: Necessary info creation"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      slug: test-device-type
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_one
+
+- name: "DEVICE_TYPE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_type']['slug'] == "test-device-type"
+      - test_one['device_type']['model'] == "ws-test-3750"
+      - test_one['device_type']['manufacturer'] == 3
+      - test_one['msg'] == "device_type test-device-type created"
+
+- name: "DEVICE_TYPE 2: Create duplicate"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      slug: test-device-type
+      model: "ws-test-3750"
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_two
+
+- name: "DEVICE_TYPE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_one['device_type']['slug'] == "test-device-type"
+      - test_one['device_type']['model'] == "ws-test-3750"
+      - test_one['device_type']['manufacturer'] == 3
+      - test_two['msg'] == "device_type test-device-type already exists"
+
+- name: "DEVICE_TYPE 3: ASSERT - Update"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      slug: test-device-type
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+      part_number: ws-3750g-v2
+      u_height: 1
+      is_full_depth: false
+      subdevice_role: parent
+    state: present
+  register: test_three
+
+- name: "DEVICE_TYPE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['is_full_depth'] == false
+      - test_three['diff']['after']['part_number'] == "ws-3750g-v2"
+      - test_three['diff']['after']['subdevice_role'] == "parent"
+      - test_three['device_type']['slug'] == "test-device-type"
+      - test_three['device_type']['model'] == "ws-test-3750"
+      - test_three['device_type']['manufacturer'] == 3
+      - test_three['device_type']['is_full_depth'] == false
+      - test_three['device_type']['part_number'] == "ws-3750g-v2"
+      - test_three['device_type']['subdevice_role'] == "parent"
+      - test_three['msg'] == "device_type test-device-type updated"
+
+- name: "DEVICE_TYPE 4: ASSERT - Delete"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: test-device-type
+    state: absent
+  register: test_four
+
+- name: "DEVICE_TYPE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "device_type test-device-type deleted"
+
+- name: "DEVICE_TYPE 5: ASSERT - Delete non existing"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: "Test Device Type"
+    state: absent
+  register: test_five
+
+- name: "DEVICE_TYPE 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['device_type'] == None
+      - test_five['msg'] == "device_type Test Device Type already absent"
+
+- name: "DEVICE_TYPE 6: Without Slug"
+  netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: "WS Test 3850"
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_six
+
+- name: "DEVICE_TYPE 6: ASSERT - Without Slug"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['device_type']['slug'] == "ws-test-3850"
+      - test_six['device_type']['model'] == "WS Test 3850"
+      - test_six['device_type']['manufacturer'] == 3
+      - test_six['msg'] == "device_type WS Test 3850 created"

--- a/tests/integration/v2.7/tasks/netbox_inventory_item.yml
+++ b/tests/integration/v2.7/tasks/netbox_inventory_item.yml
@@ -1,0 +1,104 @@
+---
+##
+##
+### NETBOX_INVENTORY_ITEM
+##
+##
+- name: "INVENTORY_ITEM 1: Necessary info creation"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+    state: present
+  register: test_one
+
+- name: "INVENTORY_ITEM 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['inventory_item']['name'] == "10G-SFP+"
+      - test_one['inventory_item']['device'] == 1
+      - test_one['msg'] == "inventory_item 10G-SFP+ created"
+
+- name: "INVENTORY_ITEM 2: Create duplicate"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+    state: present
+  register: test_two
+
+- name: "INVENTORY_ITEM 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['inventory_item']['name'] == "10G-SFP+"
+      - test_two['inventory_item']['device'] == 1
+      - test_two['msg'] == "inventory_item 10G-SFP+ already exists"
+
+- name: "INVENTORY_ITEM 3: ASSERT - Update"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+      manufacturer: "Cisco"
+      part_id: "10G-SFP+"
+      serial: "1234"
+      asset_tag: "1234"
+      description: "New SFP"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "INVENTORY_ITEM 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['asset_tag'] == "1234"
+      - test_three['diff']['after']['serial'] == "1234"
+      - test_three['diff']['after']['description'] == "New SFP"
+      - test_three['diff']['after']['manufacturer'] == 1
+      - test_three['diff']['after']['part_id'] == "10G-SFP+"
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['inventory_item']['name'] == "10G-SFP+"
+      - test_three['inventory_item']['device'] == 1
+      - test_three['inventory_item']['asset_tag'] == "1234"
+      - test_three['inventory_item']['serial'] == "1234"
+      - test_three['inventory_item']['description'] == "New SFP"
+      - test_three['inventory_item']['manufacturer'] == 1
+      - test_three['inventory_item']['part_id'] == "10G-SFP+"
+      - test_three['inventory_item']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "inventory_item 10G-SFP+ updated"
+
+- name: "INVENTORY_ITEM 4: ASSERT - Delete"
+  netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      device: "test100"
+      name: "10G-SFP+"
+    state: absent
+  register: test_four
+
+- name: "INVENTORY_ITEM 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['inventory_item']['name'] == "10G-SFP+"
+      - test_four['inventory_item']['device'] == 1
+      - test_four['inventory_item']['asset_tag'] == "1234"
+      - test_four['inventory_item']['serial'] == "1234"
+      - test_four['inventory_item']['description'] == "New SFP"
+      - test_four['inventory_item']['manufacturer'] == 1
+      - test_four['inventory_item']['part_id'] == "10G-SFP+"
+      - test_four['inventory_item']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "inventory_item 10G-SFP+ deleted"

--- a/tests/integration/v2.7/tasks/netbox_ip_address.yml
+++ b/tests/integration/v2.7/tasks/netbox_ip_address.yml
@@ -1,0 +1,325 @@
+---
+##
+##
+### NETBOX_IP_ADDRESS
+##
+##
+- name: "1 - Create IP address within Netbox with only required information - State: Present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.10/30
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['msg'] == "ip_address 192.168.1.10/30 created"
+      - test_one['ip_address']['address'] == "192.168.1.10/30"
+
+- name: "2 - Update 192.168.1.10/30"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.10/30
+      description: "Updated ip address"
+      tags:
+        - Updated
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - test_two is changed
+      - test_two['diff']['after']['description'] == "Updated ip address"
+      - test_two['diff']['after']['tags'][0] == "Updated"
+      - test_two['msg'] == "ip_address 192.168.1.10/30 updated"
+      - test_two['ip_address']['address'] == "192.168.1.10/30"
+      - test_two['ip_address']['tags'][0] == "Updated"
+      - test_two['ip_address']['description'] == "Updated ip address"
+
+- name: "3 - Delete IP - 192.168.1.10 - State: Absent"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.10/30
+    state: absent
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "ip_address 192.168.1.10/30 deleted"
+
+- name: "4 - Create IP in global VRF - 192.168.1.20/30 - State: Present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.20/30
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['msg'] == "ip_address 192.168.1.20/30 created"
+      - test_four['ip_address']['address'] == "192.168.1.20/30"
+
+- name: "5 - Create IP in global VRF - 192.168.1.20/30 - State: New"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.1.20/30
+    state: new
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['msg'] == "ip_address 192.168.1.20/30 created"
+      - test_five['ip_address']['address'] == "192.168.1.20/30"
+
+- name: "6 - Create new address with only prefix specified - State: new"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 192.168.100.0/24
+    state: new
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['msg'] == "ip_address 192.168.100.1/24 created"
+      - test_six['ip_address']['address'] == "192.168.100.1/24"
+
+- name: "7 - Create IP address with several specified"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 172.16.1.20/24
+      vrf: Test VRF
+      tenant: Test Tenant
+      status: Reserved
+      role: Loopback
+      description: Test description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['msg'] == "ip_address 172.16.1.20/24 created"
+      - test_seven['ip_address']['address'] == "172.16.1.20/24"
+      - test_seven['ip_address']['description'] == "Test description"
+      - test_seven['ip_address']['family'] == 4
+      - test_seven['ip_address']['role'] == "loopback"
+      - test_seven['ip_address']['status'] == "reserved"
+      - test_seven['ip_address']['tags'][0] == "Schnozzberry"
+      - test_seven['ip_address']['tenant'] == 1
+      - test_seven['ip_address']['vrf'] == 1
+
+- name: "8 - Create IP address and assign a nat_inside IP"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 10.10.1.30/16
+      vrf: Test VRF
+      nat_inside:
+        address: 172.16.1.20
+        vrf: Test VRF
+      interface:
+        name: GigabitEthernet1
+        device: test100
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "absent"
+      - test_eight['diff']['after']['state'] == "present"
+      - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
+      - test_eight['ip_address']['address'] == "10.10.1.30/16"
+      - test_eight['ip_address']['family'] == 4
+      - test_eight['ip_address']['interface'] == 2
+      - test_eight['ip_address']['nat_inside'] == 7
+      - test_eight['ip_address']['vrf'] == 1
+
+- name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 10.10.200.30/16
+      interface:
+        name: GigabitEthernet2
+        device: test100
+  register: test_nine
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['msg'] == "ip_address 10.10.200.30/16 created"
+      - test_nine['ip_address']['address'] == "10.10.200.30/16"
+      - test_nine['ip_address']['family'] == 4
+      - test_nine['ip_address']['interface'] == 3
+
+- name: "10 - Create IP address on GigabitEthernet2 - test100 - State: new"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      prefix: 10.10.0.0/16
+      interface:
+        name: GigabitEthernet2
+        device: test100
+    state: new
+  register: test_ten
+
+- name: "10 - ASSERT"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['msg'] == "ip_address 10.10.0.1/16 created"
+      - test_ten['ip_address']['address'] == "10.10.0.1/16"
+      - test_ten['ip_address']['family']['value'] == 4
+      - test_ten['ip_address']['interface']['id'] == 3
+
+- name: "11 - Create IP address on GigabitEthernet2 - test100 - State: present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      prefix: 192.168.100.0/24
+      interface:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  register: test_eleven
+
+- name: "11 - ASSERT"
+  assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "absent"
+      - test_eleven['diff']['after']['state'] == "present"
+      - test_eleven['msg'] == "ip_address 192.168.100.2/24 created"
+      - test_eleven['ip_address']['address'] == "192.168.100.2/24"
+
+- name: "12 - Duplicate - 192.168.100.2/24 on interface"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.100.2/24
+      interface:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  register: test_twelve
+
+- name: "12 - ASSERT"
+  assert:
+    that:
+      - not test_twelve['changed']
+      - test_twelve['msg'] == "ip_address 192.168.100.2/24 already exists"
+      - test_twelve['ip_address']['address'] == "192.168.100.2/24"
+      - test_twelve['ip_address']['interface'] == 3
+
+- name: "13 - Duplicate - 192.168.100.2/24"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 192.168.100.2/24
+    state: present
+  register: test_thirteen
+
+- name: "13 - ASSERT"
+  assert:
+    that:
+      - not test_thirteen['changed']
+      - test_thirteen['msg'] == "ip_address 192.168.100.2/24 already exists"
+      - test_thirteen['ip_address']['address'] == "192.168.100.2/24"
+
+- name: "14 - Create IP address on Eth0 - test100-vm - State: present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      address: 10.188.1.100/24
+      interface:
+        name: Eth0
+        virtual_machine: test100-vm
+  register: test_fourteen
+
+- name: "14 - ASSERT"
+  assert:
+    that:
+      - test_fourteen is changed
+      - test_fourteen['diff']['before']['state'] == "absent"
+      - test_fourteen['diff']['after']['state'] == "present"
+      - test_fourteen['msg'] == "ip_address 10.188.1.100/24 created"
+      - test_fourteen['ip_address']['address'] == "10.188.1.100/24"
+      - test_fourteen['ip_address']['family'] == 4
+      - test_fourteen['ip_address']['interface'] == 4
+
+- name: "15 - Create IP address with no mask - State: Present"
+  netbox_ip_address:
+    netbox_url: http://localhost.org:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      address: 10.120.10.1
+    state: present
+  register: test_fifteen
+
+- name: "15 - ASSERT"
+  assert:
+    that:
+      - test_fifteen is changed
+      - test_fifteen['diff']['before']['state'] == "absent"
+      - test_fifteen['diff']['after']['state'] == "present"
+      - test_fifteen['msg'] == "ip_address 10.120.10.1/32 created"
+      - test_fifteen['ip_address']['address'] == "10.120.10.1/32"

--- a/tests/integration/v2.7/tasks/netbox_ipam_role.yml
+++ b/tests/integration/v2.7/tasks/netbox_ipam_role.yml
@@ -1,0 +1,94 @@
+---
+##
+##
+### NETBOX_IPAM_ROLE
+##
+##
+- name: "IPAM_ROLE 1: Necessary info creation"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test IPAM Role"
+    state: present
+  register: test_one
+
+- name: "IPAM_ROLE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['role']['name'] == "Test IPAM Role"
+      - test_one['role']['slug'] == "test-ipam-role"
+      - test_one['msg'] == "role Test IPAM Role created"
+
+- name: "IPAM_ROLE 2: Create duplicate"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test IPAM Role"
+    state: present
+  register: test_two
+
+- name: "IPAM_ROLE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['role']['name'] == "Test IPAM Role"
+      - test_two['role']['slug'] == "test-ipam-role"
+      - test_two['msg'] == "role Test IPAM Role already exists"
+
+- name: "IPAM_ROLE 3: ASSERT - Update"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test IPAM Role"
+      weight: 4096
+    state: present
+  register: test_three
+
+- name: "IPAM_ROLE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['weight'] == 4096
+      - test_three['role']['name'] == "Test IPAM Role"
+      - test_three['role']['slug'] == "test-ipam-role"
+      - test_three['role']['weight'] == 4096
+      - test_three['msg'] == "role Test IPAM Role updated"
+
+- name: "IPAM_ROLE 4: ASSERT - Delete"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test IPAM Role
+    state: absent
+  register: test_four
+
+- name: "IPAM_ROLE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "role Test IPAM Role deleted"
+
+- name: "IPAM_ROLE 5: ASSERT - Delete non existing"
+  netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test IPAM Role
+    state: absent
+  register: test_five
+
+- name: "IPAM_ROLE 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['role'] == None
+      - test_five['msg'] == "role Test IPAM Role already absent"

--- a/tests/integration/v2.7/tasks/netbox_lookup.yml
+++ b/tests/integration/v2.7/tasks/netbox_lookup.yml
@@ -1,0 +1,69 @@
+---
+##
+##
+### NETBOX_LOOKUP
+##
+##
+- name: "NETBOX_LOOKUP 1: Lookup returns exactly two sites"
+  assert:
+    that: "{{ query_result|count }} == 3"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
+  assert:
+    that: "{{ query_result|json_query('[?value.display_name==`Wibble`]')|count }} == 0"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
+  assert:
+    that: "{{ query_result|json_query('[?value.display_name==`TestDeviceR1`]')|count }} == 1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 4: VLAN ID 400 can be queried and is named 'Test VLAN'"
+  assert:
+    that: "{{ (query_result|json_query('[?value.vid==`400`].value.name'))[0] == 'Test VLAN' }}"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'vlans', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 5: Add one of two devices for lookup filter test."
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "L1"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+      tags:
+        - "nolookup"
+    state: present
+
+- name: "NETBOX_LOOKUP 6: Add two of two devices for lookup filter test."
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "L2"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+      tags:
+        - "lookup"
+    state: present
+
+- name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
+  assert:
+    that: "{{ query_result|json_query('[?value.display_name==`L2`]')|count }} == 1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
+
+- name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
+  assert:
+    that: "{{ query_result|json_query('[?display_name==`L2`]')|count }} == 1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567', raw_data=True) }}"

--- a/tests/integration/v2.7/tasks/netbox_manufacturer.yml
+++ b/tests/integration/v2.7/tasks/netbox_manufacturer.yml
@@ -1,0 +1,91 @@
+---
+##
+##
+### NETBOX_MANUFACTURER
+##
+##
+- name: "MANUFACTURER 1: Necessary info creation"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Manufacturer Two
+    state: present
+  register: test_one
+
+- name: "MANUFACTURER 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['manufacturer']['name'] == "Test Manufacturer Two"
+      - test_one['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_one['msg'] == "manufacturer Test Manufacturer Two created"
+
+- name: "MANUFACTURER 2: Create duplicate"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Manufacturer Two
+    state: present
+  register: test_two
+
+- name: "MANUFACTURER 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['manufacturer']['name'] == "Test Manufacturer Two"
+      - test_two['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_two['msg'] == "manufacturer Test Manufacturer Two already exists"
+
+- name: "MANUFACTURER 3: Update"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: test manufacturer two
+    state: present
+  register: test_three
+
+- name: "MANUFACTURER 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three['changed']
+      - test_three['manufacturer']['name'] == "test manufacturer two"
+      - test_three['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_three['msg'] == "manufacturer test manufacturer two updated"
+
+- name: "MANUFACTURER 4: ASSERT - Delete"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: test manufacturer two
+    state: absent
+  register: test_four
+
+- name: "MANUFACTURER 3: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "manufacturer test manufacturer two deleted"
+
+- name: "MANUFACTURER 5: ASSERT - Delete non existing"
+  netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Manufacturer Two
+    state: absent
+  register: test_five
+
+- name: "MANUFACTURER 5: ASSERT - Delete non existing"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['manufacturer'] == None
+      - test_five['msg'] == "manufacturer Test Manufacturer Two already absent"

--- a/tests/integration/v2.7/tasks/netbox_platform.yml
+++ b/tests/integration/v2.7/tasks/netbox_platform.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_PLATFORM
+##
+##
+- name: "PLATFORM 1: Necessary info creation"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: present
+  register: test_one
+
+- name: "PLATFORM 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['platform']['name'] == "Test Platform"
+      - test_one['platform']['slug'] == "test-platform"
+      - test_one['msg'] == "platform Test Platform created"
+
+- name: "PLATFORM 2: Create duplicate"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: present
+  register: test_two
+
+- name: "PLATFORM 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['platform']['name'] == "Test Platform"
+      - test_two['platform']['slug'] == "test-platform"
+      - test_two['msg'] == "platform Test Platform already exists"
+
+- name: "PLATFORM 3: ASSERT - Update"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+      manufacturer: Test Manufacturer
+      napalm_driver: ios
+      napalm_args:
+        global_delay_factor: 2
+    state: present
+  register: test_three
+
+- name: "PLATFORM 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['manufacturer'] == 3
+      - test_three['diff']['after']['napalm_args']['global_delay_factor'] == 2
+      - test_three['diff']['after']['napalm_driver'] == "ios"
+      - test_three['platform']['manufacturer'] == 3
+      - test_three['platform']['napalm_args']['global_delay_factor'] == 2
+      - test_three['platform']['napalm_driver'] == "ios"
+      - test_three['msg'] == "platform Test Platform updated"
+
+- name: "PLATFORM 4: ASSERT - Delete"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: absent
+  register: test_four
+
+- name: "PLATFORM 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "platform Test Platform deleted"
+
+- name: "PLATFORM 5: ASSERT - Delete non existing"
+  netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Platform
+    state: absent
+  register: test_five
+
+- name: "PLATFORM 5: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['platform'] == None
+      - test_five['msg'] == "platform Test Platform already absent"

--- a/tests/integration/v2.7/tasks/netbox_prefix.yml
+++ b/tests/integration/v2.7/tasks/netbox_prefix.yml
@@ -1,0 +1,245 @@
+---
+##
+##
+### NETBOX_PREFIX
+##
+##
+- name: "1 - Create prefix within Netbox with only required information"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['msg'] == "prefix 10.156.0.0/19 created"
+      - test_one['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: "2 - Duplicate"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "prefix 10.156.0.0/19 already exists"
+      - test_two['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: "3 - Update 10.156.0.0/19"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+      site: Test Site
+      status: Reserved
+      description: "This prefix has been updated"
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['site'] == 1
+      - test_three['diff']['after']['status'] == "reserved"
+      - test_three['diff']['after']['description'] == "This prefix has been updated"
+      - test_three['msg'] == "prefix 10.156.0.0/19 updated"
+      - test_three['prefix']['prefix'] == "10.156.0.0/19"
+      - test_three['prefix']['site'] == 1
+      - test_three['prefix']['status'] == "reserved"
+      - test_three['prefix']['description'] == "This prefix has been updated"
+
+- name: "4 - Delete prefix within netbox"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: absent
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "prefix 10.156.0.0/19 deleted"
+
+- name: "5 - Create prefix with several specified options"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      family: 4
+      prefix: 10.156.32.0/19
+      site: Test Site
+      vrf: Test VRF
+      tenant: Test Tenant
+      vlan:
+        name: Test VLAN
+        site: Test Site
+        tenant: Test Tenant
+        vlan_group: Test Vlan Group
+      status: Reserved
+      prefix_role: Network of care
+      description: Test description
+      is_pool: true
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['msg'] == "prefix 10.156.32.0/19 created"
+      - test_five['prefix']['prefix'] == "10.156.32.0/19"
+      - test_five['prefix']['family'] == 4
+      - test_five['prefix']['site'] == 1
+      - test_five['prefix']['vrf'] == 1
+      - test_five['prefix']['tenant'] == 1
+      - test_five['prefix']['vlan'] == 4
+      - test_five['prefix']['status'] == "reserved"
+      - test_five['prefix']['role'] == 1
+      - test_five['prefix']['description'] == "Test description"
+      - test_five['prefix']['is_pool'] == true
+      - test_five['prefix']['tags'][0] == "Schnozzberry"
+
+- name: "6 - Get a new /24 inside 10.156.0.0/19 within Netbox - Parent doesn't exist"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: yes
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - not test_six['changed']
+      - test_six['msg'] == "Parent prefix does not exist - 10.156.0.0/19"
+
+- name: "7 - Create prefix within Netbox with only required information"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['msg'] == "prefix 10.156.0.0/19 created"
+      - test_seven['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: "8 - Get a new /24 inside 10.156.0.0/19 within Netbox"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: yes
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "absent"
+      - test_eight['diff']['after']['state'] == "present"
+      - test_eight['msg'] == "prefix 10.156.0.0/24 created"
+      - test_eight['prefix']['prefix'] == "10.156.0.0/24"
+
+- name: "9 - Create 10.157.0.0/19"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      prefix: 10.157.0.0/19
+      vrf: Test VRF
+      site: Test Site
+    state: present
+  register: test_nine
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['msg'] == "prefix 10.157.0.0/19 created"
+      - test_nine['prefix']['prefix'] == "10.157.0.0/19"
+      - test_nine['prefix']['site'] == 1
+      - test_nine['prefix']['vrf'] == 1
+
+- name: "10 - Get a new /24 inside 10.157.0.0/19 within Netbox with additional values"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.157.0.0/19
+      prefix_length: 24
+      vrf: Test VRF
+      site: Test Site
+    state: present
+    first_available: yes
+  register: test_ten
+
+- name: "10 - ASSERT"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['msg'] == "prefix 10.157.0.0/24 created"
+      - test_ten['prefix']['prefix'] == "10.157.0.0/24"
+      - test_ten['prefix']['site']['id'] == 1
+      - test_ten['prefix']['vrf']['id'] == 1
+
+- name: "11 - Get a new /24 inside 10.156.0.0/19 within Netbox"
+  netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: yes
+  register: test_eleven
+
+- name: "11 - ASSERT"
+  assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "absent"
+      - test_eleven['diff']['after']['state'] == "present"
+      - test_eleven['msg'] == "prefix 10.156.1.0/24 created"
+      - test_eleven['prefix']['prefix'] == "10.156.1.0/24"

--- a/tests/integration/v2.7/tasks/netbox_provider.yml
+++ b/tests/integration/v2.7/tasks/netbox_provider.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_PROVIDER
+##
+##
+- name: "NETBOX_PROVIDER 1: Create provider within Netbox with only required information"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+    state: present
+  register: test_one
+
+- name: "NETBOX_PROVIDER 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['provider']['name'] == "Test Provider One"
+      - test_one['provider']['slug'] == "test-provider-one"
+      - test_one['msg'] == "provider Test Provider One created"
+
+- name: "NETBOX_PROVIDER 2: Duplicate"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+    state: present
+  register: test_two
+
+- name: "NETBOX_PROVIDER 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['provider']['name'] == "Test Provider One"
+      - test_two['provider']['slug'] == "test-provider-one"
+      - test_two['msg'] == "provider Test Provider One already exists"
+
+- name: "NETBOX_PROVIDER 3: Update provider with other fields"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+      asn: 65001
+      account: "200129104"
+      portal_url: http://provider.net
+      noc_contact: noc@provider.net
+      admin_contact: admin@provider.net
+      comments: "BAD PROVIDER"
+    state: present
+  register: test_three
+
+- name: "NETBOX_PROVIDER 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['asn'] == 65001
+      - test_three['diff']['after']['account'] == "200129104"
+      - test_three['diff']['after']['portal_url'] == "http://provider.net"
+      - test_three['diff']['after']['noc_contact'] == "noc@provider.net"
+      - test_three['diff']['after']['admin_contact'] == "admin@provider.net"
+      - test_three['diff']['after']['comments'] == "BAD PROVIDER"
+      - test_three['provider']['name'] == "Test Provider One"
+      - test_three['provider']['slug'] == "test-provider-one"
+      - test_three['provider']['asn'] == 65001
+      - test_three['provider']['account'] == "200129104"
+      - test_three['provider']['portal_url'] == "http://provider.net"
+      - test_three['provider']['noc_contact'] == "noc@provider.net"
+      - test_three['provider']['admin_contact'] == "admin@provider.net"
+      - test_three['provider']['comments'] == "BAD PROVIDER"
+      - test_three['msg'] == "provider Test Provider One updated"
+
+- name: "NETBOX_PROVIDER 4: Delete provider within netbox"
+  netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test Provider One
+    state: absent
+  register: test_four
+
+- name: "NETBOX_PROVIDER 4 : ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['provider']['name'] == "Test Provider One"
+      - test_four['provider']['slug'] == "test-provider-one"
+      - test_four['provider']['asn'] == 65001
+      - test_four['provider']['account'] == "200129104"
+      - test_four['provider']['portal_url'] == "http://provider.net"
+      - test_four['provider']['noc_contact'] == "noc@provider.net"
+      - test_four['provider']['admin_contact'] == "admin@provider.net"
+      - test_four['provider']['comments'] == "BAD PROVIDER"
+      - test_four['msg'] == "provider Test Provider One deleted"

--- a/tests/integration/v2.7/tasks/netbox_rack.yml
+++ b/tests/integration/v2.7/tasks/netbox_rack.yml
@@ -1,0 +1,177 @@
+---
+##
+##
+### NETBOX_RACK
+##
+##
+- name: "1 - Test rack creation"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test rack one"
+      site: "Test Site"
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack']['name'] == "Test rack one"
+      - test_one['rack']['site'] == 1
+
+- name: "Test duplicate rack"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test rack one"
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack']['name'] == "Test rack one"
+      - test_two['rack']['site'] == 1
+      - test_two['msg'] == "rack Test rack one already exists"
+
+- name: "3 - Create new rack with similar name"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack - Test Site
+      site: Test Site
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['rack']['name'] == "Test rack - Test Site"
+      - test_three['rack']['site'] == 1
+      - test_three['msg'] == "rack Test rack - Test Site created"
+
+- name: "4 - Attempt to create Test rack one again"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack one
+      site: Test Site
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - not test_four['changed']
+      - test_four['rack']['name'] == "Test rack one"
+      - test_four['rack']['site'] == 1
+      - test_four['msg'] == "rack Test rack one already exists"
+
+- name: "5 - Update Test rack one with more options"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack one
+      site: Test Site
+      rack_role: "Test Rack Role"
+      rack_group: "Test Rack Group"
+      facility_id: "EQUI10291"
+      tenant: "Test Tenant"
+      status: Available
+      serial: "FXS10001"
+      asset_tag: "1234"
+      width: 23
+      u_height: 48
+      type: "2-post frame"
+      outer_width: 32
+      outer_depth: 24
+      outer_unit: "Inches"
+      comments: "Just testing rack module"
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['asset_tag'] == "1234"
+      - test_five['diff']['after']['comments'] == "Just testing rack module"
+      - test_five['diff']['after']['facility_id'] == "EQUI10291"
+      - test_five['diff']['after']['group'] == 1
+      - test_five['diff']['after']['outer_depth'] == 24
+      - test_five['diff']['after']['outer_unit'] == "in"
+      - test_five['diff']['after']['outer_width'] == 32
+      - test_five['diff']['after']['role'] == 1
+      - test_five['diff']['after']['serial'] == "FXS10001"
+      - test_five['diff']['after']['status'] == "available"
+      - test_five['diff']['after']['tenant'] == 1
+      - test_five['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_five['diff']['after']['type'] == "2-post-frame"
+      - test_five['diff']['after']['u_height'] == 48
+      - test_five['diff']['after']['width'] == "23"
+      - test_five['rack']['name'] == "Test rack one"
+      - test_five['rack']['site'] == 1
+      - test_five['rack']['asset_tag'] == "1234"
+      - test_five['rack']['comments'] == "Just testing rack module"
+      - test_five['rack']['facility_id'] == "EQUI10291"
+      - test_five['rack']['group'] == 1
+      - test_five['rack']['outer_depth'] == 24
+      - test_five['rack']['outer_unit'] == "in"
+      - test_five['rack']['outer_width'] == 32
+      - test_five['rack']['role'] == 1
+      - test_five['rack']['serial'] == "FXS10001"
+      - test_five['rack']['status'] == "available"
+      - test_five['rack']['tenant'] == 1
+      - test_five['rack']['tags'][0] == "Schnozzberry"
+      - test_five['rack']['type'] == "2-post-frame"
+      - test_five['rack']['u_height'] == 48
+      - test_five['rack']['width'] == "23"
+      - test_five['msg'] == "rack Test rack one updated"
+
+- name: "6 - Create rack with same asset tag and serial number"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test rack two
+      site: Test Site
+      serial: "FXS10001"
+      asset_tag: "1234"
+    state: present
+  ignore_errors: yes
+  register: test_six
+
+- name: "6 - ASSERT"
+  assert:
+    that:
+      - test_six is failed
+      - "'Asset tag already exists' in test_six['msg']"
+
+- name: "7 - Test delete"
+  netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test rack one"
+    state: "absent"
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "present"
+      - test_seven['diff']['after']['state'] == "absent"
+      - test_seven['msg'] == "rack Test rack one deleted"

--- a/tests/integration/v2.7/tasks/netbox_rack_group.yml
+++ b/tests/integration/v2.7/tasks/netbox_rack_group.yml
@@ -1,0 +1,62 @@
+---
+##
+##
+### NETBOX_RACK_GROUP
+##
+##
+- name: "RACK_GROUP 1: Necessary info creation"
+  netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Group
+      site: Test Site
+    state: present
+  register: test_one
+
+- name: "RACK_GROUP 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack_group']['name'] == "Rack Group"
+      - test_one['rack_group']['slug'] == "rack-group"
+      - test_one['rack_group']['site'] == 1
+      - test_one['msg'] == "rack_group Rack Group created"
+
+- name: "RACK_GROUP 2: Create duplicate"
+  netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Group
+      site: Test Site
+    state: present
+  register: test_two
+
+- name: "RACK_GROUP 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack_group']['name'] == "Rack Group"
+      - test_two['rack_group']['slug'] == "rack-group"
+      - test_two['rack_group']['site'] == 1
+      - test_two['msg'] == "rack_group Rack Group already exists"
+
+- name: "RACK_GROUP 3: ASSERT - Delete"
+  netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Group
+    state: absent
+  register: test_three
+
+- name: "RACK_GROUP 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "rack_group Rack Group deleted"

--- a/tests/integration/v2.7/tasks/netbox_rack_role.yml
+++ b/tests/integration/v2.7/tasks/netbox_rack_role.yml
@@ -1,0 +1,81 @@
+---
+##
+##
+### NETBOX_RACK_ROLE
+##
+##
+- name: "RACK_ROLE 1: Necessary info creation"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+      color: "ffffff"
+    state: present
+  register: test_one
+
+- name: "RACK_ROLE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack_role']['name'] == "Rack Role"
+      - test_one['rack_role']['slug'] == "rack-role"
+      - test_one['rack_role']['color'] == "ffffff"
+      - test_one['msg'] == "rack_role Rack Role created"
+
+- name: "RACK_ROLE 2: Create duplicate"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+    state: present
+  register: test_two
+
+- name: "RACK_ROLE 1: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack_role']['name'] == "Rack Role"
+      - test_two['rack_role']['slug'] == "rack-role"
+      - test_two['rack_role']['color'] == "ffffff"
+      - test_two['msg'] == "rack_role Rack Role already exists"
+
+- name: "RACK_ROLE 3: Update"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+      color: "003EFF"
+    state: present
+  register: test_three
+
+- name: "RACK_ROLE 3: ASSERT - Update"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "003eff"
+      - test_three['rack_role']['name'] == "Rack Role"
+      - test_three['rack_role']['slug'] == "rack-role"
+      - test_three['rack_role']['color'] == "003eff"
+      - test_three['msg'] == "rack_role Rack Role updated"
+
+- name: "RACK_ROLE 4: Delete"
+  netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Rack Role
+    state: absent
+  register: test_four
+
+- name: "RACK_ROLE 4: ASSERT - Update"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "rack_role Rack Role deleted"

--- a/tests/integration/v2.7/tasks/netbox_region.yml
+++ b/tests/integration/v2.7/tasks/netbox_region.yml
@@ -1,0 +1,79 @@
+---
+##
+##
+### NETBOX_REGION
+##
+##
+- name: "REGION 1: Necessary info creation"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+    state: present
+  register: test_one
+
+- name: "REGION 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['region']['name'] == "Test Region One"
+      - test_one['region']['slug'] == "test-region-one"
+      - test_one['msg'] == "region Test Region One created"
+
+- name: "REGION 2: Create duplicate"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+    state: present
+  register: test_two
+
+- name: "REGION 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['region']['name'] == "Test Region One"
+      - test_two['region']['slug'] == "test-region-one"
+      - test_two['msg'] == "region Test Region One already exists"
+
+- name: "REGION 3: ASSERT - Update"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+      parent_region: "Test Region"
+    state: present
+  register: test_three
+
+- name: "REGION 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['parent'] == 1
+      - test_three['region']['name'] == "Test Region One"
+      - test_three['region']['slug'] == "test-region-one"
+      - test_three['region']['parent'] == 1
+      - test_three['msg'] == "region Test Region One updated"
+
+- name: "REGION 4: ASSERT - Delete"
+  netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Region One"
+    state: absent
+  register: test_four
+
+- name: "REGION 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['region']['name'] == "Test Region One"
+      - test_four['region']['slug'] == "test-region-one"
+      - test_four['region']['parent'] == 1
+      - test_four['msg'] == "region Test Region One deleted"

--- a/tests/integration/v2.7/tasks/netbox_rir.yml
+++ b/tests/integration/v2.7/tasks/netbox_rir.yml
@@ -1,0 +1,79 @@
+---
+##
+##
+### NETBOX_RIR
+##
+##
+- name: "RIR 1: Necessary info creation"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test RIR One
+    state: present
+  register: test_one
+
+- name: "RIR 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rir']['name'] == "Test RIR One"
+      - test_one['rir']['slug'] == "test-rir-one"
+      - test_one['msg'] == "rir Test RIR One created"
+
+- name: "RIR 2: Create duplicate"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test RIR One
+    state: present
+  register: test_two
+
+- name: "RIR 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['rir']['name'] == "Test RIR One"
+      - test_two['rir']['slug'] == "test-rir-one"
+      - test_two['msg'] == "rir Test RIR One already exists"
+
+- name: "RIR 3: ASSERT - Update"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test RIR One"
+      is_private: true
+    state: present
+  register: test_three
+
+- name: "RIR 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['is_private'] == true
+      - test_three['rir']['name'] == "Test RIR One"
+      - test_three['rir']['slug'] == "test-rir-one"
+      - test_three['rir']['is_private'] == true
+      - test_three['msg'] == "rir Test RIR One updated"
+
+- name: "RIR 4: ASSERT - Delete"
+  netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test RIR One"
+    state: absent
+  register: test_four
+
+- name: "RIR 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['rir']['name'] == "Test RIR One"
+      - test_four['rir']['slug'] == "test-rir-one"
+      - test_four['rir']['is_private'] == true
+      - test_four['msg'] == "rir Test RIR One deleted"

--- a/tests/integration/v2.7/tasks/netbox_service.yml
+++ b/tests/integration/v2.7/tasks/netbox_service.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_SERVICE
+##
+##
+- name: "1 - Device with required information needs to add new service"
+  netbox_device:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "FOR_SERVICE"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
+      site: "Test Site"
+      status: "Staged"
+    state: present
+
+- name: "NETBOX_SERVICE: Create new service"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: TCP
+    state: present
+  register: test_service_create
+
+- name: "NETBOX_SERVICE ASSERT - Create"
+  assert:
+    that:
+      - test_service_create is changed
+      - test_service_create['services']['name'] == "node-exporter"
+      - test_service_create['services']['port'] == 9100
+      - test_service_create['services']['protocol'] == "tcp"
+      - test_service_create['diff']['after']['state'] == "present"
+      - test_service_create['diff']['before']['state'] == "absent"
+      - test_service_create['msg'] == "services node-exporter created"
+
+- name: "NETBOX_SERVICE: Test idempotence"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: TCP
+    state: present
+  register: test_service_idempotence
+
+- name: "NETBOX_SERVICE ASSERT - Not changed"
+  assert:
+    that:
+      - test_service_idempotence['services']['name'] == "node-exporter"
+      - test_service_idempotence['services']['port'] == 9100
+      - test_service_idempotence['services']['protocol'] == "tcp"
+      - test_service_idempotence['msg'] == "services node-exporter already exists"
+- name: "NETBOX_SERVICE: Test update"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: UDP
+    state: present
+  register: test_service_update
+
+- name: "NETBOX_SERVICE ASSERT - Service has been updated"
+  assert:
+    that:
+      - test_service_update is changed
+      - test_service_update['diff']['before']['protocol'] == "tcp"
+      - test_service_update['diff']['after']['protocol'] == "udp"
+      - test_service_update['msg'] == "services node-exporter updated"
+
+- name: "NETBOX_SERVICE: Test service deletion"
+  netbox_service:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "FOR_SERVICE"
+      name: "node-exporter"
+      port: 9100
+      protocol: UDP
+    state: absent
+  register: test_service_delete
+
+- name: "NETBOX_SERVICE ASSERT - Service has been deleted"
+  assert:
+    that:
+      - test_service_delete is changed
+      - test_service_delete['diff']['after']['state'] == "absent"
+      - test_service_delete['diff']['before']['state'] == "present"
+      - test_service_delete['msg'] == "services node-exporter deleted"

--- a/tests/integration/v2.7/tasks/netbox_site.yml
+++ b/tests/integration/v2.7/tasks/netbox_site.yml
@@ -1,0 +1,132 @@
+---
+##
+##
+### NETBOX_SITE
+##
+##
+- name: "1 - Create site within Netbox with only required information"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+    state: present
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['site']['name'] == "Test - Colorado"
+      - test_one['msg'] == "site Test - Colorado created"
+
+- name: "2 - Duplicate"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+    state: present
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "site Test - Colorado already exists"
+      - test_two['site']['name'] == "Test - Colorado"
+
+- name: "3 - Update Test - Colorado"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+      status: Planned
+      region: Test Region
+      contact_name: Mikhail
+    state: present
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['diff']['after']['contact_name'] == "Mikhail"
+      - test_three['diff']['after']['region'] == 1
+      - test_three['msg'] == "site Test - Colorado updated"
+      - test_three['site']['name'] == "Test - Colorado"
+      - test_three['site']['status'] == "planned"
+      - test_three['site']['contact_name'] == "Mikhail"
+      - test_three['site']['region'] == 1
+
+- name: "4 - Create site with all parameters"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - California
+      status: Planned
+      region: Test Region
+      tenant: Test Tenant
+      facility: EquinoxCA7
+      asn: 65001
+      time_zone: America/Los Angeles
+      description: This is a test description
+      physical_address: Hollywood, CA, 90210
+      shipping_address: Hollywood, CA, 90210
+      latitude: 10.1
+      longitude: 12.2
+      contact_name: Jenny
+      contact_phone: 867-5309
+      contact_email: jenny@changednumber.com
+      comments: "### Placeholder"
+      slug: "test_california"
+    state: present
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['site']['name'] == "Test - California"
+      - test_four['msg'] == "site Test - California created"
+      - test_four['site']['status'] == "planned"
+      - test_four['site']['region'] == 1
+      - test_four['site']['tenant'] == 1
+      - test_four['site']['facility'] == "EquinoxCA7"
+      - test_four['site']['asn'] == 65001
+      - test_four['site']['time_zone'] == "America/Los_Angeles"
+      - test_four['site']['description'] == "This is a test description"
+      - test_four['site']['physical_address'] == "Hollywood, CA, 90210"
+      - test_four['site']['shipping_address'] == "Hollywood, CA, 90210"
+      - test_four['site']['latitude'] == "10.100000"
+      - test_four['site']['longitude'] == "12.200000"
+      - test_four['site']['contact_name'] == "Jenny"
+      - test_four['site']['contact_phone'] == "867-5309"
+      - test_four['site']['contact_email'] == "jenny@changednumber.com"
+      - test_four['site']['comments'] == "### Placeholder"
+      - test_four['site']['slug'] == "test_california"
+
+- name: "5 - Delete site within netbox"
+  netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test - Colorado
+    state: absent
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['site']['name'] == "Test - Colorado"
+      - test_five['msg'] == "site Test - Colorado deleted"

--- a/tests/integration/v2.7/tasks/netbox_tenant.yml
+++ b/tests/integration/v2.7/tasks/netbox_tenant.yml
@@ -1,0 +1,106 @@
+---
+##
+##
+### NETBOX_TENANT
+##
+##
+- name: "1 - Test tenant creation"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tenant']['name'] == "Tenant ABC"
+      - test_one['tenant']['slug'] == "tenant-abc"
+      - test_one['msg'] == "tenant Tenant ABC created"
+
+- name: "Test duplicate tenant"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['tenant']['name'] == "Tenant ABC"
+      - test_two['tenant']['slug'] == "tenant-abc"
+      - test_two['msg'] == "tenant Tenant ABC already exists"
+
+- name: "3 - Test update"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+      description: "Updated description"
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Updated description"
+      - test_three['tenant']['name'] == "Tenant ABC"
+      - test_three['tenant']['slug'] == "tenant-abc"
+      - test_three['tenant']['description'] == "Updated description"
+      - test_three['msg'] == "tenant Tenant ABC updated"
+
+- name: "4 - Test delete"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+    state: "absent"
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "tenant Tenant ABC deleted"
+
+- name: "5 - Create tenant with all parameters"
+  netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Tenant ABC"
+      description: "ABC Incorporated"
+      comments: "### This tenant is super cool"
+      tenant_group: "Test Tenant Group"
+      slug: "tenant_abc"
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: "5 - ASSERT"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['tenant']['name'] == "Tenant ABC"
+      - test_five['tenant']['slug'] == "tenant_abc"
+      - test_five['tenant']['description'] == "ABC Incorporated"
+      - test_five['tenant']['comments'] == "### This tenant is super cool"
+      - test_five['tenant']['group'] == 1
+      - test_five['tenant']['tags'] | length == 3
+      - test_five['msg'] == "tenant Tenant ABC created"

--- a/tests/integration/v2.7/tasks/netbox_tenant_group.yml
+++ b/tests/integration/v2.7/tasks/netbox_tenant_group.yml
@@ -1,0 +1,75 @@
+---
+##
+##
+### NETBOX_TENANT_GROUP
+##
+##
+- name: "1 - Test tenant group creation"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group Two"
+  register: test_one
+
+- name: "1 - ASSERT"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tenant_group']['name'] == "Test Tenant Group Two"
+      - test_one['tenant_group']['slug'] == "test-tenant-group-two"
+      - test_one['msg'] == "tenant_group Test Tenant Group Two created"
+
+- name: "Test duplicate tenant group"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group Two"
+  register: test_two
+
+- name: "2 - ASSERT"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['tenant_group']['name'] == "Test Tenant Group Two"
+      - test_two['tenant_group']['slug'] == "test-tenant-group-two"
+      - test_two['msg'] == "tenant_group Test Tenant Group Two already exists"
+
+- name: "3 - Test delete"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group Two"
+    state: "absent"
+  register: test_three
+
+- name: "3 - ASSERT"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "tenant_group Test Tenant Group Two deleted"
+
+- name: "4 - Test another tenant group creation"
+  netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test Tenant Group ABC"
+      slug: "test_tenant_group_four"
+  register: test_four
+
+- name: "4 - ASSERT"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['tenant_group']['name'] == "Test Tenant Group ABC"
+      - test_four['tenant_group']['slug'] == "test_tenant_group_four"
+      - test_four['msg'] == "tenant_group Test Tenant Group ABC created"

--- a/tests/integration/v2.7/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/v2.7/tasks/netbox_virtual_machine.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_VIRTUAL_MACHINES
+##
+##
+- name: "VIRTUAL_MACHINE 1: Necessary info creation"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+    state: present
+  register: test_one
+
+- name: "VIRTUAL_MACHINE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['virtual_machine']['name'] == "Test VM One"
+      - test_one['virtual_machine']['cluster'] == 1
+      - test_one['msg'] == "virtual_machine Test VM One created"
+
+- name: "VIRTUAL_MACHINE 2: Create duplicate"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+    state: present
+  register: test_two
+
+- name: "VIRTUAL_MACHINE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['virtual_machine']['name'] == "Test VM One"
+      - test_two['virtual_machine']['cluster'] == 1
+      - test_two['msg'] == "virtual_machine Test VM One already exists"
+
+- name: "VIRTUAL_MACHINE 3: Update"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+      vcpus: 8
+      memory: 8
+      status: "Planned"
+      virtual_machine_role: "Test VM Role"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "VIRTUAL_MACHINE 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['vcpus'] == 8
+      - test_three['diff']['after']['memory'] == 8
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['diff']['after']['role'] == 2
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['virtual_machine']['name'] == "Test VM One"
+      - test_three['virtual_machine']['cluster'] == 1
+      - test_three['virtual_machine']['vcpus'] == 8
+      - test_three['virtual_machine']['memory'] == 8
+      - test_three['virtual_machine']['status'] == "planned"
+      - test_three['virtual_machine']['role'] == 2
+      - test_three['virtual_machine']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "virtual_machine Test VM One updated"
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
+  netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+    state: absent
+  register: test_four
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['virtual_machine']['name'] == "Test VM One"
+      - test_four['virtual_machine']['cluster'] == 1
+      - test_four['virtual_machine']['vcpus'] == 8
+      - test_four['virtual_machine']['memory'] == 8
+      - test_four['virtual_machine']['status'] == "planned"
+      - test_four['virtual_machine']['role'] == 2
+      - test_four['virtual_machine']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "virtual_machine Test VM One deleted"

--- a/tests/integration/v2.7/tasks/netbox_vlan.yml
+++ b/tests/integration/v2.7/tasks/netbox_vlan.yml
@@ -1,0 +1,143 @@
+---
+##
+##
+### NETBOX_VLAN
+##
+##
+- name: "VLAN 1: Necessary info creation"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VLAN 500
+      vid: 500
+    state: present
+  register: test_one
+
+- name: "VLAN 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vlan']['name'] == "Test VLAN 500"
+      - test_one['vlan']['vid'] == 500
+      - test_one['msg'] == "vlan Test VLAN 500 created"
+
+- name: "VLAN 2: Create duplicate"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VLAN 500
+      vid: 500
+    state: present
+  register: test_two
+
+- name: "VLAN 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['vlan']['name'] == "Test VLAN 500"
+      - test_two['vlan']['vid'] == 500
+      - test_two['msg'] == "vlan Test VLAN 500 already exists"
+
+- name: "VLAN 3: Create VLAN with same name, but different site"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VLAN 500
+      vid: 500
+      site: Test Site
+      tenant: Test Tenant
+    state: present
+  register: test_three
+
+- name: "VLAN 3: ASSERT - Create VLAN with same name, but different site"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['vlan']['name'] == "Test VLAN 500"
+      - test_three['vlan']['vid'] == 500
+      - test_three['vlan']['site'] == 1
+      - test_three['msg'] == "vlan Test VLAN 500 created"
+
+- name: "VLAN 4: ASSERT - Update"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VLAN 500"
+      vid: 500
+      tenant: "Test Tenant"
+      vlan_group: "Test VLAN Group"
+      status: Reserved
+      vlan_role: Network of care
+      description: Updated description
+      site: "Test Site"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four
+
+- name: "VLAN 4: ASSERT - Updated"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['group'] == 1
+      - test_four['diff']['after']['status'] == "reserved"
+      - test_four['diff']['after']['role'] == 1
+      - test_four['diff']['after']['description'] == "Updated description"
+      - test_four['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_four['vlan']['name'] == "Test VLAN 500"
+      - test_four['vlan']['tenant'] == 1
+      - test_four['vlan']['site'] == 1
+      - test_four['vlan']['group'] == 1
+      - test_four['vlan']['status'] == "reserved"
+      - test_four['vlan']['role'] == 1
+      - test_four['vlan']['description'] == "Updated description"
+      - test_four['vlan']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "vlan Test VLAN 500 updated"
+
+- name: "VLAN 5: ASSERT - Delete more than one result"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VLAN 500"
+    state: absent
+  ignore_errors: yes
+  register: test_five
+
+- name: "VLAN 5: ASSERT - Delete more than one result"
+  assert:
+    that:
+      - test_five is failed
+      - test_five['msg'] == "More than one result returned for Test VLAN 500"
+
+- name: "VLAN 6: ASSERT - Delete"
+  netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VLAN 500"
+      site: Test Site
+    state: absent
+  register: test_six
+
+- name: "VLAN 6: ASSERT - Delete"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['vlan']['name'] == "Test VLAN 500"
+      - test_six['vlan']['tenant'] == 1
+      - test_six['vlan']['site'] == 1
+      - test_six['vlan']['group'] == 1
+      - test_six['vlan']['status'] == "reserved"
+      - test_six['vlan']['role'] == 1
+      - test_six['vlan']['description'] == "Updated description"
+      - test_six['vlan']['tags'][0] == "Schnozzberry"
+      - test_six['msg'] == "vlan Test VLAN 500 deleted"

--- a/tests/integration/v2.7/tasks/netbox_vlan_group.yml
+++ b/tests/integration/v2.7/tasks/netbox_vlan_group.yml
@@ -1,0 +1,118 @@
+---
+##
+##
+### NETBOX_VLAN_GROUP
+##
+##
+- name: "VLAN_GROUP 1: Necessary info creation"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+      site: Test Site
+    state: present
+  register: test_one
+
+- name: "VLAN_GROUP 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vlan_group']['name'] == "VLAN Group One"
+      - test_one['vlan_group']['slug'] == "vlan-group-one"
+      - test_one['vlan_group']['site'] == 1
+      - test_one['msg'] == "vlan_group VLAN Group One created"
+
+- name: "VLAN_GROUP 2: Create duplicate"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+      site: Test Site
+    state: present
+  register: test_two
+
+- name: "VLAN_GROUP 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['vlan_group']['name'] == "VLAN Group One"
+      - test_two['vlan_group']['slug'] == "vlan-group-one"
+      - test_two['vlan_group']['site'] == 1
+      - test_two['msg'] == "vlan_group VLAN Group One already exists"
+
+- name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+      site: "Test Site2"
+    state: present
+  register: test_three
+
+- name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['vlan_group']['name'] == "VLAN Group One"
+      - test_three['vlan_group']['slug'] == "vlan-group-one"
+      - test_three['vlan_group']['site'] == 2
+      - test_three['msg'] == "vlan_group VLAN Group One created"
+
+- name: "VLAN_GROUP 4: ASSERT - Create vlan group, no site"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "VLAN Group One"
+    state: present
+  ignore_errors: yes
+  register: test_four
+
+- name: "VLAN_GROUP 4: ASSERT - Create with same name, different site"
+  assert:
+    that:
+      - test_four is failed
+      - test_four['msg'] == "More than one result returned for VLAN Group One"
+
+- name: "VLAN_GROUP 5: ASSERT - Delete"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: VLAN Group One
+      site: Test Site2
+    state: absent
+  register: test_five
+
+- name: "VLAN_GROUP 5: ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['vlan_group']['name'] == "VLAN Group One"
+      - test_five['vlan_group']['slug'] == "vlan-group-one"
+      - test_five['vlan_group']['site'] == 2
+      - test_five['msg'] == "vlan_group VLAN Group One deleted"
+
+- name: "VLAN_GROUP 6: ASSERT - Delete non existing"
+  netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: VLAN Group One
+      site: Test Site2
+    state: absent
+  register: test_six
+
+- name: "VLAN_GROUP 6: ASSERT - Delete non existing`"
+  assert:
+    that:
+      - not test_six['changed']
+      - test_six['vlan_group'] == None
+      - test_six['msg'] == "vlan_group VLAN Group One already absent"

--- a/tests/integration/v2.7/tasks/netbox_vm_interface.yml
+++ b/tests/integration/v2.7/tasks/netbox_vm_interface.yml
@@ -1,0 +1,159 @@
+---
+##
+##
+### NETBOX_VM_INTERFACE
+##
+##
+- name: "NETBOX_VM_INTERFACE 1: Necessary info creation"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth10"
+    state: present
+  register: test_one
+
+- name: "NETBOX_VM_INTERFACE 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['interface']['name'] == "Eth10"
+      - test_one['interface']['virtual_machine'] == 1
+      - test_one['msg'] == "interface Eth10 created"
+
+- name: "NETBOX_VM_INTERFACE 2: Create duplicate"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth10"
+    state: present
+  register: test_two
+
+- name: "NETBOX_VM_INTERFACE 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['interface']['name'] == "Eth10"
+      - test_two['interface']['virtual_machine'] == 1
+      - test_two['msg'] == "interface Eth10 already exists"
+
+- name: "NETBOX_VM_INTERFACE 3: Updated"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth10"
+      enabled: false
+      mtu: 9000
+      mac_address: "00:00:00:AA:AA:01"
+      description: "Updated test100-vm"
+      mode: Tagged
+      untagged_vlan:
+        name: Wireless
+        site: Test Site
+      tagged_vlans:
+        - name: Data
+          site: Test Site
+        - name: VoIP
+          site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['enabled'] == false
+      - test_three['diff']['after']['mtu'] == 9000
+      - test_three['diff']['after']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_three['diff']['after']['description'] == "Updated test100-vm"
+      - test_three['diff']['after']['mode'] == "tagged"
+      - test_three['diff']['after']['untagged_vlan'] == 1
+      - test_three['diff']['after']['tagged_vlans'] == [2, 3]
+      - test_three['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_three['interface']['name'] == "Eth10"
+      - test_three['interface']['virtual_machine'] == 1
+      - test_three['interface']['enabled'] == false
+      - test_three['interface']['mtu'] == 9000
+      - test_three['interface']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_three['interface']['description'] == "Updated test100-vm"
+      - test_three['interface']['mode'] == "tagged"
+      - test_three['interface']['untagged_vlan'] == 1
+      - test_three['interface']['tagged_vlans'] == [2, 3]
+      - test_three['interface']['tags'][0] == "Schnozzberry"
+      - test_three['msg'] == "interface Eth10 updated"
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Eth10"
+      virtual_machine: "test100-vm"
+    state: absent
+  register: test_four
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['interface']['name'] == "Eth10"
+      - test_four['interface']['virtual_machine'] == 1
+      - test_four['msg'] == "interface Eth10 deleted"
+
+- name: "NETBOX_VM_INTERFACE 5: Attempt to update interface with same name on other VMs"
+  netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Eth0"
+      enabled: false
+      mtu: 9000
+      mac_address: "00:00:00:AA:AA:01"
+      description: "Updated test100-vm Eth0 intf"
+      mode: Tagged
+      untagged_vlan:
+        name: Wireless
+        site: Test Site
+      tagged_vlans:
+        - name: Data
+          site: Test Site
+        - name: VoIP
+          site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: "NETBOX_VM_INTERFACE 5: ASSERT - Updated"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['enabled'] == false
+      - test_five['diff']['after']['mtu'] == 9000
+      - test_five['diff']['after']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_five['diff']['after']['description'] == "Updated test100-vm Eth0 intf"
+      - test_five['diff']['after']['mode'] == "tagged"
+      - test_five['diff']['after']['untagged_vlan'] == 1
+      - test_five['diff']['after']['tagged_vlans'] == [2, 3]
+      - test_five['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_five['interface']['name'] == "Eth0"
+      - test_five['interface']['virtual_machine'] == 1
+      - test_five['interface']['enabled'] == false
+      - test_five['interface']['mtu'] == 9000
+      - test_five['interface']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_five['interface']['description'] == "Updated test100-vm Eth0 intf"
+      - test_five['interface']['mode'] == "tagged"
+      - test_five['interface']['untagged_vlan'] == 1
+      - test_five['interface']['tagged_vlans'] == [2, 3]
+      - test_five['interface']['tags'][0] == "Schnozzberry"
+      - test_five['msg'] == "interface Eth0 updated"

--- a/tests/integration/v2.7/tasks/netbox_vrf.yml
+++ b/tests/integration/v2.7/tasks/netbox_vrf.yml
@@ -1,0 +1,128 @@
+---
+##
+##
+### NETBOX_VRF
+##
+##
+- name: "VRF 1: Necessary info creation"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VRF One
+    state: present
+  register: test_one
+
+- name: "VRF 1: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vrf']['name'] == "Test VRF One"
+      - test_one['msg'] == "vrf Test VRF One created"
+
+- name: "VRF 2: Create duplicate"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VRF One
+    state: present
+  register: test_two
+
+- name: "VRF 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_two['changed']
+      - test_two['vrf']['name'] == "Test VRF One"
+      - test_two['msg'] == "vrf Test VRF One already exists"
+
+- name: "VRF 3: Create VRF with same name, but different tenant"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Test VRF One
+      tenant: Test Tenant
+    state: present
+  register: test_three
+
+- name: "VRF 3: ASSERT - Create VRF with same name, but different site"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['vrf']['name'] == "Test VRF One"
+      - test_three['vrf']['tenant'] == 1
+      - test_three['msg'] == "vrf Test VRF One created"
+
+- name: "VRF 4: ASSERT - Update"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VRF One"
+      rd: "65001:1"
+      enforce_unique: False
+      tenant: "Test Tenant"
+      description: Updated description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four
+
+- name: "VRF 4: ASSERT - Updated"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['rd'] == "65001:1"
+      - test_four['diff']['after']['enforce_unique'] == false
+      - test_four['diff']['after']['description'] == "Updated description"
+      - test_four['diff']['after']['tags'][0] == "Schnozzberry"
+      - test_four['vrf']['name'] == "Test VRF One"
+      - test_four['vrf']['tenant'] == 1
+      - test_four['vrf']['rd'] == "65001:1"
+      - test_four['vrf']['enforce_unique'] == false
+      - test_four['vrf']['description'] == "Updated description"
+      - test_four['vrf']['tags'][0] == "Schnozzberry"
+      - test_four['msg'] == "vrf Test VRF One updated"
+
+- name: "VRF 5: ASSERT - Delete more than one result"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VRF One"
+    state: absent
+  ignore_errors: yes
+  register: test_five
+
+- name: "VRF 5: ASSERT - Delete more than one result"
+  assert:
+    that:
+      - test_five is failed
+      - test_five['msg'] == "More than one result returned for Test VRF One"
+
+- name: "VRF 6: ASSERT - Delete"
+  netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VRF One"
+      tenant: Test Tenant
+    state: absent
+  register: test_six
+
+- name: "VRF 6: ASSERT - Delete"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['vrf']['name'] == "Test VRF One"
+      - test_six['vrf']['tenant'] == 1
+      - test_six['vrf']['rd'] == "65001:1"
+      - test_six['vrf']['enforce_unique'] == false
+      - test_six['vrf']['description'] == "Updated description"
+      - test_six['vrf']['tags'][0] == "Schnozzberry"
+      - test_six['msg'] == "vrf Test VRF One deleted"


### PR DESCRIPTION
Fixes #149 

This implements separate tests for NetBox 2.6 and 2.7 since there were changes `_choices`. May need to implement this in a different way to account for changes between future versions that doesn't consist of having to clone tests for each version