### PR TITLE
Fetch host/group vars before compose step (Resolves #439)

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -263,6 +263,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress
 from ansible.utils.vars import combine_vars
 from ansible.inventory.helpers import get_group_vars
 
+
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = "netbox.netbox.nb_inventory"
 
@@ -1468,7 +1469,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             # Parse created object
             host = combine_vars(
                 get_group_vars(self.inventory.hosts[hostname].get_groups()),
-                self.inventory.hosts[hostname].get_vars()
+                self.inventory.hosts[hostname].get_vars(),
             )
 
             # Composed variables

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -260,6 +260,8 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress
     ip_interface,
 )
 
+from ansible.utils.vars import combine_vars
+from ansible.inventory.helpers import get_group_vars
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = "netbox.netbox.nb_inventory"
@@ -1462,6 +1464,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._fill_host_variables(host=host, hostname=hostname)
 
             strict = self.get_option("strict")
+
+            # Parse created object
+            host = combine_vars(
+                get_group_vars(self.inventory.hosts[hostname].get_groups()),
+                self.inventory.hosts[hostname].get_vars()
+            )
 
             # Composed variables
             self._set_composite_vars(

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.json
@@ -139,7 +139,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": 100
             },
             "test101-vm": {
                 "cluster": "Test Cluster",
@@ -156,7 +157,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": 101
             },
             "test102-vm": {
                 "cluster": "Test Cluster",
@@ -173,7 +175,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": 102
             },
             "test103-vm": {
                 "cluster": "Test Cluster",
@@ -190,7 +193,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": 103
             },
             "test104-vm": {
                 "cluster": "Test Cluster 2",
@@ -202,7 +206,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": 104
             }
         }
     },

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.json
@@ -42,7 +42,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": "0"
             },
             "Test VM With Spaces": {
                 "cluster": "Test Cluster 2",
@@ -54,7 +55,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": "0"
             },
             "TestDeviceR1": {
                 "custom_fields": {},
@@ -78,7 +80,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": "0"
             },
             "VC1": {
                 "ansible_host": "nexus.example.com",
@@ -99,7 +102,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": "0"
             },
             "test100": {
                 "custom_fields": {},
@@ -122,7 +126,8 @@
                     "label": "Active",
                     "value": "active"
                 },
-                "tags": []
+                "tags": [],
+                "vid": "0"
             },
             "test100-vm": {
                 "cluster": "Test Cluster",
@@ -140,7 +145,7 @@
                     "value": "active"
                 },
                 "tags": [],
-                "vid": 100
+                "vid": "100"
             },
             "test101-vm": {
                 "cluster": "Test Cluster",
@@ -158,7 +163,7 @@
                     "value": "active"
                 },
                 "tags": [],
-                "vid": 101
+                "vid": "101"
             },
             "test102-vm": {
                 "cluster": "Test Cluster",
@@ -176,7 +181,7 @@
                     "value": "active"
                 },
                 "tags": [],
-                "vid": 102
+                "vid": "102"
             },
             "test103-vm": {
                 "cluster": "Test Cluster",
@@ -194,7 +199,7 @@
                     "value": "active"
                 },
                 "tags": [],
-                "vid": 103
+                "vid": "103"
             },
             "test104-vm": {
                 "cluster": "Test Cluster 2",
@@ -207,7 +212,7 @@
                     "value": "active"
                 },
                 "tags": [],
-                "vid": 104
+                "vid": "104"
             }
         }
     },

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
@@ -49,6 +49,7 @@ vm_query_filters:
 # https://docs.ansible.com/ansible/latest/plugins/inventory/constructed.html
 
 compose:
+  vid: inventory_hostname | regex_replace('^test([0-9]+)\-vm$', '\\1' | int
   display: display_name
   rack_id: rack.id
   ntp_servers: config_context.ntp_servers

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
@@ -49,7 +49,7 @@ vm_query_filters:
 # https://docs.ansible.com/ansible/latest/plugins/inventory/constructed.html
 
 compose:
-  vid: inventory_hostname | regex_replace('^test([0-9]+)\-vm$', '\\1' | int
+  vid: inventory_hostname | regex_search('^test([0-9]+)\-vm$') | regex_replace('^test([0-9]+)\-vm$', '\1') | int
   display: display_name
   rack_id: rack.id
   ntp_servers: config_context.ntp_servers


### PR DESCRIPTION
Added support of having `inventory_hostname` available on the compose step to have same functionality as constructed plugin.