### PR TITLE
Make group_by work with services

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -127,6 +127,7 @@ DOCUMENTATION = """
                 - cluster_type
                 - cluster_group
                 - is_virtual
+                - services
             default: []
         group_names_raw:
             description: Will not add the group_by choice name to the group names
@@ -1054,6 +1055,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             else:
                 # Don't create the inverse group
                 return None
+
+        # Special case. Extract name from service, which is a hash.
+        if grouping == "services":
+            group = group["name"]
+            grouping = "service"
 
         if self.group_names_raw:
             return group


### PR DESCRIPTION
The group_by has apparent support for grouping by "services", but the functionality doesn't work, as it provides a list of dicts, which are not accepted.  This PR makes group_by accept 'service', or 'services' (depending on plurality), and adds hosts to groups based on the service.