### PR TITLE
Bugfix: Properly convert values to integers when passed into modules

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -630,15 +630,6 @@ class NetboxModule(object):
                         query_params = {QUERY_TYPES.get(k, "q"): search}
                     query_id = self._nb_endpoint_get(nb_endpoint, query_params, k)
 
-                # Code to work around Ansible templating converting all values to strings
-                # This should allow users to pass in IDs obtained from previous tasks
-                # without causing the module to fail
-                if isinstance(v, str):
-                    try:
-                        v = int(v)
-                    except ValueError:
-                        pass
-
                 if isinstance(v, list):
                     data[k] = id_list
                 elif isinstance(v, int):
@@ -664,6 +655,27 @@ class NetboxModule(object):
             convert_chars = re.sub(r"[\-\.\s]+", "-", removed_chars)
             return convert_chars.strip().lower()
 
+    def _normalize_to_integer(self, key, value):
+        """
+        :returns value (str/int): Returns either the original value or the
+        converted value (int) if able to make the conversion.
+
+        :params (str/int): Value that needs to be tested whether or not it
+        needs to be converted to an integer.
+        """
+        DO_NOT_CONVERT_TO_INT = {"asset_tag"}
+        if key in DO_NOT_CONVERT_TO_INT:
+            return value
+        elif isinstance(value, int):
+            return value
+
+        try:
+            value = int(value)
+        except ValueError:
+            return value
+        except TypeError:
+            return value
+
     def _normalize_data(self, data):
         """
         :returns data (dict): Normalized module data to formats accepted by Netbox searches
@@ -677,6 +689,7 @@ class NetboxModule(object):
                     sub_data_type = QUERY_TYPES.get(subk, "q")
                     if sub_data_type == "slug":
                         data[k][subk] = self._to_slug(subv)
+                    data[k][subk] = self._normalize_to_integer(subk, data[k].get(subk))
             else:
                 data_type = QUERY_TYPES.get(k, "q")
                 if data_type == "slug":
@@ -684,6 +697,7 @@ class NetboxModule(object):
                 elif data_type == "timezone":
                     if " " in v:
                         data[k] = v.replace(" ", "_")
+                    data[k] = self._normalize_to_integer(k, data.get(k))
 
         return data
 

--- a/tests/integration/targets/latest/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/latest/tasks/netbox_ip_address.yml
@@ -160,9 +160,7 @@
       nat_inside:
         address: 172.16.1.20
         vrf: Test VRF
-      interface:
-        name: GigabitEthernet1
-        device: test100
+      interface: 3
   register: test_eight
 
 - name: "8 - ASSERT"

--- a/tests/unit/module_utils/test_data/normalize_data/data.json
+++ b/tests/unit/module_utils/test_data/normalize_data/data.json
@@ -286,5 +286,37 @@
         "after": {
             "vrf": "Test VRF"
         }
+    },
+    {
+        "before": {
+            "interface": 1
+        },
+        "after": {
+            "interface": 1
+        }
+    },
+    {
+        "before": {
+            "interface": {
+                "vrf": "Test VRF"
+            }
+        },
+        "after": {
+            "interface": {
+                "vrf": "Test VRF"
+            }
+        }
+    },
+    {
+        "before": {
+            "vlan": {
+                "vlan_group": "Test VLAN Group"
+            }
+        },
+        "after": {
+            "vlan": {
+                "vlan_group": "test-vlan-group"
+            }
+        }
     }
 ]

--- a/tests/unit/module_utils/test_data/normalize_integer/data.json
+++ b/tests/unit/module_utils/test_data/normalize_integer/data.json
@@ -1,0 +1,29 @@
+[
+    {
+        "data": [
+            "site",
+            "test-site"
+        ],
+        "expected": "test-site"
+    },
+    {
+        "data": [
+            "interface",
+            1
+        ],
+        "expected": 1
+    },
+    {
+        "data": [
+            "interface",
+            {
+                "name": "ethernet1",
+                "device": "test100"
+            }
+        ],
+        "expected": {
+            "name": "ethernet1",
+            "device": "test100"
+        }
+    }
+]

--- a/tests/unit/module_utils/test_netbox_base_class.py
+++ b/tests/unit/module_utils/test_netbox_base_class.py
@@ -162,6 +162,13 @@ def test_normalize_data_returns_correct_data(mock_netbox_module, before, after):
     assert norm_data == after
 
 
+@pytest.mark.parametrize("data, expected", load_relative_test_data("normalize_integer"))
+def test_normalize_to_integer_returns_correct_data(mock_netbox_module, data, expected):
+    value = mock_netbox_module._normalize_to_integer(*data)
+
+    assert value == expected
+
+
 @pytest.mark.parametrize("data, expected", load_relative_test_data("arg_spec_default"))
 def test_remove_arg_spec_defaults(mock_netbox_module, data, expected):
     new_data = mock_netbox_module._remove_arg_spec_default(data)


### PR DESCRIPTION
Fixes #231 

This is more of a global fix as it converts any values passed in to integers if they're able to. This allows users to pass in IDs of objects in NetBox if queried or known.

Previously this was only in `_find_ids` method, but now moved into `_normalize_data` method.