### PR TITLE
Bugfix: Fixes no endpoint updates if tags are specified

### DIFF
--- a/changelogs/fragments/fix_tags.yml
+++ b/changelogs/fragments/fix_tags.yml
@@ -1,0 +1,2 @@
+bugfix:
+  - Fix bug introduced by #247 to deal with tags

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -871,6 +871,9 @@ class NetboxModule(object):
         serialized_nb_obj = self.nb_object.serialize()
         updated_obj = serialized_nb_obj.copy()
         updated_obj.update(data)
+        if serialized_nb_obj.get("tags") and data.get("tags"):
+            serialized_nb_obj["tags"] = set(serialized_nb_obj["tags"])
+            updated_obj["tags"] = set(data["tags"])
 
         if serialized_nb_obj == updated_obj:
             return serialized_nb_obj, None

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -870,11 +870,7 @@ class NetboxModule(object):
         """
         serialized_nb_obj = self.nb_object.serialize()
         updated_obj = serialized_nb_obj.copy()
-        if serialized_nb_obj.get("tags") and data.get("tags"):
-            serialized_nb_obj["tags"] = set(serialized_nb_obj["tags"])
-            updated_obj["tags"] = set(data["tags"])
-        else:
-            updated_obj.update(data)
+        updated_obj.update(data)
 
         if serialized_nb_obj == updated_obj:
             return serialized_nb_obj, None

--- a/tests/integration/targets/regression/tasks/main.yml
+++ b/tests/integration/targets/regression/tasks/main.yml
@@ -90,6 +90,7 @@
           device_role: "Core Switch"
           site: "Test Site"
           status: "Staged"
+          asset_tag: "1234"
           tags:
             - second
             - third
@@ -134,3 +135,27 @@
           - test_six.results[3]["diff"]["before"]["state"] == "absent"
           - test_six.results[3]["diff"]["after"]["state"] == "present"
           - test_six.results[3]["interface_template"]["device_type"] == 3
+
+    - name: "7 - Don't prevent updates to other params if tags are specified"
+      netbox.netbox.netbox_device:
+        netbox_url: "http://localhost:32768"
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: "issue-242"
+          device_type: "Cisco Test"
+          device_role: "Core Switch"
+          site: "Test Site"
+          status: "Staged"
+          asset_tag: "Null"
+          tags:
+            - second
+            - third
+            - first
+      register: test_seven
+
+    - name: "5 - Assert added tag - Tests #242 is fixed"
+      assert:
+        that:
+          - test_seven is changed
+          - test_seven["diff"]["after"]["asset_tag"] == "Null"
+          - test_seven["device"]["asset_tag"] == "Null"


### PR DESCRIPTION
Bug was introduced in #247. I forgot to update the object to check for any other possible updates if tags were specified.

Fixes #324 
Fixes #311 
Fixes #316 
Fixes #322 