### PR TITLE
Bugfix: Inventory - ValueError max() if either no devices or vms exist

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -302,7 +302,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             return separator + query_key + "=" + str(value)
 
         # Calculate how many queries we can do per API call to stay within max_url_length
-        largest_value = str(max(query_values))  # values are always id ints
+        largest_value = str(max(query_values, default=1))  # values are always id ints
         length_per_value = len(query_string(largest_value))
         chunk_size = math.floor((self.max_uri_length - len(api_url)) / length_per_value)
 

--- a/tests/unit/inventory/test_data/get_resource_list_chunked/data.json
+++ b/tests/unit/inventory/test_data/get_resource_list_chunked/data.json
@@ -3,7 +3,12 @@
         "api_url": "https://netbox:1234?limit=0",
         "max_uri_length": 35,
         "query_key": "key",
-        "query_values": [1, 2, 3, 4],
+        "query_values": [
+            1,
+            2,
+            3,
+            4
+        ],
         "expected": [
             "https://netbox:1234?limit=0&key=1",
             "https://netbox:1234?limit=0&key=2",
@@ -15,7 +20,12 @@
         "api_url": "https://netbox:1234?limit=0",
         "max_uri_length": -5,
         "query_key": "key",
-        "query_values": [1, 2, 3, 4],
+        "query_values": [
+            1,
+            2,
+            3,
+            4
+        ],
         "expected": [
             "https://netbox:1234?limit=0&key=1",
             "https://netbox:1234?limit=0&key=2",
@@ -27,7 +37,12 @@
         "api_url": "https://netbox:1234?limit=0",
         "max_uri_length": 50,
         "query_key": "key",
-        "query_values": [1, 2, 3000, 4],
+        "query_values": [
+            1,
+            2,
+            3000,
+            4
+        ],
         "expected": [
             "https://netbox:1234?limit=0&key=1&key=2",
             "https://netbox:1234?limit=0&key=3000&key=4"
@@ -37,10 +52,25 @@
         "api_url": "https://netbox:1234",
         "max_uri_length": 42,
         "query_key": "key",
-        "query_values": [1, 2, 3, 4],
+        "query_values": [
+            1,
+            2,
+            3,
+            4
+        ],
         "expected": [
             "https://netbox:1234?key=1&key=2&key=3",
             "https://netbox:1234?key=4"
+        ]
+    },
+    {
+        "api_url": "https://netbox:1234?limit=0",
+        "max_uri_length": 50,
+        "query_key": "key",
+        "query_values": [],
+        "expected": [
+            "https://netbox:1234?limit=0",
+            "https://netbox:1234?limit=0"
         ]
     }
 ]


### PR DESCRIPTION
Fixes #214 

Added unit test to test this at the moment since the integration tests have both devices and VMs created in the `test/integration/netbox-deploy.py`.