### PR TITLE
Bugfix: netbox_device_interface: Add type and add deprecation to form_factor option

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -678,10 +678,15 @@ class NetboxModule(object):
                         data_before[key] = serialized_nb_obj[key]
                         data_after[key] = updated_obj[key]
                 except KeyError:
-                    self._handle_errors(
-                        msg="%s does not exist on existing object. Check to make sure valid field."
-                        % (key)
-                    )
+                    if key == "form_factor":
+                        msg = "form_factor is not valid for NetBox 2.7 onword. Please use the type key instead."
+                    else:
+                        msg = (
+                            "%s does not exist on existing object. Check to make sure valid field."
+                            % (key)
+                        )
+
+                    self._handle_errors(msg=msg)
 
             if not self.check_mode:
                 self.nb_object.update(data)

--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -60,6 +60,16 @@ options:
             ex. 1000Base-T (1GE), Virtual, 10GBASE-T (10GE)
             This has to be specified exactly as what is found within UI
         type: str
+        deprecated:
+          removed_in: "0.3.0"
+          why: "NetBox now uses Type instead of Form Factor from 2.7 on."
+      type:
+        description:
+          - |
+            Form factor of the interface:
+            ex. 1000Base-T (1GE), Virtual, 10GBASE-T (10GE)
+            This has to be specified exactly as what is found within UI
+        type: str
       enabled:
         description:
           - Sets whether interface shows enabled or disabled
@@ -156,7 +166,7 @@ EXAMPLES = r"""
         data:
           device: test100
           name: port-channel1
-          form_factor: Link Aggregation Group (LAG)
+          type: Link Aggregation Group (LAG)
           mtu: 1600
           mgmt_only: false
           mode: Access
@@ -169,7 +179,7 @@ EXAMPLES = r"""
           device: test100
           name: GigabitEthernet1
           enabled: false
-          form_factor: 1000Base-t (1GE)
+          type: 1000Base-t (1GE)
           lag:
             name: port-channel1
           mtu: 1600
@@ -184,7 +194,7 @@ EXAMPLES = r"""
           device: test100
           name: GigabitEthernet25
           enabled: false
-          form_factor: 1000Base-t (1GE)
+          type: 1000Base-t (1GE)
           untagged_vlan:
             name: Wireless
             site: Test Site
@@ -243,7 +253,10 @@ def main():
                 options=dict(
                     device=dict(required=False, type="raw"),
                     name=dict(required=True, type="str"),
-                    form_factor=dict(required=False, type="raw"),
+                    form_factor=dict(
+                        required=False, type="raw", removed_in_version="2.10"
+                    ),
+                    type=dict(required=False, type="str"),
                     enabled=dict(required=False, type="bool"),
                     lag=dict(required=False, type="raw"),
                     mtu=dict(required=False, type="int"),


### PR DESCRIPTION
Fixes #193 

This adds the following:
- Deprecation warning for `form_factor` option.
- Add `type` to options.
- Adds clearer messaging when using `form_factor` on 2.7 and to change to using `type`

I decided not to add any logic to change the form_factor key when updating the object and just clarify the warning as I will remove any form_factor code on 0.3.0 release which will probably be sooner than later.