### PR TITLE
Added validate_certs option for lookup plugin

### DIFF
--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -49,6 +49,11 @@ DOCUMENTATION = """
                 - The API token created through Netbox
                 - This may not be required depending on the Netbox setup.
             required: False
+        validate_certs:
+            description:
+                - Whether or not to validate SSL of the NetBox instance
+            required: False
+            default: True
         key_file:
             description:
                 - The location of the private key tied to user account.
@@ -97,7 +102,7 @@ tasks:
 RETURN = """
   _list:
     description:
-      - list of composed dictonaries with key and value
+      - list of composed dictionaries with key and value
     type: list
 """
 
@@ -190,6 +195,7 @@ class LookupModule(LookupBase):
 
         netbox_api_token = kwargs.get("token")
         netbox_api_endpoint = kwargs.get("api_endpoint")
+        netbox_ssl_verify = kwargs.get("validate_certs")
         netbox_private_key_file = kwargs.get("key_file")
         netbox_api_filter = kwargs.get("api_filter")
         netbox_raw_return = kwargs.get("raw_data")
@@ -201,6 +207,7 @@ class LookupModule(LookupBase):
             netbox = pynetbox.api(
                 netbox_api_endpoint,
                 token=netbox_api_token if netbox_api_token else None,
+                ssl_verify=netbox_ssl_verify,
                 private_key_file=netbox_private_key_file,
             )
         except FileNotFoundError:


### PR DESCRIPTION
Fixes #216 

@dakennedy

Do you mind testing with it set and without the new option set?

I just want to see if it sets the validate_certs to True by default so it should fail for you if it's not specified and if `false`, then work for you.