### PR TITLE
Enhancement: netbox_device_interface - Add mark_connected

### DIFF
--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -124,6 +124,11 @@ options:
           - Any tags that the interface may need to be associated with
         required: false
         type: list
+      mark_connected:
+        description:
+          - Mark an interface as connected without a cable attached (netbox >= 2.11 required)
+        required: false
+        type: bool
     required: true
     type: dict
   update_vc_child:
@@ -235,6 +240,15 @@ EXAMPLES = r"""
           name: GigabitEthernet2/0/1
           enabled: false
         update_vc_child: True
+    - name: Mark interface as connected without a cable (netbox >= 2.11 required)
+      netbox.netbox.netbox_device_interface:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          device: test100
+          name: GigabitEthernet1
+          mark_connected: true
+        state: present
 """
 
 RETURN = r"""
@@ -288,6 +302,7 @@ def main():
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list"),
+                    mark_connected=dict(required=False, type="bool"),
                 ),
             ),
         )

--- a/tests/integration/targets/latest/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/latest/tasks/netbox_device_interface.yml
@@ -289,3 +289,25 @@
     that:
       - test_eleven is failed
       - test_eleven['msg'] == "Must set update_vc_child to True to allow child device interface modification"
+
+- name: "12 - Create interface and mark it as connected"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet5
+      type: 1000Base-T (1GE)
+      mark_connected: true
+    register: test_twelve
+
+- name: "12- ASSERT"
+  assert:
+    that:
+      - test_twelve is changed
+      - test_twelve['msg'] == "interface GigabitEthernet5 created"
+      - test_twelve['diff']['before']['state'] == 'absent'
+      - test_twelve['diff']['after']['state'] == 'present'
+      - test_twelve['interface']['name'] == "GigabitEthernet5"
+      - test_twelve['interface']['device'] == 1
+      - test_twelve['interface']['mark_connected'] == true


### PR DESCRIPTION
Add mark_connected option to netbox_device_interface module.

Add integration test to test adding an interface that is marked as connected.

Closes #504 