### PR TITLE
Local context data

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -49,6 +49,20 @@ DOCUMENTATION = """
             default: False
             type: boolean
             version_added: "0.2.1"
+        local_context_data:
+            description:
+                - If True, it adds local_context_data in host vars.
+                - Local enables the association of arbitrary data to devices and virtual machines that overrides the group-specific configuration contexts. 
+                  Please check official netbox docs for more info.
+            default: False
+            type: boolean
+        flatten_local_context_data:
+            description:
+                - If I(local_context_data) is enabled, by default it's added as a host var named local_context_data.
+                - If flatten_local_context_data is set to True, the config context variables will be added directly to the host instead.
+            default: False
+            type: boolean
+            version_added: "0.2.1"
         flatten_custom_fields:
             description:
                 - By default, host custom fields are added as a dictionary host var named custom_fields.
@@ -341,6 +355,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "memory": self.extract_memory,
             "vcpus": self.extract_vcpus,
             "config_context": self.extract_config_context,
+            "local_context_data": self.extract_local_context_data,
             "custom_fields": self.extract_custom_fields,
             "region": self.extract_regions,
             "cluster": self.extract_cluster,
@@ -464,6 +479,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 return host["config_context"]
             else:
                 return self._pluralize(host["config_context"])
+        except Exception:
+            return
+
+    def extract_local_context_data(self, host):
+        try:
+            if self.flatten_local_context_data:
+                # Don't wrap in an array if we're about to flatten it to separate host vars
+                return host["local_context_data"]
+            else:
+                return self._pluralize(host["local_context_data"])
         except Exception:
             return
 
@@ -995,6 +1020,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if vm_url:
                 vm_url = vm_url + "&exclude=config_context"
 
+        # Exclude config_context if not required
+        if not self.local_context_data:
+            if device_url:
+                device_url = device_url + "&exclude=local_context_data"
+            if vm_url:
+                vm_url = vm_url + "&exclude=local_context_data"
+
         return device_url, vm_url
 
     def fetch_hosts(self):
@@ -1153,6 +1185,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if isinstance(extracted_value, dict) and (
                 (attribute == "config_context" and self.flatten_config_context)
                 or (attribute == "custom_fields" and self.flatten_custom_fields)
+                or (attribute == "local_context_data" and self.flatten_local_context_data)
             ):
                 for key, value in extracted_value.items():
                     self.inventory.set_variable(hostname, key, value)
@@ -1247,6 +1280,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.validate_certs = self.get_option("validate_certs")
         self.config_context = self.get_option("config_context")
         self.flatten_config_context = self.get_option("flatten_config_context")
+        self.local_context_data = self.get_option("local_context_data")
+        self.flatten_local_context_data = self.get_option("flatten_local_context_data")
         self.flatten_custom_fields = self.get_option("flatten_custom_fields")
         self.plurals = self.get_option("plurals")
         self.interfaces = self.get_option("interfaces")

--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -139,6 +139,11 @@ options:
           - must exist in Netbox
         required: false
         type: dict
+      config_context:
+        description:
+          - JSON data that defines device configuration
+        required: false
+        type: dict
     required: true
     type: dict
   state:
@@ -278,6 +283,7 @@ def main():
                     cluster=dict(required=False, type="raw"),
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type="list"),
+                    local_context_data=dict(required=False, type="dict"),
                     custom_fields=dict(required=False, type="dict"),
                 ),
             ),

--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -139,9 +139,9 @@ options:
           - must exist in Netbox
         required: false
         type: dict
-      config_context:
+      local_context_data:
         description:
-          - JSON data that defines device configuration
+          - Arbitrary JSON data to define the devices configuration variables.
         required: false
         type: dict
     required: true

--- a/tests/integration/targets/latest/tasks/netbox_device.yml
+++ b/tests/integration/targets/latest/tasks/netbox_device.yml
@@ -231,6 +231,7 @@
     data:
       name: "Router10"
       device_type: "Cisco Test"
+      site: "Test Site"
       device_role: "Core Switch"
       local_context_data: {'bgp_as': '64512'}
     state: present
@@ -244,6 +245,7 @@
       - test_nine['diff']['before']['state'] == "absent"
       - test_nine['diff']['after']['state'] == "present"
       - test_nine['device']['name'] == "Router10"
+      - test_nine['device']['site'] == 1
       - test_nine['device']['device_role'] == 1
       - test_nine['device']['device_type'] == 1
       - test_nine['device']['local_context_data']['bgp_as'] == "64512"

--- a/tests/integration/targets/latest/tasks/netbox_device.yml
+++ b/tests/integration/targets/latest/tasks/netbox_device.yml
@@ -223,3 +223,25 @@
       - test_eight['device']['status'] == "staged"
       - "'-' in test_eight['device']['name']"
       - "test_eight['device']['name'] | length == 36"
+
+- name: "9 - Create device with local config context"
+  netbox_device:
+    netbox_url: http://192.168.6.106
+    netbox_token: "8014e60fc5a061fbcfc470f6a20bfa1511a5ee40"
+    data:
+      name: "Router10"
+      local_context_data: {'bgp_as': '64512'}
+    state: present
+  delegate_to: localhost
+  register: test_nine
+  
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['device']['name'] == "Router10"
+      - test_nine['device']['local_context_data']['bgp_as'] == "64512"
+      - test_nine['device']['status'] == "active"
+      - test_nine['msg'] == "Device Router10 created"

--- a/tests/integration/targets/latest/tasks/netbox_device.yml
+++ b/tests/integration/targets/latest/tasks/netbox_device.yml
@@ -226,8 +226,8 @@
 
 - name: "9 - Create device with local config context"
   netbox_device:
-    netbox_url: http://192.168.6.106
-    netbox_token: "8014e60fc5a061fbcfc470f6a20bfa1511a5ee40"
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
     data:
       name: "Router10"
       local_context_data: {'bgp_as': '64512'}

--- a/tests/integration/targets/latest/tasks/netbox_device.yml
+++ b/tests/integration/targets/latest/tasks/netbox_device.yml
@@ -230,6 +230,8 @@
     netbox_token: "0123456789abcdef0123456789abcdef01234567"
     data:
       name: "Router10"
+      device_type: "Cisco Test"
+      device_role: "Core Switch"
       local_context_data: {'bgp_as': '64512'}
     state: present
   delegate_to: localhost
@@ -242,6 +244,8 @@
       - test_nine['diff']['before']['state'] == "absent"
       - test_nine['diff']['after']['state'] == "present"
       - test_nine['device']['name'] == "Router10"
+      - test_nine['device']['device_role'] == 1
+      - test_nine['device']['device_type'] == 1
       - test_nine['device']['local_context_data']['bgp_as'] == "64512"
       - test_nine['device']['status'] == "active"
       - test_nine['msg'] == "Device Router10 created"


### PR DESCRIPTION
Added the "local_context_data" parameter to allow posting device-specific configuration context data. The code addition is just a clone of the config_context code.

```
- name: Update device context with Ansible facts
      netbox_device:
        netbox_url: https://www.netbox.com
        netbox_token: "token"
        data:
          name: "RHEL_DEV"
          device_type: VM
          device_role: servers
          platform: linux
          local_context_data: "{{ ansible_facts }}"
```