### PR TITLE
Add dns_name option for the Primary IP's dns_name host_var

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -732,7 +732,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if host["is_virtual"]:
                 ip_address = self.vm_ipaddresses_lookup.get(host["primary_ip"]["id"])
             else:
-                ip_address = self.device_ipaddresses_lookup.get(host["primary_ip"]["id"])
+                ip_address = self.device_ipaddresses_lookup.get(
+                    host["primary_ip"]["id"]
+                )
 
         # Don"t assign a host_var for empty dns_name
         if ip_address.get("dns_name") == "":

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -660,7 +660,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     interface["ip_addresses"] = list(
                         self.vm_ipaddresses_intf_lookup[interface["id"]].values()
                         if host["is_virtual"]
-                        else self.device_ipaddresses_intf_lookup[interface["id"]].values()
+                        else self.device_ipaddresses_intf_lookup[
+                            interface["id"]
+                        ].values()
                     )
 
             return interfaces
@@ -720,23 +722,23 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def extract_dns_name(self, host):
         # No primary IP assigned
-        if not host.get('primary_ip'):
+        if not host.get("primary_ip"):
             return None
 
         before_netbox_v29 = bool(self.ipaddresses_lookup)
         if before_netbox_v29:
-            ip_address = self.ipaddresses_lookup.get(host['primary_ip']['id'])
+            ip_address = self.ipaddresses_lookup.get(host["primary_ip"]["id"])
         else:
-            if host['is_virtual']:
-                ip_address = self.vm_ipaddresses_lookup.get(host['primary_ip']['id'])
+            if host["is_virtual"]:
+                ip_address = self.vm_ipaddresses_lookup.get(host["primary_ip"]["id"])
             else:
-                ip_address = self.device_ipaddresses_lookup.get(host['primary_ip']['id'])
+                ip_address = self.device_ipaddresses_lookup.get(host["primary_ip"]["id"])
 
-        # Don't assign a host_var for empty dns_name
-        if ip_address.get('dns_name') == '':
+        # Don"t assign a host_var for empty dns_name
+        if ip_address.get("dns_name") == "":
             return None
 
-        return ip_address.get('dns_name')
+        return ip_address.get("dns_name")
 
     def refresh_platforms_lookup(self):
         url = self.api_endpoint + "/api/dcim/platforms/?limit=0"
@@ -1003,7 +1005,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
                 if ipaddress["assigned_object_type"] == "virtualization.vminterface":
                     self.vm_ipaddresses_lookup[ip_id] = ipaddress_copy
-                    self.vm_ipaddresses_intf_lookup[interface_id][ip_id] = ipaddress_copy
+                    self.vm_ipaddresses_intf_lookup[interface_id][
+                        ip_id
+                    ] = ipaddress_copy
                 else:
                     self.device_ipaddresses_lookup[ip_id] = ipaddress_copy
                     self.device_ipaddresses_intf_lookup[interface_id][

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -171,6 +171,12 @@ DOCUMENTATION = """
                 - The host var values will be from the virtual chassis master.
             type: boolean
             default: False
+        dns_name:
+            description:
+                - Force IP Addresses to be fetched so that the dns_name for the primary_ip of each device or VM is set as a host_var.
+                - Setting interfaces will also fetch IP addresses and the dns_name host_var will be set.
+            type: boolean
+            default: False
         compose:
             description: List of custom ansible host vars to create from the device object fetched from NetBox
             default: {}
@@ -420,6 +426,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 {"interfaces": self.extract_interfaces,}
             )
 
+        if self.interfaces or self.dns_name:
+            extractors.update(
+                {"dns_name": self.extract_dns_name,}
+            )
+
         return extractors
 
     def _pluralize_group_by(self, group_by):
@@ -638,18 +649,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             interfaces = list(interfaces_lookup[host["id"]].values())
 
-            before_netbox_v29 = bool(self.ipaddresses_lookup)
+            before_netbox_v29 = bool(self.ipaddresses_intf_lookup)
             # Attach IP Addresses to their interface
             for interface in interfaces:
                 if before_netbox_v29:
                     interface["ip_addresses"] = list(
-                        self.ipaddresses_lookup[interface["id"]].values()
+                        self.ipaddresses_intf_lookup[interface["id"]].values()
                     )
                 else:
                     interface["ip_addresses"] = list(
-                        self.vm_ipaddresses_lookup[interface["id"]].values()
+                        self.vm_ipaddresses_intf_lookup[interface["id"]].values()
                         if host["is_virtual"]
-                        else self.device_ipaddresses_lookup[interface["id"]].values()
+                        else self.device_ipaddresses_intf_lookup[interface["id"]].values()
                     )
 
             return interfaces
@@ -706,6 +717,26 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def extract_is_virtual(self, host):
         return host.get("is_virtual")
+
+    def extract_dns_name(self, host):
+        # No primary IP assigned
+        if not host.get('primary_ip'):
+            return None
+
+        before_netbox_v29 = bool(self.ipaddresses_lookup)
+        if before_netbox_v29:
+            ip_address = self.ipaddresses_lookup.get(host['primary_ip']['id'])
+        else:
+            if host['is_virtual']:
+                ip_address = self.vm_ipaddresses_lookup.get(host['primary_ip']['id'])
+            else:
+                ip_address = self.device_ipaddresses_lookup.get(host['primary_ip']['id'])
+
+        # Don't assign a host_var for empty dns_name
+        if ip_address.get('dns_name') == '':
+            return None
+
+        return ip_address.get('dns_name')
 
     def refresh_platforms_lookup(self):
         url = self.api_endpoint + "/api/dcim/platforms/?limit=0"
@@ -953,10 +984,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # Construct a dictionary of lists, to allow looking up ip addresses by interface id
         # Note that interface ids share the same namespace for both devices and vms so this is a single dictionary
-        self.ipaddresses_lookup = defaultdict(dict)
+        self.ipaddresses_intf_lookup = defaultdict(dict)
+        # Construct a dictionary of the IP addresses themselves
+        self.ipaddresses_lookup = dict()
         # NetBox v2.9 and onwards
-        self.vm_ipaddresses_lookup = defaultdict(dict)
-        self.device_ipaddresses_lookup = defaultdict(dict)
+        self.vm_ipaddresses_intf_lookup = defaultdict(dict)
+        self.vm_ipaddresses_lookup = dict()
+        self.device_ipaddresses_intf_lookup = defaultdict(dict)
+        self.device_ipaddresses_lookup = dict()
 
         for ipaddress in ipaddresses:
             # As of NetBox v2.9 "assigned_object_x" replaces "interface"
@@ -967,9 +1002,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 ipaddress_copy = ipaddress.copy()
 
                 if ipaddress["assigned_object_type"] == "virtualization.vminterface":
-                    self.vm_ipaddresses_lookup[interface_id][ip_id] = ipaddress_copy
+                    self.vm_ipaddresses_lookup[ip_id] = ipaddress_copy
+                    self.vm_ipaddresses_intf_lookup[interface_id][ip_id] = ipaddress_copy
                 else:
-                    self.device_ipaddresses_lookup[interface_id][
+                    self.device_ipaddresses_lookup[ip_id] = ipaddress_copy
+                    self.device_ipaddresses_intf_lookup[interface_id][
                         ip_id
                     ] = ipaddress_copy  # Remove "assigned_object_X" attributes, as that's redundant when ipaddress is added to an interface
 
@@ -986,7 +1023,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             # We need to copy the ipaddress entry to preserve the original in case caching is used.
             ipaddress_copy = ipaddress.copy()
 
-            self.ipaddresses_lookup[interface_id][ip_id] = ipaddress_copy
+            self.ipaddresses_intf_lookup[interface_id][ip_id] = ipaddress_copy
+            self.ipaddresses_lookup[ip_id] = ipaddress_copy
             # Remove "interface" attribute, as that's redundant when ipaddress is added to an interface
             del ipaddress_copy["interface"]
 
@@ -1017,7 +1055,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def lookup_processes_secondary(self):
         lookups = []
 
-        if self.interfaces:
+        # IP addresses are needed for either interfaces or dns_name options
+        if self.interfaces or self.dns_name:
             lookups.append(self.refresh_ipaddresses)
 
         return lookups
@@ -1458,5 +1497,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.device_query_filters = self.get_option("device_query_filters")
         self.vm_query_filters = self.get_option("vm_query_filters")
         self.virtual_chassis_name = self.get_option("virtual_chassis_name")
+        self.dns_name = self.get_option("dns_name")
 
         self.main()

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -990,12 +990,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Note that interface ids share the same namespace for both devices and vms so this is a single dictionary
         self.ipaddresses_intf_lookup = defaultdict(dict)
         # Construct a dictionary of the IP addresses themselves
-        self.ipaddresses_lookup = dict()
+        self.ipaddresses_lookup = defaultdict(dict)
         # NetBox v2.9 and onwards
         self.vm_ipaddresses_intf_lookup = defaultdict(dict)
-        self.vm_ipaddresses_lookup = dict()
+        self.vm_ipaddresses_lookup = defaultdict(dict)
         self.device_ipaddresses_intf_lookup = defaultdict(dict)
-        self.device_ipaddresses_lookup = dict()
+        self.device_ipaddresses_lookup = defaultdict(dict)
 
         for ipaddress in ipaddresses:
             # As of NetBox v2.9 "assigned_object_x" replaces "interface"

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -320,14 +320,14 @@ test100_gi2 = nb.dcim.interfaces.get(name="GigabitEthernet2", device_id=1)
 
 ## Create IP Addresses
 ip_addresses = [
-    {
-        "address": "172.16.180.1/24",
-        "interface": test100_gi1.id,
-        "dns_name": "test100.example.com",
-    },
+    {"address": "172.16.180.1/24", "interface": test100_gi1.id},
     {"address": "2001::1:1/64", "interface": test100_gi2.id},
     {"address": "172.16.180.11/24", "interface": created_nexus_interfaces[0].id},
-    {"address": "172.16.180.12/24", "interface": created_nexus_interfaces[1].id},
+    {
+        "address": "172.16.180.12/24",
+        "interface": created_nexus_interfaces[1].id,
+        "dns_name": "nexus.example.com",
+    },
     {"address": "172.16.180.254/24"},
 ]
 if nb_version > version.parse("2.8"):
@@ -341,7 +341,7 @@ if nb_version > version.parse("2.8"):
 created_ip_addresses = make_netbox_calls(nb.ipam.ip_addresses, ip_addresses)
 
 # Assign Primary IP
-test100.update({"primary_ip4": 1})
+nexus.update({"primary_ip4": 4})
 
 ## Create RIRs
 rirs = [{"name": "Example RIR", "slug": "example-rir"}]

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -320,7 +320,11 @@ test100_gi2 = nb.dcim.interfaces.get(name="GigabitEthernet2", device_id=1)
 
 ## Create IP Addresses
 ip_addresses = [
-    {"address": "172.16.180.1/24", "interface": test100_gi1.id, "dns_name": "test100.example.com"},
+    {
+        "address": "172.16.180.1/24",
+        "interface": test100_gi1.id,
+        "dns_name": "test100.example.com"
+    },
     {"address": "2001::1:1/64", "interface": test100_gi2.id},
     {"address": "172.16.180.11/24", "interface": created_nexus_interfaces[0].id},
     {"address": "172.16.180.12/24", "interface": created_nexus_interfaces[1].id},
@@ -431,8 +435,8 @@ services = [
 # 2.10+ requires the port attribute to be 'ports' and a list instead of an integer
 for service in services:
     if nb_version >= version.parse("2.10"):
-        service['ports'] = [service['port']]
-        del(service['port'])
+        service["ports"] = [service["port"]]
+        del(service["port"])
 
 created_services = make_netbox_calls(nb.ipam.services, services)
 

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -323,7 +323,7 @@ ip_addresses = [
     {
         "address": "172.16.180.1/24",
         "interface": test100_gi1.id,
-        "dns_name": "test100.example.com"
+        "dns_name": "test100.example.com",
     },
     {"address": "2001::1:1/64", "interface": test100_gi2.id},
     {"address": "172.16.180.11/24", "interface": created_nexus_interfaces[0].id},
@@ -436,7 +436,7 @@ services = [
 for service in services:
     if nb_version >= version.parse("2.10"):
         service["ports"] = [service["port"]]
-        del(service["port"])
+        del service["port"]
 
 created_services = make_netbox_calls(nb.ipam.services, services)
 

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 import os
 import sys
 import pynetbox
+from packaging import version
 
 # NOTE: If anything depends on specific versions of NetBox, can check INTEGRATION_TESTS in env
 # os.environ["INTEGRATION_TESTS"]
@@ -16,7 +17,7 @@ import pynetbox
 nb_host = os.getenv("NETBOX_HOST", "http://localhost:32768")
 nb_token = os.getenv("NETBOX_TOKEN", "0123456789abcdef0123456789abcdef01234567")
 nb = pynetbox.api(nb_host, nb_token)
-version = float(nb.version)
+nb_version = version.parse(nb.version)
 
 ERRORS = False
 
@@ -39,7 +40,7 @@ def make_netbox_calls(endpoint, payload):
 
 
 # Create tags used in future tests
-if version >= 2.9:
+if nb_version >= version.parse("2.9"):
     create_tags = nb.extras.tags.create(
         [
             {"name": "First", "slug": "first"},
@@ -187,7 +188,7 @@ device_types = [
     },
     {"model": "1841", "slug": "1841", "manufacturer": cisco_manu.id,},
 ]
-if version > 2.8:
+if nb_version > version.parse("2.8"):
     temp_dt = []
     for dt_type in device_types:
         if dt_type.get("subdevice_role") is not None and not dt_type["subdevice_role"]:
@@ -319,13 +320,13 @@ test100_gi2 = nb.dcim.interfaces.get(name="GigabitEthernet2", device_id=1)
 
 ## Create IP Addresses
 ip_addresses = [
-    {"address": "172.16.180.1/24", "interface": test100_gi1.id},
+    {"address": "172.16.180.1/24", "interface": test100_gi1.id, "dns_name": "test100.example.com"},
     {"address": "2001::1:1/64", "interface": test100_gi2.id},
     {"address": "172.16.180.11/24", "interface": created_nexus_interfaces[0].id},
     {"address": "172.16.180.12/24", "interface": created_nexus_interfaces[1].id},
     {"address": "172.16.180.254/24"},
 ]
-if version > 2.8:
+if nb_version > version.parse("2.8"):
     temp_ips = []
     for ip in ip_addresses:
         if ip.get("interface"):
@@ -335,6 +336,8 @@ if version > 2.8:
 
 created_ip_addresses = make_netbox_calls(nb.ipam.ip_addresses, ip_addresses)
 
+# Assign Primary IP
+test100.update({"primary_ip4": 1})
 
 ## Create RIRs
 rirs = [{"name": "Example RIR", "slug": "example-rir"}]
@@ -425,6 +428,12 @@ services = [
         "protocol": "tcp",
     },
 ]
+# 2.10+ requires the port attribute to be 'ports' and a list instead of an integer
+for service in services:
+    if nb_version >= version.parse("2.10"):
+        service['ports'] = [service['port']]
+        del(service['port'])
+
 created_services = make_netbox_calls(nb.ipam.services, services)
 
 

--- a/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
@@ -63,7 +63,9 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "port": 23,
+                        "ports": [
+                            23
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -98,7 +100,9 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -153,6 +157,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_roles": [
                     "core-switch"
@@ -171,6 +176,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -187,7 +193,9 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -217,7 +225,9 @@
                             }
                         ],
                         "name": "http",
-                        "port": 80,
+                        "ports": [
+                            80
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
@@ -33,6 +33,7 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "custom_fields": {},
                 "device_roles": [
                     "core-switch"
@@ -47,6 +48,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -63,9 +65,7 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "ports": [
-                            23
-                        ],
+                        "port": 23,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -100,9 +100,7 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -157,7 +155,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_roles": [
                     "core-switch"
@@ -176,7 +173,6 @@
                 "manufacturers": [
                     "cisco"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -193,9 +189,7 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -225,9 +219,7 @@
                             }
                         ],
                         "name": "http",
-                        "ports": [
-                            80
-                        ],
+                        "port": 80,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
@@ -48,9 +48,11 @@
                 "interfaces": [
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -100,9 +102,11 @@
                     },
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -170,7 +174,9 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "port": 23,
+                        "ports": [
+                            23
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -235,7 +241,9 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -277,13 +285,17 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "device_type": "cisco-test",
+                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -298,7 +310,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "test100.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -333,9 +345,11 @@
                     },
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -389,6 +403,7 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -406,7 +421,9 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -436,7 +453,9 @@
                             }
                         ],
                         "name": "http",
-                        "port": 80,
+                        "ports": [
+                            80
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
@@ -44,15 +44,15 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
                 "interfaces": [
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -102,11 +102,9 @@
                     },
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -121,7 +119,7 @@
                                 "address": "172.16.180.12/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "nexus.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -157,6 +155,7 @@
                 ],
                 "is_virtual": false,
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -174,9 +173,7 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "ports": [
-                            23
-                        ],
+                        "port": 23,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -241,9 +238,7 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -285,17 +280,13 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "device_type": "cisco-test",
-                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -310,7 +301,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "test100.example.com",
+                                "dns_name": "",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -345,11 +336,9 @@
                     },
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -403,7 +392,6 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -421,9 +409,7 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -453,9 +439,7 @@
                             }
                         ],
                         "name": "http",
-                        "ports": [
-                            80
-                        ],
+                        "port": 80,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.json
@@ -99,9 +99,11 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_type": "cisco-test",
                 "display": "test100",
+                "dns_name": "test100.example.com",
                 "is_virtual": false,
                 "local_context_data": {
                     "ntp_servers": [
@@ -109,6 +111,7 @@
                     ]
                 },
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.json
@@ -81,11 +81,14 @@
                 "tags": []
             },
             "VC1": {
+                "ansible_host": "172.16.180.12",
                 "custom_fields": {},
                 "device_type": "nexus-parent",
                 "display": "Test Nexus One",
+                "dns_name": "nexus.example.com",
                 "is_virtual": false,
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -99,11 +102,9 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_type": "cisco-test",
                 "display": "test100",
-                "dns_name": "test100.example.com",
                 "is_virtual": false,
                 "local_context_data": {
                     "ntp_servers": [
@@ -111,7 +112,6 @@
                     ]
                 },
                 "manufacturer": "cisco",
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
@@ -16,6 +16,7 @@ interfaces: False
 services: False
 group_names_raw: True
 virtual_chassis_name: True
+dns_name: True
 
 group_by:
   - site

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
@@ -130,6 +130,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "device_roles": [
                     "core-switch"
                 ],
@@ -150,6 +151,7 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
@@ -55,6 +55,7 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "device_roles": [
                     "core-switch"
                 ],
@@ -68,6 +69,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -130,7 +132,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "device_roles": [
                     "core-switch"
                 ],
@@ -151,7 +152,6 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
@@ -50,9 +50,11 @@
                 "interfaces": [
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -102,9 +104,11 @@
                     },
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -176,7 +180,9 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "port": 23,
+                        "ports": [
+                            23
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -250,7 +256,9 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -309,6 +317,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "config_context": [
                     {
                         "ntp_servers": [
@@ -323,12 +332,15 @@
                 "device_types": [
                     "cisco-test"
                 ],
+                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -343,7 +355,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "test100.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -378,9 +390,11 @@
                     },
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -440,6 +454,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -456,7 +471,9 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -486,7 +503,9 @@
                             }
                         ],
                         "name": "http",
-                        "port": 80,
+                        "ports": [
+                            80
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
@@ -37,6 +37,7 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "config_context": [
                     {}
                 ],
@@ -47,14 +48,13 @@
                 "device_types": [
                     "nexus-parent"
                 ],
+                "dns_name": "nexus.example.com",
                 "interfaces": [
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -104,11 +104,9 @@
                     },
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -123,7 +121,7 @@
                                 "address": "172.16.180.12/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "nexus.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -164,6 +162,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -180,9 +179,7 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "ports": [
-                            23
-                        ],
+                        "port": 23,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -256,9 +253,7 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -317,7 +312,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "config_context": [
                     {
                         "ntp_servers": [
@@ -332,15 +326,12 @@
                 "device_types": [
                     "cisco-test"
                 ],
-                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -355,7 +346,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "test100.example.com",
+                                "dns_name": "",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -390,11 +381,9 @@
                     },
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -454,7 +443,6 @@
                 "manufacturers": [
                     "cisco"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -471,9 +459,7 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -503,9 +489,7 @@
                             }
                         ],
                         "name": "http",
-                        "ports": [
-                            80
-                        ],
+                        "port": 80,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"

--- a/tests/integration/targets/inventory-latest/files/test-inventory.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory.json
@@ -28,9 +28,11 @@
                 "interfaces": [
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -80,9 +82,11 @@
                     },
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -150,7 +154,9 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "port": 23,
+                        "ports": [
+                            23
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -217,7 +223,9 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -261,6 +269,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "config_context": {
                     "ntp_servers": [
                         "pool.ntp.org"
@@ -268,12 +277,15 @@
                 },
                 "custom_fields": {},
                 "device_type": "cisco-test",
+                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -288,7 +300,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "test100.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -323,9 +335,11 @@
                     },
                     {
                         "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
                         "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
-                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -381,6 +395,7 @@
                     ]
                 },
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -398,7 +413,9 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "port": 22,
+                        "ports": [
+                            22
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -428,7 +445,9 @@
                             }
                         ],
                         "name": "http",
-                        "port": 80,
+                        "ports": [
+                            80
+                        ],
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -843,14 +862,14 @@
             "test100"
         ]
     },
-    "service_ssh": {
+    "service_http": {
         "hosts": [
-            "Test VM With Spaces",
             "test100"
         ]
     },
-    "service_http": {
+    "service_ssh": {
         "hosts": [
+            "Test VM With Spaces",
             "test100"
         ]
     },

--- a/tests/integration/targets/inventory-latest/files/test-inventory.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory.json
@@ -22,17 +22,17 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "config_context": {},
                 "custom_fields": {},
                 "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
                 "interfaces": [
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -82,11 +82,9 @@
                     },
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -101,7 +99,7 @@
                                 "address": "172.16.180.12/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "nexus.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -137,6 +135,7 @@
                 ],
                 "is_virtual": false,
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -154,9 +153,7 @@
                         "id": 3,
                         "ipaddresses": [],
                         "name": "telnet",
-                        "ports": [
-                            23
-                        ],
+                        "port": 23,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -223,9 +220,7 @@
                         "id": 4,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -269,7 +264,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "config_context": {
                     "ntp_servers": [
                         "pool.ntp.org"
@@ -277,15 +271,12 @@
                 },
                 "custom_fields": {},
                 "device_type": "cisco-test",
-                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -300,7 +291,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "test100.example.com",
+                                "dns_name": "",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -335,11 +326,9 @@
                     },
                     {
                         "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
                         "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
+                        "connection_status": null,
                         "count_ipaddresses": 1,
                         "description": "",
                         "device": {
@@ -395,7 +384,6 @@
                     ]
                 },
                 "manufacturer": "cisco",
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -413,9 +401,7 @@
                         "id": 1,
                         "ipaddresses": [],
                         "name": "ssh",
-                        "ports": [
-                            22
-                        ],
+                        "port": 22,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"
@@ -445,9 +431,7 @@
                             }
                         ],
                         "name": "http",
-                        "ports": [
-                            80
-                        ],
+                        "port": 80,
                         "protocol": {
                             "label": "TCP",
                             "value": "tcp"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-legacy.json
@@ -34,6 +34,7 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "custom_fields": {},
                 "device_roles": [
                     "core-switch"
@@ -48,6 +49,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -159,7 +161,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_roles": [
                     "core-switch"
@@ -178,7 +179,6 @@
                 "manufacturers": [
                     "cisco"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-legacy.json
@@ -159,6 +159,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_roles": [
                     "core-switch"
@@ -177,6 +178,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-options-flatten.json
@@ -45,7 +45,9 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -119,7 +121,7 @@
                                 "address": "172.16.180.12/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "nexus.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -156,6 +158,7 @@
                 ],
                 "is_virtual": false,
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -293,9 +296,7 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "device_type": "cisco-test",
-                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -316,7 +317,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "test100.example.com",
+                                "dns_name": "",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -409,7 +410,6 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-options-flatten.json
@@ -293,7 +293,9 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "device_type": "cisco-test",
+                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -314,7 +316,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "test100.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -407,6 +409,7 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-options.json
@@ -103,9 +103,11 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_type": "cisco-test",
                 "display": "test100",
+                "dns_name": "test100.example.com",
                 "is_virtual": false,
                 "local_context_data": {
                     "ntp_servers": [
@@ -113,6 +115,7 @@
                     ]
                 },
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-options.json
@@ -46,11 +46,14 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "custom_fields": {},
                 "device_type": "nexus-parent",
                 "display": "Test Nexus One",
+                "dns_name": "nexus.example.com",
                 "is_virtual": false,
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -103,11 +106,9 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "custom_fields": {},
                 "device_type": "cisco-test",
                 "display": "test100",
-                "dns_name": "test100.example.com",
                 "is_virtual": false,
                 "local_context_data": {
                     "ntp_servers": [
@@ -115,7 +116,6 @@
                     ]
                 },
                 "manufacturer": "cisco",
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-options.yml
@@ -15,6 +15,7 @@ plurals: False
 interfaces: False
 services: False
 group_names_raw: True
+dns_name: True
 
 group_by:
   - site

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals-flatten.json
@@ -134,6 +134,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "device_roles": [
                     "core-switch"
                 ],
@@ -154,6 +155,7 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals-flatten.json
@@ -56,6 +56,7 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "device_roles": [
                     "core-switch"
                 ],
@@ -69,6 +70,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -134,7 +136,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "device_roles": [
                     "core-switch"
                 ],
@@ -155,7 +156,6 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals.json
@@ -325,6 +325,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "config_context": [
                     {
                         "ntp_servers": [
@@ -339,6 +340,7 @@
                 "device_types": [
                     "cisco-test"
                 ],
+                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -359,7 +361,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "test100.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -458,6 +460,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory-plurals.json
@@ -38,6 +38,7 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "config_context": [
                     {}
                 ],
@@ -48,6 +49,7 @@
                 "device_types": [
                     "nexus-parent"
                 ],
+                "dns_name": "nexus.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -121,7 +123,7 @@
                                 "address": "172.16.180.12/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "nexus.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -163,6 +165,7 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -325,7 +328,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "config_context": [
                     {
                         "ntp_servers": [
@@ -340,7 +342,6 @@
                 "device_types": [
                     "cisco-test"
                 ],
-                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -361,7 +362,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "test100.example.com",
+                                "dns_name": "",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -460,7 +461,6 @@
                 "manufacturers": [
                     "cisco"
                 ],
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory.json
@@ -23,9 +23,11 @@
                 "tags": []
             },
             "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
                 "config_context": {},
                 "custom_fields": {},
                 "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -99,7 +101,7 @@
                                 "address": "172.16.180.12/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "nexus.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -136,6 +138,7 @@
                 ],
                 "is_virtual": false,
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -277,7 +280,6 @@
                 "tags": []
             },
             "test100": {
-                "ansible_host": "172.16.180.1",
                 "config_context": {
                     "ntp_servers": [
                         "pool.ntp.org"
@@ -285,7 +287,6 @@
                 },
                 "custom_fields": {},
                 "device_type": "cisco-test",
-                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -306,7 +307,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "test100.example.com",
+                                "dns_name": "",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -401,7 +402,6 @@
                     ]
                 },
                 "manufacturer": "cisco",
-                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"

--- a/tests/integration/targets/inventory-v2.8/files/test-inventory.json
+++ b/tests/integration/targets/inventory-v2.8/files/test-inventory.json
@@ -277,6 +277,7 @@
                 "tags": []
             },
             "test100": {
+                "ansible_host": "172.16.180.1",
                 "config_context": {
                     "ntp_servers": [
                         "pool.ntp.org"
@@ -284,6 +285,7 @@
                 },
                 "custom_fields": {},
                 "device_type": "cisco-test",
+                "dns_name": "test100.example.com",
                 "interfaces": [
                     {
                         "cable": null,
@@ -304,7 +306,7 @@
                                 "address": "172.16.180.1/24",
                                 "custom_fields": {},
                                 "description": "",
-                                "dns_name": "",
+                                "dns_name": "test100.example.com",
                                 "family": {
                                     "label": "IPv4",
                                     "value": 4
@@ -399,6 +401,7 @@
                     ]
                 },
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -909,14 +912,14 @@
             "test100"
         ]
     },
-    "service_ssh": {
+    "service_http": {
         "hosts": [
-            "Test VM With Spaces",
             "test100"
         ]
     },
-    "service_http": {
+    "service_ssh": {
         "hosts": [
+            "Test VM With Spaces",
             "test100"
         ]
     },

--- a/tests/unit/inventory/test_data/group_extractors/data.json
+++ b/tests/unit/inventory/test_data/group_extractors/data.json
@@ -3,6 +3,7 @@
         "plurals": false,
         "interfaces": false,
         "services": false,
+        "dns_name": false,
         "expected": [
             "disk",
             "memory",
@@ -33,13 +34,15 @@
             "device_types",
             "manufacturers",
             "services",
-            "interfaces"
+            "interfaces",
+            "dns_name"
         ]
     },
     {
         "plurals": true,
         "interfaces": true,
         "services": true,
+        "dns_name": true,
         "expected": [
             "disk",
             "memory",
@@ -60,7 +63,8 @@
             "device_types",
             "manufacturers",
             "services",
-            "interfaces"
+            "interfaces",
+            "dns_name"
         ],
         "not_expected": [
             "site",

--- a/tests/unit/inventory/test_nb_inventory.py
+++ b/tests/unit/inventory/test_nb_inventory.py
@@ -142,15 +142,16 @@ def test_refresh_lookups(inventory_fixture):
 
 
 @pytest.mark.parametrize(
-    "plurals, services, interfaces, expected, not_expected",
+    "plurals, services, interfaces, dns_name, expected, not_expected",
     load_relative_test_data("group_extractors"),
 )
 def test_group_extractors(
-    inventory_fixture, plurals, services, interfaces, expected, not_expected
+    inventory_fixture, plurals, services, interfaces, dns_name, expected, not_expected
 ):
     inventory_fixture.plurals = plurals
     inventory_fixture.services = services
     inventory_fixture.interfaces = interfaces
+    inventory_fixture.dns_name = dns_name
     extractors = inventory_fixture.group_extractors
 
     for key in expected:


### PR DESCRIPTION
Fixes #378. Adds the dns_name from the host's Primary IP to host_vars.
- Adds the dns_name option which forces IP addresses to be fetched and sets the dns_name host_var
- The interfaces option also causes IP addresses to be fetched, so the dns_name host_var will also be set with the interfaces option
- Added v2.10 fixes for the netbox_deploy.py script, but didn't fix all testing to work with v2.10. The inventory testing won't pass with v2.10
- I tested v2.9 locally and it passed. The automated testing will fail since it automatically gets latest from docker which is now v2.10.