### PR TITLE
Enhancement: add tags to netbox_cable

### DIFF
--- a/plugins/modules/netbox_cable.py
+++ b/plugins/modules/netbox_cable.py
@@ -145,6 +145,12 @@ options:
           - in
         required: false
         type: str
+      tags:
+        description:
+          - Any tags that the cable may need to be associated with
+        required: false
+        type: list
+        elements: str
   state:
     description:
       - Use C(present) or C(absent) for adding or removing.
@@ -207,6 +213,8 @@ EXAMPLES = r"""
           color: abcdef
           length: 30
           length_unit: m
+          tags:
+            - foo
         state: present
 
     - name: Delete cable within netbox
@@ -327,6 +335,7 @@ def main():
                     length_unit=dict(
                         required=False, choices=["m", "cm", "ft", "in"], type="str"
                     ),
+                    tags=dict(required=False, type="list", elements="str"),
                 ),
             ),
         )

--- a/tests/integration/targets/latest/tasks/netbox_cable.yml
+++ b/tests/integration/targets/latest/tasks/netbox_cable.yml
@@ -80,6 +80,8 @@
       color: abcdef
       length: 30
       length_unit: m
+      tags:
+        - "Schnozzberry"
     state: present
   register: test_three
 
@@ -93,6 +95,7 @@
       - test_three['diff']['after']['color'] == "abcdef"
       - test_three['diff']['after']['length'] == 30
       - test_three['diff']['after']['length_unit'] == "m"
+      - test_three['diff']['after']['tags'][0] == 4
       - test_three['cable']['termination_a_type'] == "dcim.interface"
       - test_three['cable']['termination_a_id'] == 13
       - test_three['cable']['termination_b_type'] == "dcim.interface"
@@ -103,6 +106,7 @@
       - test_three['cable']['color'] == "abcdef"
       - test_three['cable']['length'] == 30
       - test_three['cable']['length_unit'] == "m"
+      - test_three['cable']['tags'][0] == 4
       - test_three['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 updated"
 
 - name: "CABLE 4: ASSERT - Delete"

--- a/tests/integration/targets/v2.9/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v2.9/tasks/netbox_cable.yml
@@ -80,6 +80,8 @@
       color: abcdef
       length: 30
       length_unit: m
+      tags:
+        - "Schnozzberry"
     state: present
   register: test_three
 
@@ -93,6 +95,7 @@
       - test_three['diff']['after']['color'] == "abcdef"
       - test_three['diff']['after']['length'] == 30
       - test_three['diff']['after']['length_unit'] == "m"
+      - test_three['diff']['after']['tags'][0] == 4
       - test_three['cable']['termination_a_type'] == "dcim.interface"
       - test_three['cable']['termination_a_id'] == 13
       - test_three['cable']['termination_b_type'] == "dcim.interface"
@@ -103,6 +106,7 @@
       - test_three['cable']['color'] == "abcdef"
       - test_three['cable']['length'] == 30
       - test_three['cable']['length_unit'] == "m"
+      - test_three['cable']['tags'][0] == 4
       - test_three['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 updated"
 
 - name: "CABLE 4: ASSERT - Delete"


### PR DESCRIPTION
Adds tags to `DOCUMENTATION` and `argument_spec` in the netbox_cable module. An example of using tags is provided in `EXAMPLES` also.

Updates netbox_cable integration tests to include adding a tag.

Fixes #448