### PR TITLE
Fixed user_query_params to pass before module_data is considered

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -653,7 +653,11 @@ class NetboxModule(object):
                     value = module_data.get(match)
                 query_dict.update({match: value})
 
-        if parent == "lag":
+        if user_query_params:
+            # This is to skip any potential changes using module_data when the user
+            # provides user_query_params
+            pass
+        elif parent == "lag":
             if not child:
                 query_dict["name"] = module_data["lag"]
             intf_type = self._fetch_choice_value(

--- a/tests/integration/targets/latest/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/latest/tasks/netbox_ip_address.yml
@@ -171,7 +171,7 @@
       - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
-      - test_eight['ip_address']['nat_inside'] == 10
+      - test_eight['ip_address']['nat_inside'] == 11
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/regression-latest/tasks/main.yml
+++ b/tests/integration/targets/regression-latest/tasks/main.yml
@@ -159,3 +159,38 @@
           - test_seven is changed
           - test_seven["diff"]["after"]["asset_tag"] == "Null"
           - test_seven["device"]["asset_tag"] == "Null"
+
+    - name: Add ip address to netbox and don't assign it to a device (Issue 372)
+      netbox.netbox.netbox_ip_address:
+        netbox_url: "http://localhost:32768"
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          address: 10.255.255.1/24
+        query_params:
+          - address
+          - vrf
+        state: present
+
+    - name: Update same ip address to attach to a device interface (Issue 372)
+      netbox.netbox.netbox_ip_address:
+        netbox_url: "http://localhost:32768"
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          address: 10.255.255.1/24
+          assigned_object:
+            device: test100
+            name: GigabitEthernet1
+        query_params:
+          - address
+          - vrf
+        state: present
+      register: query_params_372
+
+    - name: Assert ip address was updated and added to device interface
+      assert:
+        that:
+          - query_params_372 is changed
+          - query_params_372['msg'] == 'ip_address 10.255.255.1/24 updated'
+          - query_params_372['after']['assigned_object'] == 3
+          - query_params_372['after']['assigned_object_id'] == 3
+          - query_params_372['after']['assigned_object_type'] == 'dcim.interface'

--- a/tests/integration/targets/regression-latest/tasks/main.yml
+++ b/tests/integration/targets/regression-latest/tasks/main.yml
@@ -191,6 +191,6 @@
         that:
           - query_params_372 is changed
           - query_params_372['msg'] == 'ip_address 10.255.255.1/24 updated'
-          - query_params_372['after']['assigned_object'] == 3
-          - query_params_372['after']['assigned_object_id'] == 3
-          - query_params_372['after']['assigned_object_type'] == 'dcim.interface'
+          - query_params_372['diff']['after']['assigned_object'] == 3
+          - query_params_372['diff']['after']['assigned_object_id'] == 3
+          - query_params_372['diff']['after']['assigned_object_type'] == 'dcim.interface'

--- a/tests/integration/targets/v2.8/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v2.8/tasks/netbox_ip_address.yml
@@ -173,7 +173,7 @@
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
       - test_eight['ip_address']['interface'] == 3
-      - test_eight['ip_address']['nat_inside'] == 11
+      - test_eight['ip_address']['nat_inside'] == 10
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/v2.8/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v2.8/tasks/netbox_ip_address.yml
@@ -173,7 +173,7 @@
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
       - test_eight['ip_address']['interface'] == 3
-      - test_eight['ip_address']['nat_inside'] == 10
+      - test_eight['ip_address']['nat_inside'] == 11
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"


### PR DESCRIPTION
Fixes #372 

There is logic that adds and manipulates data in the query params that should be skipped when a user defines `user_query_params`.