### PR TITLE
Bugfix: Inventory - Prevent failing inventory on 403

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -279,13 +279,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 """
                 # Prevent inventory from failing completely if the token does not have the proper permissions for specific URLs
                 if e.code == 403:
-                    self.display.v(
+                    self.display.display(
                         "Permission denied: {0}. This may impair functionality of the inventory plugin.".format(
                             url
-                        )
+                        ),
+                        color="red",
                     )
-                    # Returning an empty iterable as it appears that most of the refresh_lookups iterate over results
-                    return []
+                    # Need to return mock response data that is empty to prevent any failures downstream
+                    return {"results": [], "next": None}
 
                 raise AnsibleError(to_native(e.fp.read()))
 

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -277,6 +277,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 This is to help determine what might be the issue when encountering an error.
                 Please check issue #294 for more info.
                 """
+                # Prevent inventory from failing completely if the token does not have the proper permissions for specific URLs
+                if e.code == 403:
+                    self.display.v(
+                        "Permission denied: {0}. This may impair functionality of the inventory plugin.".format(
+                            url
+                        )
+                    )
+                    # Returning an empty iterable as it appears that most of the refresh_lookups iterate over results
+                    return []
+
                 raise AnsibleError(to_native(e.fp.read()))
 
             try:


### PR DESCRIPTION
Fixes #312 

This will print a red error message for any endpoints that return a 403. This should help users to determine why the inventory may not look as expected when they're using RBAC.