### PR TITLE
Small adjustment on the custom venv

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -77,7 +77,8 @@ This will cover the basic usage of the NetBox inventory plugin within this colle
 5. Create inventory and select ``source from project``.
 6. Select the AWX/Tower project from Step 2
 7. Select the ``inventory.yml`` file in the project from Step 3
-8. Click ``Save`` and sync source.
+8. Make sure your Tower installation uses Python 3 or select the proper ``ANSIBLE ENVIRONMENT``
+9. Click ``Save`` and sync source.
 
 .. toctree::
    :maxdepth: 4


### PR DESCRIPTION
Small adjustment on the custom venv with Ansible Tower. Our production Tower installation ships with Python 2 by default. We need to add multiple custom venv for different uses.