### PR TITLE
Enhancement: Removed choices for mode and will allow API to return error

### DIFF
--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -90,7 +90,7 @@ options:
         choices:
           - Access
           - Tagged
-          - Tagged All
+          - Tagged (All)
         type: str
       untagged_vlan:
         description:
@@ -250,9 +250,7 @@ def main():
                     mac_address=dict(required=False, type="str"),
                     mgmt_only=dict(required=False, type="bool"),
                     description=dict(required=False, type="str"),
-                    mode=dict(
-                        required=False, choices=["Access", "Tagged", "Tagged All"],
-                    ),
+                    mode=dict(required=False, type="raw"),
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list"),

--- a/plugins/modules/netbox_vm_interface.py
+++ b/plugins/modules/netbox_vm_interface.py
@@ -74,7 +74,7 @@ options:
         choices:
           - Access
           - Tagged
-          - Tagged All
+          - Tagged (All)
         type: str
       untagged_vlan:
         description:
@@ -188,9 +188,7 @@ def main():
                     mtu=dict(required=False, type="int"),
                     mac_address=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
-                    mode=dict(
-                        required=False, choices=["Access", "Tagged", "Tagged All"],
-                    ),
+                    mode=dict(required=False, type="raw"),
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type=list),


### PR DESCRIPTION
Fixes #158 

This just removes the choices for mode from `netbox_device_interface` and `netbox_vm_interface` and the NetBox API will throw the error back as you can use the slug or regular value.

@ThomasADavis Do you mind testing this to make sure you're seeing the behavior you're expecting?