### PR TITLE
Properly handle interface tags.

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -668,6 +668,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                             interface["id"]
                         ].values()
                     )
+                    interface["tags"] = list(sub["slug"] for sub in interface["tags"])
+
 
             return interfaces
         except Exception:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -670,7 +670,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     )
                     interface["tags"] = list(sub["slug"] for sub in interface["tags"])
 
-
             return interfaces
         except Exception:
             return


### PR DESCRIPTION
This fixes issue #472 

netbox-2.9 and up changed the tag format.  this converts the returned tags from an array of
instances, to a just an array of the tag slug values.

ie,

this:

```
"tags": [
  {
    "color": "9e9e9e",
    "id": 130,
    "name": "default",
    "slug": "default",
    "url": "http://netbox/api/extras/tags/130/"
  }
],
```
becomes:
```
tags: [ 'default' ]
```