### PR TITLE
Fix plugins/inventory -> options/group_by

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -114,7 +114,7 @@ DOCUMENTATION = """
                 - I(rack_group) is supported on NetBox versions 2.10 or lower only
                 - I(location) is supported on NetBox versions 2.11 or higher only
             type: list
-            choices:
+            elements:
                 - sites
                 - site
                 - location


### PR DESCRIPTION
The documentation for a plugin's `options` are located [here]( https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec).

Changing this to `elements` allows users to select "Any of" the options in the list rather than "The whole list (or not)" As it stands the `default: []` prevents the plugin from loading at all.