### PR TITLE
BugFix: Find proper LAG if not defined as dictionary

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,2 @@
 [inventory]
-enable_plugins =  netbox.netbox.nb_inventory
+enable_plugins =  netbox.netbox.nb_inventory, auto, host_list, yaml, ini, toml, script

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -565,9 +565,11 @@ class NetboxModule(object):
                             id_list.append(query_id.id)
                         else:
                             self._handle_errors(msg="%s not found" % (list_item))
-
                 else:
-                    query_params = {QUERY_TYPES.get(k, "q"): search}
+                    if k in ["lag"]:
+                        query_params = self._build_query_params(k, data)
+                    else:
+                        query_params = {QUERY_TYPES.get(k, "q"): search}
                     query_id = self._nb_endpoint_get(nb_endpoint, query_params, k)
 
                 # Code to work around Ansible templating converting all values to strings

--- a/tests/integration/v2.6/tasks/netbox_device_interface.yml
+++ b/tests/integration/v2.6/tasks/netbox_device_interface.yml
@@ -183,6 +183,15 @@
       - test_seven['interface']['name'] == "GigabitEthernet1"
       - test_seven['interface']['device'] == 1
 
+- name: "Add port-channel1 to R1 to test finding proper port-channel1"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "R1-Device"
+      name: "port-channel1"
+      form_factor: "Link Aggregation Group (LAG)"
+
 - name: "8 - Create interface and assign it to parent LAG - non dict"
   netbox_device_interface:
     netbox_url: "http://localhost:32768"

--- a/tests/integration/v2.7/tasks/netbox_device_interface.yml
+++ b/tests/integration/v2.7/tasks/netbox_device_interface.yml
@@ -184,6 +184,15 @@
       - test_seven['interface']['name'] == "GigabitEthernet1"
       - test_seven['interface']['device'] == 1
 
+- name: "Add port-channel1 to R1 to test finding proper port-channel1"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "R1-Device"
+      name: "port-channel1"
+      form_factor: "Link Aggregation Group (LAG)"
+
 - name: "8 - Create interface and assign it to parent LAG - non dict"
   netbox_device_interface:
     netbox_url: "http://localhost:32768"

--- a/tests/integration/v2.8/tasks/netbox_device_interface.yml
+++ b/tests/integration/v2.8/tasks/netbox_device_interface.yml
@@ -184,6 +184,15 @@
       - test_seven['interface']['name'] == "GigabitEthernet1"
       - test_seven['interface']['device'] == 1
 
+- name: "Add port-channel1 to R1 to test finding proper port-channel1"
+  netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: "R1-Device"
+      name: "port-channel1"
+      form_factor: "Link Aggregation Group (LAG)"
+
 - name: "8 - Create interface and assign it to parent LAG - non dict"
   netbox_device_interface:
     netbox_url: "http://localhost:32768"


### PR DESCRIPTION
Fixes #166 

If lag is defined as just a string, it will send it to `_build_query_params` to properly build the query to find the LAG interface.