### PR TITLE
Updated documentation for the family in netbox_ip_address

### DIFF
--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -52,6 +52,7 @@ options:
           - 4
           - 6
         required: false
+        removed_in: 0.3.0
         type: int
       address:
         description:

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -45,6 +45,15 @@ options:
     description:
       - Defines the IP address configuration
     suboptions:
+      family:
+        description:
+          - (DEPRECATED) - NetBox now handles determining the IP family natively.
+          - Specifies with address family the IP address belongs to
+        choices:
+          - 4
+          - 6
+        required: false
+        type: int
       address:
         description:
           - Required if state is C(present)

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -45,15 +45,6 @@ options:
     description:
       - Defines the IP address configuration
     suboptions:
-      family:
-        description:
-          - Specifies with address family the IP address belongs to
-        choices:
-          - 4
-          - 6
-        required: false
-        removed_in: 0.3.0
-        type: int
       address:
         description:
           - Required if state is C(present)


### PR DESCRIPTION
Fixes #373

Not a great way, but appears you just document in the `DOCUMENTATION` description for the option.