### PR TITLE
Bugfix: Change query_dict for _templates modules to choose devicetype_id

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -665,10 +665,6 @@ class NetboxModule(object):
                 }
                 query_dict.update(rear_port)
 
-        elif parent == "interface_template" or parent == "device_bay_template":
-            if query_dict.get("device_type"):
-                query_dict["devicetype_id"] = query_dict.pop("device_type")
-
         elif parent == "rear_port_template" and self.endpoint == "front_port_templates":
             if isinstance(module_data.get("rear_port_template"), str):
                 rear_port_template = {
@@ -676,6 +672,10 @@ class NetboxModule(object):
                     "name": module_data.get("rear_port_template"),
                 }
                 query_dict.update(rear_port_template)
+
+        elif "_template" in parent:
+            if query_dict.get("device_type"):
+                query_dict["devicetype_id"] = query_dict.pop("device_type")
 
         query_dict = self._convert_identical_keys(query_dict)
         return query_dict

--- a/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
+++ b/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
@@ -353,7 +353,7 @@
         }
     },
     {
-        "parent": "device_interface_template",
+        "parent": "interface_template",
         "module_data": {
             "name": "Dev Intf 1",
             "device_type": 1

--- a/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
+++ b/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
@@ -331,6 +331,72 @@
         }
     },
     {
+        "parent": "console_port_template",
+        "module_data": {
+            "name": "CP 1",
+            "device_type": 1
+        },
+        "expected": {
+            "name": "CP 1",
+            "devicetype_id": 1
+        }
+    },
+    {
+        "parent": "console_server_port_template",
+        "module_data": {
+            "name": "CP - Server 1",
+            "device_type": 1
+        },
+        "expected": {
+            "name": "CP - Server 1",
+            "devicetype_id": 1
+        }
+    },
+    {
+        "parent": "device_interface_template",
+        "module_data": {
+            "name": "Dev Intf 1",
+            "device_type": 1
+        },
+        "expected": {
+            "name": "Dev Intf 1",
+            "devicetype_id": 1
+        }
+    },
+    {
+        "parent": "front_port_template",
+        "module_data": {
+            "name": "FP 1",
+            "device_type": 1
+        },
+        "expected": {
+            "name": "FP 1",
+            "devicetype_id": 1
+        }
+    },
+    {
+        "parent": "power_outlet_template",
+        "module_data": {
+            "name": "PO 1",
+            "device_type": 1
+        },
+        "expected": {
+            "name": "PO 1",
+            "devicetype_id": 1
+        }
+    },
+    {
+        "parent": "power_port_template",
+        "module_data": {
+            "name": "PP 1",
+            "device_type": 1
+        },
+        "expected": {
+            "name": "PP 1",
+            "devicetype_id": 1
+        }
+    },
+    {
         "parent": "virtual_machine",
         "module_data": {
             "name": "Test VM 100",


### PR DESCRIPTION
I fixed this for just two templates instead of all of them. This new code should resolve that issue.