### PR TITLE
Remove ansible.netcommon dependency

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -46,9 +46,6 @@ tags:
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-  # Required for ipaddress python library
-  ansible.netcommon: ">=1.0.0"
-
   # Required for json_query used in lookup plugin integration tests
   community.general: ">=1.0.0"
 

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -248,6 +248,7 @@ from threading import Thread
 from typing import Iterable
 from itertools import chain
 from collections import defaultdict
+from ipaddress import ip_interface
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.ansible_release import __version__ as ansible_version
@@ -256,9 +257,6 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib import error as urllib_error
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import (
-    ip_interface,
-)
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):

--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 # Import necessary packages
 import traceback
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat import ipaddress
+from ipaddress import ip_interface
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import missing_required_lib
 
@@ -169,7 +169,7 @@ class NetboxIpamModule(NetboxModule):
         if self.endpoint == "ip_addresses":
             if data.get("address"):
                 try:
-                    data["address"] = to_text(ipaddress.ip_network(data["address"]))
+                    data["address"] = to_text(ip_interface(data["address"]).with_prefixlen)
                 except ValueError:
                     pass
             name = data.get("address")

--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -169,7 +169,9 @@ class NetboxIpamModule(NetboxModule):
         if self.endpoint == "ip_addresses":
             if data.get("address"):
                 try:
-                    data["address"] = to_text(ip_interface(data["address"]).with_prefixlen)
+                    data["address"] = to_text(
+                        ip_interface(data["address"]).with_prefixlen
+                    )
                 except ValueError:
                     pass
             name = data.get("address")

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -15,8 +15,6 @@ import json
 
 from itertools import chain
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat import ipaddress
-
 from ansible.module_utils.common.text.converters import to_text
 
 from ansible.module_utils._text import to_native


### PR DESCRIPTION
The ansible.netcommon collection pushed a breaking change with the module_utils: https://github.com/ansible-collections/ansible.netcommon/commit/8cda0e6906a86790ab423b11adafa425e870926a

- Replaced the ipaddress usage with the built-in python3 ipaddress module where it was needed.
- Removed the dependency in galaxy.yml.

Fixes #452 