### PR TITLE
Update netbox ansible-modules to support Netbox 2.9

### DIFF
--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -57,14 +57,12 @@ class NetboxIpamModule(NetboxModule):
         if not data.get("assigned_object_id") or not data.get("assigned_object_type") or not data.get("prefix"):
             self._handle_errors("A prefix, assigned_object_type and assigned_object are required")
 
-        query_params = { "parent": data["prefix"] }
-        #, {"assigned_object_id": data["assigned_object_id"], "assigned_object_type" : data["assigned_object_type"] 
+        query_params = {"parent": data["prefix"]}
 
         if data["assigned_object_type"] == "dcim.interface":
             query_params['interface_id'] = data["assigned_object_id"]
         else:
             query_params['vminterface_id'] = data['assigned_object_id']
-
 
         if data.get("vrf"):
             query_params["vrf_id"] = data["vrf"]

--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -54,10 +54,18 @@ class NetboxIpamModule(NetboxModule):
         self, nb_app, nb_endpoint, data, endpoint_name
     ):
         """"""
-        if not data.get("interface") or not data.get("prefix"):
-            self._handle_errors("A prefix and interface are required")
+        if not data.get("assigned_object_id") or not data.get("assigned_object_type") or not data.get("prefix"):
+            self._handle_errors("A prefix, assigned_object_type and assigned_object are required")
 
-        query_params = {"interface_id": data["interface"], "parent": data["prefix"]}
+        query_params = { "parent": data["prefix"] }
+        #, {"assigned_object_id": data["assigned_object_id"], "assigned_object_type" : data["assigned_object_type"] 
+
+        if data["assigned_object_type"] == "dcim.interface":
+            query_params['interface_id'] = data["assigned_object_id"]
+        else:
+            query_params['vminterface_id'] = data['assigned_object_id']
+
+
         if data.get("vrf"):
             query_params["vrf_id"] = data["vrf"]
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -185,6 +185,7 @@ CONVERT_TO_ID = {
     "tenant_group": "tenant_groups",
     "termination_a": "interfaces",
     "termination_b": "interfaces",
+    "assigned_object" : "interfaces",
     "untagged_vlan": "vlans",
     "virtual_chassis": "virtual_chassis",
     "virtual_machine": "virtual_machines",
@@ -320,6 +321,7 @@ ALLOWED_QUERY_PARAMS = {
     "vlan": set(["name", "site", "tenant", "vid", "vlan_group"]),
     "vlan_group": set(["slug", "site"]),
     "vrf": set(["name", "tenant"]),
+    "assigned_object": set(['name', 'device']),
 }
 
 QUERY_PARAMS_IDS = set(
@@ -384,6 +386,7 @@ CONVERT_KEYS = {
     "virtual_machine_role": "role",
     "vlan_role": "role",
     "vlan_group": "group",
+    "assigned_object" : "assigned_object_id",
 }
 
 # This is used to dynamically conver name to slug on endpoints requiring a slug
@@ -743,6 +746,8 @@ class NetboxModule(object):
                     endpoint = CONVERT_TO_ID[data.get("termination_a_type")]
                 elif k == "termination_b":
                     endpoint = CONVERT_TO_ID[data.get("termination_b_type")]
+                elif k == "assigned_object":
+                    endpoint = CONVERT_TO_ID[data.get("assigned_object_type")]
                 else:
                     endpoint = CONVERT_TO_ID[k]
                 search = v

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -759,6 +759,7 @@ class NetboxModule(object):
                     if k == "interface" and v.get("virtual_machine"):
                         nb_app = getattr(self.nb, "virtualization")
                         nb_endpoint = getattr(nb_app, endpoint)
+
                     query_params = self._build_query_params(k, data, child=v)
                     query_id = self._nb_endpoint_get(nb_endpoint, query_params, k)
 

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -320,7 +320,14 @@ def main():
                             "CARP",
                         ],
                     ),
-                    assigned_object_type=dict(required=False, type="str"),
+                    assigned_object_type=dict(
+                        required=False, 
+                        choices=[
+                            "dcim.interface",
+                            "virtualization.vminterface",
+                        ],
+                        type="str",
+                    ),
                     assigned_object=dict(required=False, type="raw"),
                     description=dict(required=False, type="str"),
                     nat_inside=dict(required=False, type="raw"),

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -101,13 +101,24 @@ options:
           - CARP
         required: false
         type: str
-      interface:
+      assigned_object_type:
+        description:
+          - | 
+            The type of the assigned object this IP address referes to
+        choices:
+          - dcim.interface
+          - virtualization.vminterface
+        required: false
+        type: str
+
+      assigned_object:
         description:
           - |
-            The name and device of the interface that the IP address should be assigned to
+            The name and device of the assigned object that the IP address should be assigned to
             Required if state is C(present) and a prefix specified.
         required: false
         type: raw
+
       description:
         description:
           - The description of the interface
@@ -309,7 +320,8 @@ def main():
                             "CARP",
                         ],
                     ),
-                    interface=dict(required=False, type="raw"),
+                    assigned_object_type=dict(required=False, type="str"),
+                    assigned_object=dict(required=False, type="raw"),
                     description=dict(required=False, type="str"),
                     nat_inside=dict(required=False, type="raw"),
                     dns_name=dict(required=False, type="str"),

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -321,7 +321,7 @@ def main():
                         ],
                     ),
                     assigned_object_type=dict(
-                        required=False, 
+                        required=False,
                         choices=[
                             "dcim.interface",
                             "virtualization.vminterface",


### PR DESCRIPTION
This is my go at trying to get netbox-ansible-modules to support Netbox 2.9 style of ipaddress assignments towards both dcim.interface and virtualization.vminterface.

Doing this PR to get the ball rolling.