### PR TITLE
Full locations functionality in inventory plugin for 2.11

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1595,7 +1595,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     group=self.location_group_names[host["location"]["id"]],
                     host=hostname,
                 )
-            else:
+            elif self.site_group_names and host.get("site"):
                 # Add host to site group when host is NOT assigned to a location
                 self.inventory.add_host(
                     group=self.site_group_names[host["site"]["id"]], host=hostname,

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -724,13 +724,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # - it will have 1 element if the device's location has no parent
         # - it will have multiple elements if the location has a parent location
 
-        location = host.get("location", None)
-        if not isinstance(location, dict):
-            # Device has no location
-            return []
-
-        location_id = location.get("id", None)
-        if location_id is None:
+        try:
+            location_id = host["location"]["id"]
+        except (KeyError, TypeError):
             # Device has no location
             return []
 
@@ -847,7 +843,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # Dictionary of location id to parent location id
         self.locations_parent_lookup = dict(
-            filter(lambda x: x is not None, map(get_location_parent, locations))
+            filter(None, map(get_location_parent, locations))
         )
         # Location to site lookup
         self.locations_site_lookup = dict(map(get_location_site, locations))
@@ -1589,11 +1585,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self.add_host_to_groups(host=host, hostname=hostname)
 
             # Special processing for sites and locations as those groups were already created
-            if (
-                getattr(self, "location_group_names", None)
-                and host.get("location")
-                and host["location"].get("id")
-            ):
+            if getattr(self, "location_group_names", None) and host.get("location"):
                 # Add host to location group when host is assigned to the location
                 self.inventory.add_host(
                     group=self.location_group_names[host["location"]["id"]],

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1401,9 +1401,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _add_region_groups(self):
         # Mapping of region id to group name
         region_transformed_group_names = self._setup_nested_groups(
-            "region",
-            self.regions_lookup,
-            self.regions_parent_lookup
+            "region", self.regions_lookup, self.regions_parent_lookup
         )
 
         # Add site groups as children of region groups
@@ -1414,15 +1412,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             self.inventory.add_child(
                 region_transformed_group_names[region_id],
-                self.site_group_names[site_id]
+                self.site_group_names[site_id],
             )
 
     def _add_location_groups(self):
         # Mapping of location id to group name
         self.location_group_names = self._setup_nested_groups(
-            "location",
-            self.locations_lookup,
-            self.locations_parent_lookup
+            "location", self.locations_lookup, self.locations_parent_lookup
         )
 
         # Add location to site groups as children
@@ -1436,8 +1432,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             ]
 
             self.inventory.add_child(
-                site_transformed_group_name,
-                self.location_group_names[location_id]
+                site_transformed_group_name, self.location_group_names[location_id]
             )
 
     def _setup_nested_groups(self, group, lookup, parent_lookup):
@@ -1447,18 +1442,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Create groups for each object
         for obj_id in lookup:
             group_name = self.generate_group_name(group, lookup[obj_id])
-            transformed_group_names[obj_id] = self.inventory.add_group(
-                group=group_name
-            )
+            transformed_group_names[obj_id] = self.inventory.add_group(group=group_name)
 
         # Now that all groups exist, add relationships between them
         for obj_id in lookup:
             group_name = transformed_group_names[obj_id]
             parent_id = parent_lookup.get(obj_id, None)
-            if (
-                parent_id is not None
-                and parent_id in transformed_group_names
-            ):
+            if parent_id is not None and parent_id in transformed_group_names:
                 parent_name = transformed_group_names[parent_id]
                 self.inventory.add_child(parent_name, group_name)
 
@@ -1553,7 +1543,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         site_group_by = self._pluralize_group_by("site")
         if (
             site_group_by in self.group_by
-            or "location" in self.group_by 
+            or "location" in self.group_by
             or "region" in self.group_by
         ):
             self._add_site_groups()
@@ -1603,15 +1593,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 # Add host to location group when host is assigned to the location
                 self.inventory.add_host(
                     group=self.location_group_names[host["location"]["id"]],
-                    host=hostname
+                    host=hostname,
                 )
             else:
                 # Add host to site group when host is NOT assigned to a location
                 self.inventory.add_host(
-                    group=self.site_group_names[host["site"]["id"]],
-                    host=hostname
+                    group=self.site_group_names[host["site"]["id"]], host=hostname,
                 )
-
 
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -109,11 +109,15 @@ DOCUMENTATION = """
             type: boolean
             version_added: "0.2.1"
         group_by:
-            description: Keys used to create groups. The I(plurals) option controls which of these are valid.
+            description:
+                - Keys used to create groups. The I(plurals) option controls which of these are valid.
+                - I(rack_group) is supported on NetBox versions 2.10 or lower only
+                - I(location) is supported on NetBox versions 2.11 or higher only
             type: list
             choices:
                 - sites
                 - site
+                - location
                 - tenants
                 - tenant
                 - racks
@@ -412,7 +416,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._pluralize_group_by("site"): self.extract_site,
             self._pluralize_group_by("tenant"): self.extract_tenant,
             self._pluralize_group_by("rack"): self.extract_rack,
-            "rack_group": self.extract_rack_group,
             "rack_role": self.extract_rack_role,
             self._pluralize_group_by("tag"): self.extract_tags,
             self._pluralize_group_by("role"): self.extract_device_role,
@@ -420,6 +423,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._pluralize_group_by("device_type"): self.extract_device_type,
             self._pluralize_group_by("manufacturer"): self.extract_manufacturer,
         }
+
+        # Locations were added in 2.11 replacing rack-groups.
+        if self.api_version >= version.parse("2.11"):
+            extractors.update(
+                {"location": self.extract_location,}
+            )
+        else:
+            extractors.update(
+                {"rack_group": self.extract_rack_group,}
+            )
 
         if self.services:
             extractors.update(
@@ -704,6 +717,29 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             object_parent_lookup=self.regions_parent_lookup,
         )
 
+    def extract_location(self, host):
+        # A host may have a location. A location may have a parent location.
+        # Produce a list of locations:
+        # - it will be empty if the device has no location
+        # - it will have 1 element if the device's location has no parent
+        # - it will have multiple elements if the location has a parent location
+
+        location = host.get("location", None)
+        if not isinstance(location, dict):
+            # Device has no location
+            return []
+
+        location_id = location.get("id", None)
+        if location_id is None:
+            # Device has no location
+            return []
+
+        return self._objects_array_following_parents(
+            initial_object_id=location_id,
+            object_lookup=self.locations_lookup,
+            object_parent_lookup=self.locations_parent_lookup,
+        )
+
     def extract_cluster(self, host):
         try:
             # cluster does not have a slug
@@ -787,6 +823,35 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             filter(lambda x: x is not None, map(get_region_parent, regions))
         )
 
+    def refresh_locations_lookup(self):
+        # Locations were added in v2.11. Return empty lookups for previous versions.
+        if self.api_version < version.parse("2.11"):
+            return
+
+        url = self.api_endpoint + "/api/dcim/locations/?limit=0"
+        locations = self.get_resource_list(api_url=url)
+        self.locations_lookup = dict(
+            (location["id"], location["slug"]) for location in locations
+        )
+
+        def get_location_parent(location):
+            # Will fail if location does not have a parent location
+            try:
+                return (location["id"], location["parent"]["id"])
+            except Exception:
+                return (location["id"], None)
+
+        def get_location_site(location):
+            # Locations MUST be assigned to a site
+            return (location["id"], location["site"]["id"])
+
+        # Dictionary of location id to parent location id
+        self.locations_parent_lookup = dict(
+            filter(lambda x: x is not None, map(get_location_parent, locations))
+        )
+        # Location to site lookup
+        self.locations_site_lookup = dict(map(get_location_site, locations))
+
     def refresh_tenants_lookup(self):
         url = self.api_endpoint + "/api/tenancy/tenants/?limit=0"
         tenants = self.get_resource_list(api_url=url)
@@ -813,16 +878,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.racks_role_lookup = dict(map(get_role_for_rack, racks))
 
     def refresh_rack_groups_lookup(self):
+        # Locations were added in v2.11 replacing rack groups. Do nothing for 2.11+
         if self.api_version >= version.parse("2.11"):
-            # In NetBox v2.11 Breaking Changes:
-            # The RackGroup model has been renamed to Location
-            # (see netbox-community/netbox#4971).
-            # Its REST API endpoint has changed from /api/dcim/rack-groups/
-            # to /api/dcim/locations/
-            # https://netbox.readthedocs.io/en/stable/release-notes/#v2110-2021-04-16
-            url = self.api_endpoint + "/api/dcim/locations/?limit=0"
-        else:
-            url = self.api_endpoint + "/api/dcim/rack-groups/?limit=0"
+            return
+
+        url = self.api_endpoint + "/api/dcim/rack-groups/?limit=0"
         rack_groups = self.get_resource_list(api_url=url)
         self.rack_groups_lookup = dict(
             (rack_group["id"], rack_group["slug"]) for rack_group in rack_groups
@@ -1054,6 +1114,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         lookups = [
             self.refresh_sites_lookup,
             self.refresh_regions_lookup,
+            self.refresh_locations_lookup,
             self.refresh_tenants_lookup,
             self.refresh_racks_lookup,
             self.refresh_rack_groups_lookup,
@@ -1288,26 +1349,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             return "_".join([grouping, group])
 
     def add_host_to_groups(self, host, hostname):
-
-        # If we're grouping by regions, hosts are not added to region groups
-        # - the site groups are added as sub-groups of regions
-        # So, we need to make sure we're also grouping by sites if regions are enabled
-
-        if "region" in self.group_by:
-            # Make sure "site" or "sites" grouping also exists, depending on plurals options
-            site_group_by = self._pluralize_group_by("site")
-            if site_group_by not in self.group_by:
-                self.group_by.append(site_group_by)
+        site_group_by = self._pluralize_group_by("site")
 
         for grouping in self.group_by:
 
-            # Don't handle regions here - that will happen in main()
-            if grouping == "region":
+            # Don't handle regions here since no hosts are ever added to region groups
+            # Sites and locations are also specially handled in the main()
+            if grouping in ["region", site_group_by, "location"]:
                 continue
 
             if grouping not in self.group_extractors:
                 raise AnsibleError(
-                    'group_by option "%s" is not valid. (Maybe check the plurals option? It can determine what group_by options are valid)'
+                    'group_by option "%s" is not valid. Check group_by documentation or check the plurals option. It can determine what group_by options are valid.'
                     % grouping
                 )
 
@@ -1331,30 +1384,27 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 transformed_group_name = self.inventory.add_group(group=group_name)
                 self.inventory.add_host(group=transformed_group_name, host=hostname)
 
+    def _add_site_groups(self):
+        # Map site id to transformed group names
+        self.site_group_names = dict()
+
+        for site_id, site_name in self.sites_lookup.items():
+            site_group_name = self.generate_group_name(
+                self._pluralize_group_by("site"), site_name
+            )
+            # Add the site group to get its transformed name
+            site_transformed_group_name = self.inventory.add_group(
+                group=site_group_name
+            )
+            self.site_group_names[site_id] = site_transformed_group_name
+
     def _add_region_groups(self):
-
         # Mapping of region id to group name
-        region_transformed_group_names = dict()
-
-        # Create groups for each region
-        for region_id in self.regions_lookup:
-            region_group_name = self.generate_group_name(
-                "region", self.regions_lookup[region_id]
-            )
-            region_transformed_group_names[region_id] = self.inventory.add_group(
-                group=region_group_name
-            )
-
-        # Now that all region groups exist, add relationships between them
-        for region_id in self.regions_lookup:
-            region_group_name = region_transformed_group_names[region_id]
-            parent_region_id = self.regions_parent_lookup.get(region_id, None)
-            if (
-                parent_region_id is not None
-                and parent_region_id in region_transformed_group_names
-            ):
-                parent_region_name = region_transformed_group_names[parent_region_id]
-                self.inventory.add_child(parent_region_name, region_group_name)
+        region_transformed_group_names = self._setup_nested_groups(
+            "region",
+            self.regions_lookup,
+            self.regions_parent_lookup
+        )
 
         # Add site groups as children of region groups
         for site_id in self.sites_lookup:
@@ -1362,21 +1412,57 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if region_id is None:
                 continue
 
-            region_transformed_group_name = region_transformed_group_names[region_id]
+            self.inventory.add_child(
+                region_transformed_group_names[region_id],
+                self.site_group_names[site_id]
+            )
 
-            site_name = self.sites_lookup[site_id]
-            site_group_name = self.generate_group_name(
-                self._pluralize_group_by("site"), site_name
-            )
-            # Add the site group to get its transformed name
-            # Will already be created by add_host_to_groups - it's ok to call add_group again just to get its name
-            site_transformed_group_name = self.inventory.add_group(
-                group=site_group_name
-            )
+    def _add_location_groups(self):
+        # Mapping of location id to group name
+        self.location_group_names = self._setup_nested_groups(
+            "location",
+            self.locations_lookup,
+            self.locations_parent_lookup
+        )
+
+        # Add location to site groups as children
+        for location_id, location_slug in self.locations_lookup.items():
+            if self.locations_parent_lookup.get(location_id, None):
+                # Only top level locations should be children of sites
+                continue
+
+            site_transformed_group_name = self.site_group_names[
+                self.locations_site_lookup[location_id]
+            ]
 
             self.inventory.add_child(
-                region_transformed_group_name, site_transformed_group_name
+                site_transformed_group_name,
+                self.location_group_names[location_id]
             )
+
+    def _setup_nested_groups(self, group, lookup, parent_lookup):
+        # Mapping of id to group name
+        transformed_group_names = dict()
+
+        # Create groups for each object
+        for obj_id in lookup:
+            group_name = self.generate_group_name(group, lookup[obj_id])
+            transformed_group_names[obj_id] = self.inventory.add_group(
+                group=group_name
+            )
+
+        # Now that all groups exist, add relationships between them
+        for obj_id in lookup:
+            group_name = transformed_group_names[obj_id]
+            parent_id = parent_lookup.get(obj_id, None)
+            if (
+                parent_id is not None
+                and parent_id in transformed_group_names
+            ):
+                parent_name = transformed_group_names[parent_id]
+                self.inventory.add_child(parent_name, group_name)
+
+        return transformed_group_names
 
     def _fill_host_variables(self, host, hostname):
         extracted_primary_ip = self.extract_primary_ip(host=host)
@@ -1412,6 +1498,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if attribute == "region":
                 attribute = "regions"
+
+            if attribute == "location":
+                attribute = "locations"
 
             if attribute == "rack_group":
                 attribute = "rack_groups"
@@ -1456,6 +1545,27 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # - can skip any device/vm without any IPs
         self.refresh_lookups(self.lookup_processes_secondary)
 
+        # If we're grouping by regions, hosts are not added to region groups
+        # If we're grouping by locations, hosts may be added to the site or location
+        # - the site groups are added as sub-groups of regions
+        # - the location groups are added as sub-groups of sites
+        # So, we need to make sure we're also grouping by sites if regions or locations are enabled
+        site_group_by = self._pluralize_group_by("site")
+        if (
+            site_group_by in self.group_by
+            or "location" in self.group_by 
+            or "region" in self.group_by
+        ):
+            self._add_site_groups()
+
+        # Create groups for locations. Will be a part of site groups.
+        if "location" in self.group_by and self.api_version >= version.parse("2.11"):
+            self._add_location_groups()
+
+        # Create groups for regions, containing the site groups
+        if "region" in self.group_by:
+            self._add_region_groups()
+
         for host in chain(self.devices_list, self.vms_list):
 
             virtual_chassis_master = self._get_host_virtual_chassis_master(host)
@@ -1488,9 +1598,20 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             )
             self.add_host_to_groups(host=host, hostname=hostname)
 
-        # Create groups for regions, containing the site groups
-        if "region" in self.group_by:
-            self._add_region_groups()
+            # Special processing for sites and locations as those groups were already created
+            if host.get("location") and host["location"].get("id"):
+                # Add host to location group when host is assigned to the location
+                self.inventory.add_host(
+                    group=self.location_group_names[host["location"]["id"]],
+                    host=hostname
+                )
+            else:
+                # Add host to site group when host is NOT assigned to a location
+                self.inventory.add_host(
+                    group=self.site_group_names[host["site"]["id"]],
+                    host=hostname
+                )
+
 
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1595,7 +1595,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     group=self.location_group_names[host["location"]["id"]],
                     host=hostname,
                 )
-            elif self.site_group_names and host.get("site"):
+            elif getattr(self, "site_group_names", None) and host.get("site"):
                 # Add host to site group when host is NOT assigned to a location
                 self.inventory.add_host(
                     group=self.site_group_names[host["site"]["id"]], host=hostname,

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1589,7 +1589,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self.add_host_to_groups(host=host, hostname=hostname)
 
             # Special processing for sites and locations as those groups were already created
-            if host.get("location") and host["location"].get("id"):
+            if (
+                getattr(self, "location_group_names", None)
+                and host.get("location")
+                and host["location"].get("id")
+            ):
                 # Add host to location group when host is assigned to the location
                 self.inventory.add_host(
                     group=self.location_group_names[host["location"]["id"]],

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -299,6 +299,13 @@ devices = [
         "site": test_site.id,
     },
 ]
+
+## Add some locations for 2.11+
+if nb_version >= version.parse("2.11"):
+    devices[0]["location"] = created_rack_groups[0].id
+    devices[1]["location"] = created_rack_groups[0].id
+    devices[3]["location"] = created_rack_groups[0].id
+
 created_devices = make_netbox_calls(nb.dcim.devices, devices)
 ### Device variables to be used later on
 test100 = nb.dcim.devices.get(name="test100")

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -252,6 +252,12 @@ racks = [
     },
     {"name": "Test Rack", "site": test_site.id, "group": created_rack_groups[0].id},
 ]
+
+## Use location instead of group for 2.11+
+if nb_version >= version.parse("2.11"):
+    racks[1]["location"] = created_rack_groups[0].id
+    del racks[1]["group"]
+
 created_racks = make_netbox_calls(nb.dcim.racks, racks)
 test_rack = nb.dcim.racks.get(name="Test Rack")  # racks don't have slugs
 test_rack_site2 = nb.dcim.racks.get(name="Test Rack Site 2")

--- a/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
@@ -13,10 +13,10 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
-                "rack_groups": [],
                 "rack_role": "test-rack-role",
                 "racks": [
                     "Test Rack Site 2"
@@ -45,6 +45,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -55,20 +56,17 @@
                 ],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
                             "display_name": "Test Nexus One",
                             "id": 4,
-                            "name": "Test Nexus One",
-                            "url": "http://localhost:9000/api/dcim/devices/4/"
+                            "name": "Test Nexus One"
                         },
                         "display": "telnet (TCP/23)",
                         "id": 3,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.459163Z",
                         "name": "telnet",
                         "ports": [
                             23
@@ -78,7 +76,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/3/",
                         "virtual_machine": null
                     }
                 ],
@@ -99,17 +96,16 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": null,
                         "display": "ssh (TCP/22)",
                         "id": 4,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.465221Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -119,12 +115,10 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/4/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     }
                 ],
@@ -146,10 +140,10 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
-                "rack_groups": [],
                 "racks": [
                     "Test Rack"
                 ],
@@ -183,6 +177,7 @@
                         ]
                     }
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -192,20 +187,17 @@
                 ],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "ssh (TCP/22)",
                         "id": 1,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.436503Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -215,19 +207,16 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/1/",
                         "virtual_machine": null
                     },
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "http (TCP/80)",
                         "id": 2,
@@ -236,18 +225,15 @@
                                 "address": "172.16.180.1/24",
                                 "display": "172.16.180.1/24",
                                 "family": 4,
-                                "id": 1,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/1/"
+                                "id": 1
                             },
                             {
                                 "address": "2001::1:1/64",
                                 "display": "2001::1:1/64",
                                 "family": 6,
-                                "id": 2,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/2/"
+                                "id": 2
                             }
                         ],
-                        "last_updated": "2021-05-08T11:30:57.443736Z",
                         "name": "http",
                         "ports": [
                             80
@@ -257,7 +243,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/2/",
                         "virtual_machine": null
                     }
                 ],
@@ -279,6 +264,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -302,6 +288,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -325,6 +312,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -348,6 +336,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -370,6 +359,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [],
                 "services": [],
                 "status": {

--- a/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-legacy.json
@@ -45,7 +45,10 @@
                 "local_context_data": [
                     null
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -140,7 +143,10 @@
                 "local_context_data": [
                     null
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -177,7 +183,10 @@
                         ]
                     }
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
@@ -172,7 +172,10 @@
                     }
                 ],
                 "is_virtual": false,
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "primary_ip4": "172.16.180.12",
                 "regions": [
@@ -298,7 +301,10 @@
                 "device_type": "cisco-test",
                 "interfaces": [],
                 "is_virtual": false,
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "rack": "Test Rack",
                 "regions": [
@@ -441,7 +447,10 @@
                     }
                 ],
                 "is_virtual": false,
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "ntp_servers": [
                     "pool.ntp.org"
@@ -934,6 +943,13 @@
             "test104-vm"
         ]
     },
+    "test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
     "test_rack_role": {
         "hosts": [
             "R1-Device"
@@ -949,9 +965,6 @@
             "parent_rack_group"
         ],
         "hosts": [
-            "Test Nexus One",
-            "TestDeviceR1",
-            "test100",
             "test100-vm",
             "test101-vm",
             "test102-vm",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.json
@@ -29,9 +29,9 @@
                 "device_type": "cisco-test",
                 "interfaces": [],
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "rack": "Test Rack Site 2",
-                "rack_groups": [],
                 "rack_role": "test-rack-role",
                 "regions": [],
                 "role": "core-switch",
@@ -57,83 +57,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "display": "Test Nexus Child One",
-                            "display_name": "Test Nexus Child One",
-                            "id": 5,
-                            "name": "Test Nexus Child One",
-                            "url": "http://localhost:9000/api/dcim/devices/5/"
-                        },
-                        "display": "Ethernet2/1",
-                        "enabled": true,
-                        "id": 2,
-                        "ip_addresses": [
-                            {
-                                "address": "172.16.180.12/24",
-                                "created": "2021-05-08",
-                                "custom_fields": {},
-                                "description": "",
-                                "display": "172.16.180.12/24",
-                                "dns_name": "nexus.example.com",
-                                "family": {
-                                    "label": "IPv4",
-                                    "value": 4
-                                },
-                                "id": 4,
-                                "last_updated": "2021-05-08T11:30:55.090531Z",
-                                "nat_inside": null,
-                                "nat_outside": null,
-                                "role": null,
-                                "status": {
-                                    "label": "Active",
-                                    "value": "active"
-                                },
-                                "tags": [],
-                                "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/4/",
-                                "vrf": null
-                            }
-                        ],
-                        "label": "",
-                        "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.800817Z",
-                        "mac_address": null,
-                        "mark_connected": false,
-                        "mgmt_only": false,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Ethernet2/1",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "type": {
-                            "label": "1000BASE-T (1GE)",
-                            "value": "1000base-t"
-                        },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/2/"
-                    },
-                    {
-                        "_occupied": false,
-                        "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
-                        "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
-                        "connected_endpoint_type": null,
-                        "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
                             "display_name": "Test Nexus One",
                             "id": 4,
-                            "name": "Test Nexus One",
-                            "url": "http://localhost:9000/api/dcim/devices/4/"
+                            "name": "Test Nexus One"
                         },
                         "display": "Ethernet1/1",
                         "enabled": true,
@@ -141,7 +71,6 @@
                         "ip_addresses": [
                             {
                                 "address": "172.16.180.11/24",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "172.16.180.11/24",
@@ -151,7 +80,6 @@
                                     "value": 4
                                 },
                                 "id": 3,
-                                "last_updated": "2021-05-08T11:30:55.084701Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -161,13 +89,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/3/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.791371Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -181,11 +107,72 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/1/"
+                        "untagged_vlan": null
+                    },
+                    {
+                        "_occupied": false,
+                        "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
+                        "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
+                        "connected_endpoint_type": null,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "display": "Test Nexus Child One",
+                            "display_name": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "label": "",
+                        "lag": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null
                     }
                 ],
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "primary_ip4": "172.16.180.12",
                 "regions": [
@@ -195,20 +182,17 @@
                 "role": "core-switch",
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
                             "display_name": "Test Nexus One",
                             "id": 4,
-                            "name": "Test Nexus One",
-                            "url": "http://localhost:9000/api/dcim/devices/4/"
+                            "name": "Test Nexus One"
                         },
                         "display": "telnet (TCP/23)",
                         "id": 3,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.459163Z",
                         "name": "telnet",
                         "ports": [
                             23
@@ -218,7 +202,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/3/",
                         "virtual_machine": null
                     }
                 ],
@@ -235,14 +218,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 11,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.285536Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -251,24 +232,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/11/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 12,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.292047Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -277,27 +254,24 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/12/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     }
                 ],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": null,
                         "display": "ssh (TCP/22)",
                         "id": 4,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.465221Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -307,12 +281,10 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/4/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     }
                 ],
@@ -326,9 +298,9 @@
                 "device_type": "cisco-test",
                 "interfaces": [],
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "rack": "Test Rack",
-                "rack_groups": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -354,15 +326,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "GigabitEthernet1",
                         "enabled": true,
@@ -370,7 +340,6 @@
                         "ip_addresses": [
                             {
                                 "address": "172.16.180.1/24",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "172.16.180.1/24",
@@ -380,7 +349,6 @@
                                     "value": 4
                                 },
                                 "id": 1,
-                                "last_updated": "2021-05-08T11:30:55.072310Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -390,13 +358,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/1/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.869203Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -410,8 +376,7 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/3/"
+                        "untagged_vlan": null
                     },
                     {
                         "_occupied": false,
@@ -422,15 +387,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "GigabitEthernet2",
                         "enabled": true,
@@ -438,7 +401,6 @@
                         "ip_addresses": [
                             {
                                 "address": "2001::1:1/64",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "2001::1:1/64",
@@ -448,7 +410,6 @@
                                     "value": 6
                                 },
                                 "id": 2,
-                                "last_updated": "2021-05-08T11:30:55.078833Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -458,13 +419,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/2/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.876923Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -478,11 +437,11 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/4/"
+                        "untagged_vlan": null
                     }
                 ],
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "ntp_servers": [
                     "pool.ntp.org"
@@ -494,20 +453,17 @@
                 "role": "core-switch",
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "ssh (TCP/22)",
                         "id": 1,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.436503Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -517,19 +473,16 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/1/",
                         "virtual_machine": null
                     },
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "http (TCP/80)",
                         "id": 2,
@@ -538,18 +491,15 @@
                                 "address": "172.16.180.1/24",
                                 "display": "172.16.180.1/24",
                                 "family": 4,
-                                "id": 1,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/1/"
+                                "id": 1
                             },
                             {
                                 "address": "2001::1:1/64",
                                 "display": "2001::1:1/64",
                                 "family": 6,
-                                "id": 2,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/2/"
+                                "id": 2
                             }
                         ],
-                        "last_updated": "2021-05-08T11:30:57.443736Z",
                         "name": "http",
                         "ports": [
                             80
@@ -559,7 +509,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/2/",
                         "virtual_machine": null
                     }
                 ],
@@ -577,14 +526,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 1,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.219270Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -593,24 +540,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/1/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 2,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.226670Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -619,24 +562,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/2/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth2",
                         "enabled": true,
                         "id": 3,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.233278Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -645,24 +584,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/3/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth3",
                         "enabled": true,
                         "id": 4,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.239805Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -671,24 +606,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/4/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth4",
                         "enabled": true,
                         "id": 5,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.246400Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -697,16 +628,15 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/5/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     }
                 ],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -726,14 +656,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 6,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.253033Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -742,24 +670,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/6/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 7,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.259421Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -768,24 +692,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/7/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth2",
                         "enabled": true,
                         "id": 8,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.265899Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -794,24 +714,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/8/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth3",
                         "enabled": true,
                         "id": 9,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.272465Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -820,24 +736,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/9/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth4",
                         "enabled": true,
                         "id": 10,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.278979Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -846,16 +758,15 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/10/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     }
                 ],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -874,6 +785,7 @@
                 "cluster_type": "test-cluster-type",
                 "interfaces": [],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -892,6 +804,7 @@
                 "cluster_type": "test-cluster-type",
                 "interfaces": [],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -909,6 +822,7 @@
                 "cluster_type": "test-cluster-type",
                 "interfaces": [],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [],
                 "services": [],
                 "status": {
@@ -992,6 +906,11 @@
             "Test Nexus One"
         ]
     },
+    "parent_rack_group": {
+        "children": [
+            "test_rack_group"
+        ]
+    },
     "parent_region": {
         "children": [
             "test_region"
@@ -1026,6 +945,9 @@
         ]
     },
     "test_site": {
+        "children": [
+            "parent_rack_group"
+        ],
         "hosts": [
             "Test Nexus One",
             "TestDeviceR1",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options-flatten.yml
@@ -24,7 +24,7 @@ group_by:
   - site
   - tenant
   - rack
-  - rack_group
+  - location
   - rack_role
   - tag
   - role

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.json
@@ -62,7 +62,10 @@
                 "device_type": "cisco-test",
                 "display": "TestDeviceR1",
                 "is_virtual": false,
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "rack": "Test Rack",
                 "rack_id": "2",
@@ -85,7 +88,10 @@
                 "display": "Test Nexus One",
                 "dns_name": "nexus.example.com",
                 "is_virtual": false,
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "primary_ip4": "172.16.180.12",
                 "regions": [
@@ -110,7 +116,10 @@
                         "pool.ntp.org"
                     ]
                 },
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "regions": [
                     "test-region",
@@ -319,6 +328,13 @@
             "test104-vm"
         ]
     },
+    "test_rack_group": {
+        "hosts": [
+            "TestDeviceR1",
+            "VC1",
+            "test100"
+        ]
+    },
     "test_rack_role": {
         "hosts": [
             "R1-Device"
@@ -334,9 +350,6 @@
             "parent_rack_group"
         ],
         "hosts": [
-            "TestDeviceR1",
-            "VC1",
-            "test100",
             "test100-vm",
             "test101-vm",
             "test102-vm",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.json
@@ -30,9 +30,9 @@
                 "device_type": "cisco-test",
                 "display": "R1-Device",
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "rack": "Test Rack Site 2",
-                "rack_groups": [],
                 "rack_id": "1",
                 "rack_role": "test-rack-role",
                 "regions": [],
@@ -49,6 +49,7 @@
                 "cluster_type": "test-cluster-type",
                 "custom_fields": {},
                 "is_virtual": true,
+                "locations": [],
                 "regions": [],
                 "status": {
                     "label": "Active",
@@ -61,9 +62,9 @@
                 "device_type": "cisco-test",
                 "display": "TestDeviceR1",
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "rack": "Test Rack",
-                "rack_groups": [],
                 "rack_id": "2",
                 "regions": [
                     "test-region",
@@ -84,6 +85,7 @@
                 "display": "Test Nexus One",
                 "dns_name": "nexus.example.com",
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "primary_ip4": "172.16.180.12",
                 "regions": [
@@ -108,6 +110,7 @@
                         "pool.ntp.org"
                     ]
                 },
+                "locations": [],
                 "manufacturer": "cisco",
                 "regions": [
                     "test-region",
@@ -127,6 +130,7 @@
                 "cluster_type": "test-cluster-type",
                 "custom_fields": {},
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -144,6 +148,7 @@
                 "cluster_type": "test-cluster-type",
                 "custom_fields": {},
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -161,6 +166,7 @@
                 "cluster_type": "test-cluster-type",
                 "custom_fields": {},
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -178,6 +184,7 @@
                 "cluster_type": "test-cluster-type",
                 "custom_fields": {},
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -194,6 +201,7 @@
                 "cluster_type": "test-cluster-type",
                 "custom_fields": {},
                 "is_virtual": true,
+                "locations": [],
                 "regions": [],
                 "status": {
                     "label": "Active",
@@ -283,6 +291,11 @@
             "VC1"
         ]
     },
+    "parent_rack_group": {
+        "children": [
+            "test_rack_group"
+        ]
+    },
     "parent_region": {
         "children": [
             "test_region"
@@ -317,6 +330,9 @@
         ]
     },
     "test_site": {
+        "children": [
+            "parent_rack_group"
+        ],
         "hosts": [
             "TestDeviceR1",
             "VC1",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-options.yml
@@ -23,7 +23,7 @@ group_by:
   - site
   - tenant
   - rack
-  - rack_group
+  - location
   - rack_role
   - tag
   - role

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
@@ -36,10 +36,10 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
-                "rack_groups": [],
                 "rack_role": "test-rack-role",
                 "racks": [
                     "Test Rack Site 2"
@@ -66,6 +66,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -90,6 +91,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [],
                 "status": {
                     "label": "Active",
@@ -108,10 +110,10 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
-                "rack_groups": [],
                 "racks": [
                     "Test Rack"
                 ],
@@ -143,6 +145,7 @@
                         ]
                     }
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -170,6 +173,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -191,6 +195,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -212,6 +217,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -233,6 +239,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -253,6 +260,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [],
                 "status": {
                     "label": "Active",
@@ -335,6 +343,11 @@
             "Test Nexus One"
         ]
     },
+    "parent_rack_group": {
+        "children": [
+            "test_rack_group"
+        ]
+    },
     "parent_region": {
         "children": [
             "test_region"
@@ -369,6 +382,9 @@
         ]
     },
     "test_site": {
+        "children": [
+            "parent_rack_group"
+        ],
         "hosts": [
             "Test Nexus One",
             "TestDeviceR1",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.json
@@ -66,7 +66,10 @@
                 "local_context_data": [
                     null
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -110,7 +113,10 @@
                 "local_context_data": [
                     null
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -145,7 +151,10 @@
                         ]
                     }
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -371,6 +380,13 @@
             "test104-vm"
         ]
     },
+    "test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
     "test_rack_role": {
         "hosts": [
             "R1-Device"
@@ -386,9 +402,6 @@
             "parent_rack_group"
         ],
         "hosts": [
-            "Test Nexus One",
-            "TestDeviceR1",
-            "test100",
             "test100-vm",
             "test101-vm",
             "test102-vm",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals-flatten.yml
@@ -16,7 +16,7 @@ group_by:
   - sites
   - tenants
   - racks
-  - rack_group
+  - location
   - rack_role
   - tags
   - device_roles

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
@@ -17,10 +17,10 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
-                "rack_groups": [],
                 "rack_role": "test-rack-role",
                 "racks": [
                     "Test Rack Site 2"
@@ -59,83 +59,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "display": "Test Nexus Child One",
-                            "display_name": "Test Nexus Child One",
-                            "id": 5,
-                            "name": "Test Nexus Child One",
-                            "url": "http://localhost:9000/api/dcim/devices/5/"
-                        },
-                        "display": "Ethernet2/1",
-                        "enabled": true,
-                        "id": 2,
-                        "ip_addresses": [
-                            {
-                                "address": "172.16.180.12/24",
-                                "created": "2021-05-08",
-                                "custom_fields": {},
-                                "description": "",
-                                "display": "172.16.180.12/24",
-                                "dns_name": "nexus.example.com",
-                                "family": {
-                                    "label": "IPv4",
-                                    "value": 4
-                                },
-                                "id": 4,
-                                "last_updated": "2021-05-08T11:30:55.090531Z",
-                                "nat_inside": null,
-                                "nat_outside": null,
-                                "role": null,
-                                "status": {
-                                    "label": "Active",
-                                    "value": "active"
-                                },
-                                "tags": [],
-                                "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/4/",
-                                "vrf": null
-                            }
-                        ],
-                        "label": "",
-                        "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.800817Z",
-                        "mac_address": null,
-                        "mark_connected": false,
-                        "mgmt_only": false,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Ethernet2/1",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "type": {
-                            "label": "1000BASE-T (1GE)",
-                            "value": "1000base-t"
-                        },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/2/"
-                    },
-                    {
-                        "_occupied": false,
-                        "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
-                        "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
-                        "connected_endpoint_type": null,
-                        "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
                             "display_name": "Test Nexus One",
                             "id": 4,
-                            "name": "Test Nexus One",
-                            "url": "http://localhost:9000/api/dcim/devices/4/"
+                            "name": "Test Nexus One"
                         },
                         "display": "Ethernet1/1",
                         "enabled": true,
@@ -143,7 +73,6 @@
                         "ip_addresses": [
                             {
                                 "address": "172.16.180.11/24",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "172.16.180.11/24",
@@ -153,7 +82,6 @@
                                     "value": 4
                                 },
                                 "id": 3,
-                                "last_updated": "2021-05-08T11:30:55.084701Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -163,13 +91,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/3/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.791371Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -183,14 +109,75 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/1/"
+                        "untagged_vlan": null
+                    },
+                    {
+                        "_occupied": false,
+                        "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
+                        "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
+                        "connected_endpoint_type": null,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "display": "Test Nexus Child One",
+                            "display_name": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "label": "",
+                        "lag": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null
                     }
                 ],
                 "is_virtual": false,
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -201,20 +188,17 @@
                 ],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
                             "display_name": "Test Nexus One",
                             "id": 4,
-                            "name": "Test Nexus One",
-                            "url": "http://localhost:9000/api/dcim/devices/4/"
+                            "name": "Test Nexus One"
                         },
                         "display": "telnet (TCP/23)",
                         "id": 3,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.459163Z",
                         "name": "telnet",
                         "ports": [
                             23
@@ -224,7 +208,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/3/",
                         "virtual_machine": null
                     }
                 ],
@@ -247,14 +230,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 11,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.285536Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -263,24 +244,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/11/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 12,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.292047Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -289,12 +266,10 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/12/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     }
                 ],
@@ -302,17 +277,16 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": null,
                         "display": "ssh (TCP/22)",
                         "id": 4,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.465221Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -322,12 +296,10 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/4/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     }
                 ],
@@ -353,10 +325,10 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
-                "rack_groups": [],
                 "racks": [
                     "Test Rack"
                 ],
@@ -399,15 +371,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "GigabitEthernet1",
                         "enabled": true,
@@ -415,7 +385,6 @@
                         "ip_addresses": [
                             {
                                 "address": "172.16.180.1/24",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "172.16.180.1/24",
@@ -425,7 +394,6 @@
                                     "value": 4
                                 },
                                 "id": 1,
-                                "last_updated": "2021-05-08T11:30:55.072310Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -435,13 +403,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/1/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.869203Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -455,8 +421,7 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/3/"
+                        "untagged_vlan": null
                     },
                     {
                         "_occupied": false,
@@ -467,15 +432,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "GigabitEthernet2",
                         "enabled": true,
@@ -483,7 +446,6 @@
                         "ip_addresses": [
                             {
                                 "address": "2001::1:1/64",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "2001::1:1/64",
@@ -493,7 +455,6 @@
                                     "value": 6
                                 },
                                 "id": 2,
-                                "last_updated": "2021-05-08T11:30:55.078833Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -503,13 +464,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/2/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.876923Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -523,8 +482,7 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/4/"
+                        "untagged_vlan": null
                     }
                 ],
                 "is_virtual": false,
@@ -535,6 +493,7 @@
                         ]
                     }
                 ],
+                "locations": [],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -544,20 +503,17 @@
                 ],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "ssh (TCP/22)",
                         "id": 1,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.436503Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -567,19 +523,16 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/1/",
                         "virtual_machine": null
                     },
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "http (TCP/80)",
                         "id": 2,
@@ -588,18 +541,15 @@
                                 "address": "172.16.180.1/24",
                                 "display": "172.16.180.1/24",
                                 "family": 4,
-                                "id": 1,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/1/"
+                                "id": 1
                             },
                             {
                                 "address": "2001::1:1/64",
                                 "display": "2001::1:1/64",
                                 "family": 6,
-                                "id": 2,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/2/"
+                                "id": 2
                             }
                         ],
-                        "last_updated": "2021-05-08T11:30:57.443736Z",
                         "name": "http",
                         "ports": [
                             80
@@ -609,7 +559,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/2/",
                         "virtual_machine": null
                     }
                 ],
@@ -633,14 +582,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 1,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.219270Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -649,24 +596,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/1/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 2,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.226670Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -675,24 +618,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/2/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth2",
                         "enabled": true,
                         "id": 3,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.233278Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -701,24 +640,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/3/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth3",
                         "enabled": true,
                         "id": 4,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.239805Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -727,24 +662,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/4/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth4",
                         "enabled": true,
                         "id": 5,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.246400Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -753,12 +684,10 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/5/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     }
                 ],
@@ -766,6 +695,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -791,14 +721,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 6,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.253033Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -807,24 +735,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/6/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 7,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.259421Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -833,24 +757,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/7/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth2",
                         "enabled": true,
                         "id": 8,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.265899Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -859,24 +779,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/8/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth3",
                         "enabled": true,
                         "id": 9,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.272465Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -885,24 +801,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/9/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth4",
                         "enabled": true,
                         "id": 10,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.278979Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -911,12 +823,10 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/10/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     }
                 ],
@@ -924,6 +834,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -951,6 +862,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -978,6 +890,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -1004,6 +917,7 @@
                 "local_context_data": [
                     null
                 ],
+                "locations": [],
                 "regions": [],
                 "services": [],
                 "status": {
@@ -1097,6 +1011,11 @@
             "test104-vm"
         ]
     },
+    "location_parent_rack_group": {
+        "children": [
+            "location_test_rack_group"
+        ]
+    },
     "manufacturers_cisco": {
         "hosts": [
             "R1-Device",
@@ -1131,6 +1050,9 @@
         ]
     },
     "sites_test_site": {
+        "children": [
+            "location_parent_rack_group"
+        ],
         "hosts": [
             "Test Nexus One",
             "TestDeviceR1",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals.json
@@ -177,7 +177,10 @@
                 "local_context_data": [
                     null
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -325,7 +328,10 @@
                 "local_context_data": [
                     null
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -493,7 +499,10 @@
                         ]
                     }
                 ],
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturers": [
                     "cisco"
                 ],
@@ -1016,6 +1025,13 @@
             "location_test_rack_group"
         ]
     },
+    "location_test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
     "manufacturers_cisco": {
         "hosts": [
             "R1-Device",
@@ -1054,9 +1070,6 @@
             "location_parent_rack_group"
         ],
         "hosts": [
-            "Test Nexus One",
-            "TestDeviceR1",
-            "test100",
             "test100-vm",
             "test101-vm",
             "test102-vm",

--- a/tests/integration/targets/inventory-latest/files/test-inventory-plurals.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory-plurals.yml
@@ -21,7 +21,7 @@ group_by:
   - sites
   - tenants
   - racks
-  - rack_group
+  - location
   - rack_role
   - tags
   - device_roles

--- a/tests/integration/targets/inventory-latest/files/test-inventory.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory.json
@@ -7,9 +7,9 @@
                 "device_type": "cisco-test",
                 "interfaces": [],
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "rack": "Test Rack Site 2",
-                "rack_groups": [],
                 "rack_role": "test-rack-role",
                 "regions": [],
                 "role": "core-switch",
@@ -37,83 +37,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "display": "Test Nexus Child One",
-                            "display_name": "Test Nexus Child One",
-                            "id": 5,
-                            "name": "Test Nexus Child One",
-                            "url": "http://localhost:9000/api/dcim/devices/5/"
-                        },
-                        "display": "Ethernet2/1",
-                        "enabled": true,
-                        "id": 2,
-                        "ip_addresses": [
-                            {
-                                "address": "172.16.180.12/24",
-                                "created": "2021-05-08",
-                                "custom_fields": {},
-                                "description": "",
-                                "display": "172.16.180.12/24",
-                                "dns_name": "nexus.example.com",
-                                "family": {
-                                    "label": "IPv4",
-                                    "value": 4
-                                },
-                                "id": 4,
-                                "last_updated": "2021-05-08T11:30:55.090531Z",
-                                "nat_inside": null,
-                                "nat_outside": null,
-                                "role": null,
-                                "status": {
-                                    "label": "Active",
-                                    "value": "active"
-                                },
-                                "tags": [],
-                                "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/4/",
-                                "vrf": null
-                            }
-                        ],
-                        "label": "",
-                        "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.800817Z",
-                        "mac_address": null,
-                        "mark_connected": false,
-                        "mgmt_only": false,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Ethernet2/1",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "type": {
-                            "label": "1000BASE-T (1GE)",
-                            "value": "1000base-t"
-                        },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/2/"
-                    },
-                    {
-                        "_occupied": false,
-                        "cable": null,
-                        "cable_peer": null,
-                        "cable_peer_type": null,
-                        "connected_endpoint": null,
-                        "connected_endpoint_reachable": null,
-                        "connected_endpoint_type": null,
-                        "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
                             "display_name": "Test Nexus One",
                             "id": 4,
-                            "name": "Test Nexus One",
-                            "url": "http://localhost:9000/api/dcim/devices/4/"
+                            "name": "Test Nexus One"
                         },
                         "display": "Ethernet1/1",
                         "enabled": true,
@@ -121,7 +51,6 @@
                         "ip_addresses": [
                             {
                                 "address": "172.16.180.11/24",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "172.16.180.11/24",
@@ -131,7 +60,6 @@
                                     "value": 4
                                 },
                                 "id": 3,
-                                "last_updated": "2021-05-08T11:30:55.084701Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -141,13 +69,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/3/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.791371Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -161,11 +87,72 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/1/"
+                        "untagged_vlan": null
+                    },
+                    {
+                        "_occupied": false,
+                        "cable": null,
+                        "cable_peer": null,
+                        "cable_peer_type": null,
+                        "connected_endpoint": null,
+                        "connected_endpoint_reachable": null,
+                        "connected_endpoint_type": null,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "display": "Test Nexus Child One",
+                            "display_name": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "label": "",
+                        "lag": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null
                     }
                 ],
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "primary_ip4": "172.16.180.12",
                 "regions": [
@@ -175,20 +162,17 @@
                 "role": "core-switch",
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
                             "display_name": "Test Nexus One",
                             "id": 4,
-                            "name": "Test Nexus One",
-                            "url": "http://localhost:9000/api/dcim/devices/4/"
+                            "name": "Test Nexus One"
                         },
                         "display": "telnet (TCP/23)",
                         "id": 3,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.459163Z",
                         "name": "telnet",
                         "ports": [
                             23
@@ -198,7 +182,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/3/",
                         "virtual_machine": null
                     }
                 ],
@@ -217,14 +200,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 11,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.285536Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -233,24 +214,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/11/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 12,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.292047Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -259,27 +236,24 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/12/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     }
                 ],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [],
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": null,
                         "display": "ssh (TCP/22)",
                         "id": 4,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.465221Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -289,12 +263,10 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/4/",
                         "virtual_machine": {
                             "display": "Test VM With Spaces",
                             "id": 6,
-                            "name": "Test VM With Spaces",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/6/"
+                            "name": "Test VM With Spaces"
                         }
                     }
                 ],
@@ -310,9 +282,9 @@
                 "device_type": "cisco-test",
                 "interfaces": [],
                 "is_virtual": false,
+                "locations": [],
                 "manufacturer": "cisco",
                 "rack": "Test Rack",
-                "rack_groups": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -344,15 +316,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "GigabitEthernet1",
                         "enabled": true,
@@ -360,7 +330,6 @@
                         "ip_addresses": [
                             {
                                 "address": "172.16.180.1/24",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "172.16.180.1/24",
@@ -370,7 +339,6 @@
                                     "value": 4
                                 },
                                 "id": 1,
-                                "last_updated": "2021-05-08T11:30:55.072310Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -380,13 +348,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/1/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.869203Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -400,8 +366,7 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/3/"
+                        "untagged_vlan": null
                     },
                     {
                         "_occupied": false,
@@ -412,15 +377,13 @@
                         "connected_endpoint_reachable": null,
                         "connected_endpoint_type": null,
                         "count_ipaddresses": 1,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "GigabitEthernet2",
                         "enabled": true,
@@ -428,7 +391,6 @@
                         "ip_addresses": [
                             {
                                 "address": "2001::1:1/64",
-                                "created": "2021-05-08",
                                 "custom_fields": {},
                                 "description": "",
                                 "display": "2001::1:1/64",
@@ -438,7 +400,6 @@
                                     "value": 6
                                 },
                                 "id": 2,
-                                "last_updated": "2021-05-08T11:30:55.078833Z",
                                 "nat_inside": null,
                                 "nat_outside": null,
                                 "role": null,
@@ -448,13 +409,11 @@
                                 },
                                 "tags": [],
                                 "tenant": null,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/2/",
                                 "vrf": null
                             }
                         ],
                         "label": "",
                         "lag": null,
-                        "last_updated": "2021-05-08T11:30:54.876923Z",
                         "mac_address": null,
                         "mark_connected": false,
                         "mgmt_only": false,
@@ -468,8 +427,7 @@
                             "label": "1000BASE-T (1GE)",
                             "value": "1000base-t"
                         },
-                        "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/dcim/interfaces/4/"
+                        "untagged_vlan": null
                     }
                 ],
                 "is_virtual": false,
@@ -478,6 +436,7 @@
                         "pool.ntp.org"
                     ]
                 },
+                "locations": [],
                 "manufacturer": "cisco",
                 "regions": [
                     "test-region",
@@ -486,20 +445,17 @@
                 "role": "core-switch",
                 "services": [
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "ssh (TCP/22)",
                         "id": 1,
                         "ipaddresses": [],
-                        "last_updated": "2021-05-08T11:30:57.436503Z",
                         "name": "ssh",
                         "ports": [
                             22
@@ -509,19 +465,16 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/1/",
                         "virtual_machine": null
                     },
                     {
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "device": {
                             "display": "test100",
                             "display_name": "test100",
                             "id": 1,
-                            "name": "test100",
-                            "url": "http://localhost:9000/api/dcim/devices/1/"
+                            "name": "test100"
                         },
                         "display": "http (TCP/80)",
                         "id": 2,
@@ -530,18 +483,15 @@
                                 "address": "172.16.180.1/24",
                                 "display": "172.16.180.1/24",
                                 "family": 4,
-                                "id": 1,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/1/"
+                                "id": 1
                             },
                             {
                                 "address": "2001::1:1/64",
                                 "display": "2001::1:1/64",
                                 "family": 6,
-                                "id": 2,
-                                "url": "http://localhost:9000/api/ipam/ip-addresses/2/"
+                                "id": 2
                             }
                         ],
-                        "last_updated": "2021-05-08T11:30:57.443736Z",
                         "name": "http",
                         "ports": [
                             80
@@ -551,7 +501,6 @@
                             "value": "tcp"
                         },
                         "tags": [],
-                        "url": "http://localhost:9000/api/ipam/services/2/",
                         "virtual_machine": null
                     }
                 ],
@@ -571,14 +520,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 1,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.219270Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -587,24 +534,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/1/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 2,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.226670Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -613,24 +556,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/2/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth2",
                         "enabled": true,
                         "id": 3,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.233278Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -639,24 +578,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/3/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth3",
                         "enabled": true,
                         "id": 4,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.239805Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -665,24 +600,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/4/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth4",
                         "enabled": true,
                         "id": 5,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.246400Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -691,16 +622,15 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/5/",
                         "virtual_machine": {
                             "display": "test100-vm",
                             "id": 1,
-                            "name": "test100-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/1/"
+                            "name": "test100-vm"
                         }
                     }
                 ],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -722,14 +652,12 @@
                 "interfaces": [
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth0",
                         "enabled": true,
                         "id": 6,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.253033Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -738,24 +666,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/6/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth1",
                         "enabled": true,
                         "id": 7,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.259421Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -764,24 +688,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/7/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth2",
                         "enabled": true,
                         "id": 8,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.265899Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -790,24 +710,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/8/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth3",
                         "enabled": true,
                         "id": 9,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.272465Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -816,24 +732,20 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/9/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     },
                     {
                         "count_ipaddresses": 0,
-                        "created": "2021-05-08",
                         "custom_fields": {},
                         "description": "",
                         "display": "Eth4",
                         "enabled": true,
                         "id": 10,
                         "ip_addresses": [],
-                        "last_updated": "2021-05-08T11:30:57.278979Z",
                         "mac_address": null,
                         "mode": null,
                         "mtu": null,
@@ -842,16 +754,15 @@
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
-                        "url": "http://localhost:9000/api/virtualization/interfaces/10/",
                         "virtual_machine": {
                             "display": "test101-vm",
                             "id": 2,
-                            "name": "test101-vm",
-                            "url": "http://localhost:9000/api/virtualization/virtual-machines/2/"
+                            "name": "test101-vm"
                         }
                     }
                 ],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -872,6 +783,7 @@
                 "custom_fields": {},
                 "interfaces": [],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -892,6 +804,7 @@
                 "custom_fields": {},
                 "interfaces": [],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -911,6 +824,7 @@
                 "custom_fields": {},
                 "interfaces": [],
                 "is_virtual": true,
+                "locations": [],
                 "regions": [],
                 "services": [],
                 "status": {
@@ -999,6 +913,11 @@
             "test104-vm"
         ]
     },
+    "location_parent_rack_group": {
+        "children": [
+            "location_test_rack_group"
+        ]
+    },
     "manufacturer_cisco": {
         "hosts": [
             "R1-Device",
@@ -1057,6 +976,9 @@
         ]
     },
     "site_test_site": {
+        "children": [
+            "location_parent_rack_group"
+        ],
         "hosts": [
             "Test Nexus One",
             "TestDeviceR1",

--- a/tests/integration/targets/inventory-latest/files/test-inventory.json
+++ b/tests/integration/targets/inventory-latest/files/test-inventory.json
@@ -152,7 +152,10 @@
                     }
                 ],
                 "is_virtual": false,
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "primary_ip4": "172.16.180.12",
                 "regions": [
@@ -282,7 +285,10 @@
                 "device_type": "cisco-test",
                 "interfaces": [],
                 "is_virtual": false,
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "rack": "Test Rack",
                 "regions": [
@@ -436,7 +442,10 @@
                         "pool.ntp.org"
                     ]
                 },
-                "locations": [],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
                 "manufacturer": "cisco",
                 "regions": [
                     "test-region",
@@ -918,6 +927,13 @@
             "location_test_rack_group"
         ]
     },
+    "location_test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
     "manufacturer_cisco": {
         "hosts": [
             "R1-Device",
@@ -980,9 +996,6 @@
             "location_parent_rack_group"
         ],
         "hosts": [
-            "Test Nexus One",
-            "TestDeviceR1",
-            "test100",
             "test100-vm",
             "test101-vm",
             "test102-vm",

--- a/tests/integration/targets/inventory-latest/files/test-inventory.yml
+++ b/tests/integration/targets/inventory-latest/files/test-inventory.yml
@@ -12,7 +12,7 @@ group_by:
   - site
   - tenant
   - rack
-  - rack_group
+  - location
   - rack_role
   - tag
   - role


### PR DESCRIPTION
Use locations instead of rack groups in 2.11. This still allows 2.10 or lower to function with rack groups.

Fixes #492 

- Will use locations or rack groups depending on the API version
- Adds locations to their specific site group as children
- Creates parent relationship with nested locations just like regions
- Devices are added to locations if assigned to a location. They are assigned to sites if **not** assigned to a location.
- Will throw an error if `location` is added to `group_by` and API version is 2.10 or lower
- Will throw an error if `rack_group` is added to `group_by` and API version is 2.11 or higher

I have not added any testing yet, but wanted to at least get this out there.