### PR TITLE
Correct labels from 'prefix' to 'interface'

### DIFF
--- a/docs/plugins/modules/netbox_device_interface/netbox.netbox.netbox_device_interface_module.rst
+++ b/docs/plugins/modules/netbox_device_interface/netbox.netbox.netbox_device_interface_module.rst
@@ -81,7 +81,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Defines the prefix configuration</div>
+                                            <div>Defines the interface configuration</div>
                                                         </td>
             </tr>
                                         <tr>
@@ -97,7 +97,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>The description of the prefix</div>
+                                            <div>The description of the interface</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -283,7 +283,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Any tags that the prefix may need to be associated with</div>
+                                            <div>Any tags that the interface may need to be associated with</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/plugins/modules/netbox_device_interface/netbox.netbox.netbox_device_interface_module.rst
+++ b/docs/plugins/modules/netbox_device_interface/netbox.netbox.netbox_device_interface_module.rst
@@ -81,7 +81,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Defines the interface configuration</div>
+                                            <div>Defines the prefix configuration</div>
                                                         </td>
             </tr>
                                         <tr>
@@ -97,7 +97,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>The description of the interface</div>
+                                            <div>The description of the prefix</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -283,7 +283,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Any tags that the interface may need to be associated with</div>
+                                            <div>Any tags that the prefix may need to be associated with</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -41,7 +41,7 @@ options:
     type: str
   data:
     description:
-      - Defines the prefix configuration
+      - Defines the interface configuration
     suboptions:
       device:
         description:
@@ -96,7 +96,7 @@ options:
         type: bool
       description:
         description:
-          - The description of the prefix
+          - The description of the interface
         required: false
         type: str
       mode:
@@ -116,7 +116,7 @@ options:
         type: raw
       tags:
         description:
-          - Any tags that the prefix may need to be associated with
+          - Any tags that the interface may need to be associated with
         required: false
         type: list
     required: true


### PR DESCRIPTION
Some of the descriptions were copied from the `netbox_prefix` module into the `netbox_device_interface` module. This PR is just to correct those.