### PR TITLE
Add option to list all virtual chassis members in inventory plugin

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -791,7 +791,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 try:
                     composite = self._compose(compose[varname], device)
                 except Exception as e:
-                    msg = "Could not set {} for VC member {}: {}".format(
+                    msg = "Could not set {0} for VC member {1}: {2}".format(
                         varname, device.get("name", ""), to_native(e)
                     )
                     if self.get_option("strict"):

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1084,11 +1084,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         raw_vc_members = self.get_resource_list(url)
 
         # Create member lookup dictionary for each virtual chassis
-        self.vc_members_lookup = dict()
+        self.vc_members_lookup = defaultdict(list)
         for member in raw_vc_members:
-            if member["virtual_chassis"]["id"] not in self.vc_members_lookup:
-                self.vc_members_lookup[member["virtual_chassis"]["id"]] = list()
-
             self.vc_members_lookup[member["virtual_chassis"]["id"]].append(member)
 
     @property

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -761,20 +761,20 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             return None
 
         # Only get VC members when the host is the master
-        if self._get_host_virtual_chassis_master(host) != host['id']:
+        if self._get_host_virtual_chassis_master(host) != host["id"]:
             return None
 
         vc_members = list()
-        for member in self.vc_members_lookup[host['virtual_chassis']['id']]:
+        for member in self.vc_members_lookup[host["virtual_chassis"]["id"]]:
             # Avoid infinite loop for master VC member
-            if member['id'] == host['id']:
+            if member["id"] == host["id"]:
                 continue
 
             # Get all vars for the VC member
             host_vars = self._get_host_variables(member)
 
             # Convert into a dictionary and add to the members list
-            vc_members.append({ v[0]: v[1] for v in host_vars })
+            vc_members.append({v[0]: v[1] for v in host_vars})
 
         return vc_members
 
@@ -1078,16 +1078,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def refresh_virtual_chassis_members(self):
         # Get all devices that are VC members
-        url = self.api_endpoint + "/api/dcim/devices/?limit=0&virtual_chassis_member=true"
+        url = (
+            self.api_endpoint + "/api/dcim/devices/?limit=0&virtual_chassis_member=true"
+        )
         raw_vc_members = self.get_resource_list(url)
 
         # Create member lookup dictionary for each virtual chassis
         self.vc_members_lookup = dict()
         for member in raw_vc_members:
-            if member['virtual_chassis']['id'] not in self.vc_members_lookup:
-                self.vc_members_lookup[member['virtual_chassis']['id']] = list()
+            if member["virtual_chassis"]["id"] not in self.vc_members_lookup:
+                self.vc_members_lookup[member["virtual_chassis"]["id"]] = list()
 
-            self.vc_members_lookup[member['virtual_chassis']['id']].append(member)
+            self.vc_members_lookup[member["virtual_chassis"]["id"]].append(member)
 
     @property
     def lookup_processes(self):
@@ -1425,7 +1427,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         extracted_vars = list()
         extracted_primary_ip = self.extract_primary_ip(host=host)
         if extracted_primary_ip:
-            extracted_vars.append(('ansible_host', extracted_primary_ip))
+            extracted_vars.append(("ansible_host", extracted_primary_ip))
 
         extracted_primary_ip4 = self.extract_primary_ip4(host=host)
         if extracted_primary_ip4:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -791,12 +791,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 try:
                     composite = self._compose(compose[varname], device)
                 except Exception as e:
-                    if strict:
-                        raise AnsibleError(
-                            "Could not set {} for VC member {}: {}".format(
-                                varname, device.get("name", ""), to_native(e)
-                            )
-                        )
+                    msg = "Could not set {} for VC member {}: {}".format(
+                        varname, device.get("name", ""), to_native(e)
+                    )
+                    if self.get_option("strict"):
+                        raise AnsibleError(msg)
+                    else:
+                        self.display.warning(msg)
                     continue
                 host_vars.append((varname, composite))
 

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
@@ -730,6 +730,20 @@
             }
         }
     },
+    "active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "Test VM With Spaces",
+            "TestDeviceR1",
+            "test100",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
     "all": {
         "children": [
             "Test_Cluster",
@@ -799,20 +813,6 @@
     "parent_region": {
         "children": [
             "test_region"
-        ]
-    },
-    "active": {
-        "hosts": [
-            "R1-Device",
-            "Test Nexus One",
-            "Test VM With Spaces",
-            "TestDeviceR1",
-            "test100",
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm",
-            "test104-vm"
         ]
     },
     "test_cluster_group": {

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.json
@@ -99,7 +99,29 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vc_position": 0,
+                "virtual_chassis_members": [
+                    {
+                        "config_context": {},
+                        "custom_fields": {},
+                        "device_type": "nexus-child",
+                        "display": "Test Nexus Child One",
+                        "manufacturer": "cisco",
+                        "regions": [
+                            "test-region",
+                            "parent-region"
+                        ],
+                        "role": "core-switch",
+                        "site": "test-site",
+                        "status": {
+                            "label": "Active",
+                            "value": "active"
+                        },
+                        "tags": [],
+                        "vc_position": 2
+                    }
+                ]
             },
             "test100": {
                 "custom_fields": {},
@@ -206,6 +228,20 @@
             }
         }
     },
+    "active": {
+        "hosts": [
+            "R1-Device",
+            "Test VM With Spaces",
+            "TestDeviceR1",
+            "VC1",
+            "test100",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
     "all": {
         "children": [
             "Test_Cluster",
@@ -282,20 +318,6 @@
     "parent_region": {
         "children": [
             "test_region"
-        ]
-    },
-    "active": {
-        "hosts": [
-            "R1-Device",
-            "Test VM With Spaces",
-            "TestDeviceR1",
-            "VC1",
-            "test100",
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm",
-            "test104-vm"
         ]
     },
     "test_cluster_group": {

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
@@ -16,6 +16,7 @@ interfaces: False
 services: False
 group_names_raw: True
 virtual_chassis_name: True
+virtual_chassis_members: True
 dns_name: True
 
 group_by:

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
@@ -265,6 +265,20 @@
             }
         }
     },
+    "active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "Test VM With Spaces",
+            "TestDeviceR1",
+            "test100",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
     "all": {
         "children": [
             "Test_Cluster",
@@ -334,20 +348,6 @@
     "parent_region": {
         "children": [
             "test_region"
-        ]
-    },
-    "active": {
-        "hosts": [
-            "R1-Device",
-            "Test Nexus One",
-            "Test VM With Spaces",
-            "TestDeviceR1",
-            "test100",
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm",
-            "test104-vm"
         ]
     },
     "test_cluster_group": {

--- a/tests/integration/targets/inventory-v2.9/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-v2.9/files/test-inventory-options.json
@@ -99,7 +99,29 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vc_position": 0,
+                "virtual_chassis_members": [
+                    {
+                        "config_context": {},
+                        "custom_fields": {},
+                        "device_type": "nexus-child",
+                        "display": "Test Nexus Child One",
+                        "manufacturer": "cisco",
+                        "regions": [
+                            "test-region",
+                            "parent-region"
+                        ],
+                        "role": "core-switch",
+                        "site": "test-site",
+                        "status": {
+                            "label": "Active",
+                            "value": "active"
+                        },
+                        "tags": [],
+                        "vc_position": 2
+                    }
+                ]
             },
             "test100": {
                 "custom_fields": {},

--- a/tests/integration/targets/inventory-v2.9/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-v2.9/files/test-inventory-options.yml
@@ -16,6 +16,7 @@ interfaces: False
 services: False
 group_names_raw: True
 virtual_chassis_name: True
+virtual_chassis_members: True
 dns_name: True
 
 group_by:

--- a/tests/unit/inventory/test_data/group_extractors/data.json
+++ b/tests/unit/inventory/test_data/group_extractors/data.json
@@ -4,6 +4,7 @@
         "interfaces": false,
         "services": false,
         "dns_name": false,
+        "virtual_chassis_members": false,
         "expected": [
             "disk",
             "memory",
@@ -35,7 +36,10 @@
             "manufacturers",
             "services",
             "interfaces",
-            "dns_name"
+            "dns_name",
+            "virtual_chassis_members",
+            "vc_position",
+            "vc_priority"
         ]
     },
     {
@@ -43,6 +47,7 @@
         "interfaces": true,
         "services": true,
         "dns_name": true,
+        "virtual_chassis_members": true,
         "expected": [
             "disk",
             "memory",
@@ -64,7 +69,10 @@
             "manufacturers",
             "services",
             "interfaces",
-            "dns_name"
+            "dns_name",
+            "virtual_chassis_members",
+            "vc_position",
+            "vc_priority"
         ],
         "not_expected": [
             "site",

--- a/tests/unit/inventory/test_nb_inventory.py
+++ b/tests/unit/inventory/test_nb_inventory.py
@@ -142,16 +142,24 @@ def test_refresh_lookups(inventory_fixture):
 
 
 @pytest.mark.parametrize(
-    "plurals, services, interfaces, dns_name, expected, not_expected",
+    "plurals, services, interfaces, dns_name, virtual_chassis_members, expected, not_expected",
     load_relative_test_data("group_extractors"),
 )
 def test_group_extractors(
-    inventory_fixture, plurals, services, interfaces, dns_name, expected, not_expected
+    inventory_fixture,
+    plurals,
+    services,
+    interfaces,
+    dns_name,
+    virtual_chassis_members,
+    expected,
+    not_expected,
 ):
     inventory_fixture.plurals = plurals
     inventory_fixture.services = services
     inventory_fixture.interfaces = interfaces
     inventory_fixture.dns_name = dns_name
+    inventory_fixture.virtual_chassis_members = virtual_chassis_members
     extractors = inventory_fixture.group_extractors
 
     for key in expected:


### PR DESCRIPTION
Fixes #369

Items of note or to review:
- Add `virtual_chassis_members` option
- Makes a new query for all virtual chassis member devices if query filters are defined
- Also adds VC position and priority fields
- Adds composite vars to VC members by replicating the `ansible.plugins.inventory.Constructable._set_composite_vars` method