### PR TITLE
updated ip doc to show family is depricated

### DIFF
--- a/docs/plugins/modules/netbox_ip_address/netbox.netbox.netbox_ip_address_module.rst
+++ b/docs/plugins/modules/netbox_ip_address/netbox.netbox.netbox_ip_address_module.rst
@@ -233,7 +233,8 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Specifies with address family the IP address belongs to</div>
+                                            <div>Specifies with address family the IP address belongs to.</div>
+                                            <div>(DEPRECATED) - NetBox now handles determining the IP family natively.</div>
                                                         </td>
             </tr>
                                 <tr>


### PR DESCRIPTION
The RTD did not show why the family option is being depreciated, but the module code did.  This is now fixed.