### PR TITLE
Added custom certificate support

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -35,6 +35,18 @@ DOCUMENTATION = """
                 - Allows connection when SSL certificates are not valid. Set to C(false) when certificates are not trusted.
             default: True
             type: boolean
+        cert:
+            description:
+                - Certificate path
+            default: False
+        key:
+            description:
+                - Certificate key path
+            default: False
+        ca_path:
+            description:
+                - CA path
+            default: False
         follow_redirects:
             description:
                 - Determine how redirects are followed.
@@ -299,6 +311,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     timeout=self.timeout,
                     validate_certs=self.validate_certs,
                     follow_redirects=self.follow_redirects,
+                    client_cert=self.cert,
+                    client_key=self.key,
+                    ca_path=self.ca_path,
                 )
             except urllib_error.HTTPError as e:
                 """This will return the response body when we encounter an error.
@@ -1623,6 +1638,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             % (ansible_version, python_version.split(" ")[0]),
             "Content-type": "application/json",
         }
+        self.cert = self.get_option("cert")
+        self.key = self.get_option("key")
+        self.ca_path = self.get_option("ca_path")
         if token:
             self.headers.update({"Authorization": "Token %s" % token})
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -463,6 +463,7 @@ NETBOX_ARG_SPEC = dict(
     state=dict(required=False, default="present", choices=["present", "absent"]),
     query_params=dict(required=False, type="list", elements="str"),
     validate_certs=dict(type="raw", default=True),
+    cert=dict(type="raw", required=False),
 )
 
 
@@ -490,10 +491,11 @@ class NetboxModule(object):
         url = self.module.params["netbox_url"]
         token = self.module.params["netbox_token"]
         ssl_verify = self.module.params["validate_certs"]
+        cert = self.module.params["cert"]
 
         # Attempt to initiate connection to Netbox
         if nb_client is None:
-            self.nb = self._connect_netbox_api(url, token, ssl_verify)
+            self.nb = self._connect_netbox_api(url, token, ssl_verify, cert)
         else:
             self.nb = nb_client
             try:
@@ -536,10 +538,11 @@ class NetboxModule(object):
         elif g_major == l_major and g_minor > l_minor:
             return True
 
-    def _connect_netbox_api(self, url, token, ssl_verify):
+    def _connect_netbox_api(self, url, token, ssl_verify, cert):
         try:
             session = requests.Session()
             session.verify = ssl_verify
+            session.cert = tuple(i for i in cert)
             nb = pynetbox.api(url, token=token)
             nb.http_session = session
             try:


### PR DESCRIPTION
Added custom certificate support for TLS authentication.

With `ansible-inventory` it can be used like this:
```
---
plugin: netbox.netbox.nb_inventory
api_endpoint: https://path.to.your.netbox:443
token: 0123456789abcdef0123456789abcdef01234567
validate_certs: true
cert: "/path/to/client.cert"
key: "/path/to/client.key"
ca_path: "/path/to/ca.crt"
config_context: false
interfaces: true
```

With `ansible-playbook` it can be used like this:
```
 - hosts: all
   gather_facts: no
   connection: local
   environment:
     REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
   vars:
     netbox_url: "https://path.to.your.netbox:443"
     netbox_token: "0123456789abcdef0123456789abcdef01234567"
     cert:
       - "/path/to/client.cert"
       - "/path/to/client.key"

   tasks:
    - name: "Task name"
      delegate_to: localhost
      block:
        - name: "BLOCK NAME"
          netbox.netbox.netbox_prefix:
            netbox_url: "{{ netbox_url }}"
            netbox_token: "{{ netbox_token }}"
            cert: "{{ cert }}"
.
.
```

The `REQUESTS_CA_BUNDLE` environmental variable is important in order to properly work.