### PR TITLE
Add `private_key` option to `nb_lookup`.

### DIFF
--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -49,7 +49,7 @@ DOCUMENTATION = """
             required: True
         api_filter:
             description:
-                - The api_filter to use.
+                - The api_filter to use. Filters should be key value pairs separated by a space.
             required: False
         plugin:
             description:

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -33,7 +33,7 @@ DOCUMENTATION = """
     description:
         - Queries Netbox via its API to return virtually any information
           capable of being held in Netbox.
-        - If wanting to obtain the plaintext attribute of a secret, key_file must be provided.
+        - If wanting to obtain the plaintext attribute of a secret, private_key or key_file must be provided.
     options:
         _terms:
             description:
@@ -69,9 +69,13 @@ DOCUMENTATION = """
                 - Whether or not to validate SSL of the NetBox instance
             required: False
             default: True
+        private_key:
+            description:
+                - The private key as a string. Mutually exclusive with I(key_file).
+            required: False
         key_file:
             description:
-                - The location of the private key tied to user account.
+                - The location of the private key tied to user account. Mutually exclusive with I(private_key).
             required: False
         raw_data:
             description:
@@ -303,6 +307,7 @@ class LookupModule(LookupBase):
             or os.getenv("NETBOX_URL")
         )
         netbox_ssl_verify = kwargs.get("validate_certs", True)
+        netbox_private_key = kwargs.get("private_key")
         netbox_private_key_file = kwargs.get("key_file")
         netbox_api_filter = kwargs.get("api_filter")
         netbox_raw_return = kwargs.get("raw_data")
@@ -318,6 +323,7 @@ class LookupModule(LookupBase):
             netbox = pynetbox.api(
                 netbox_api_endpoint,
                 token=netbox_api_token if netbox_api_token else None,
+                private_key=netbox_private_key,
                 private_key_file=netbox_private_key_file,
             )
             netbox.http_session = session

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -33,7 +33,7 @@ DOCUMENTATION = """
     description:
         - Queries Netbox via its API to return virtually any information
           capable of being held in Netbox.
-        - If wanting to obtain the plaintext attribute of a secret, private_key or key_file must be provided.
+        - If wanting to obtain the plaintext attribute of a secret, I(private_key) or I(key_file) must be provided.
     options:
         _terms:
             description:

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -78,6 +78,7 @@ DOCUMENTATION = """
                 - The location of the private key tied to user account. Mutually exclusive with I(private_key).
             required: False
         raw_data:
+            type: bool
             description:
                 - Whether to return raw API data with the lookup/query or whether to return a key/value dict
             required: False


### PR DESCRIPTION
This PR adds a `private_key` option to `nb_lookup`.
It allows the private key (for secret decryption) to be read from a variable instead of a file.
This may be useful if the private key is stored in an ansible-vault for example.

I've also clarified the documentation for `api_filter` and `raw_data`.