### PR TITLE
Fix: More than one result returned for virtual_chassis

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -345,7 +345,7 @@ ALLOWED_QUERY_PARAMS = {
     "termination_a": set(["name", "device", "virtual_machine"]),
     "termination_b": set(["name", "device", "virtual_machine"]),
     "untagged_vlan": set(["group", "name", "site", "vid", "vlan_group", "tenant"]),
-    "virtual_chassis": set(["name", "master"]),
+    "virtual_chassis": set(["name", "device"]),
     "virtual_machine": set(["name", "cluster"]),
     "vlan": set(["group", "name", "site", "tenant", "vid", "vlan_group"]),
     "vlan_group": set(["slug", "site", "scope"]),
@@ -763,9 +763,6 @@ class NetboxModule(object):
                 query_dict.update(
                     {"interface_id": module_data.get("assigned_object_id")}
                 )
-
-        elif parent == "virtual_chassis":
-            query_dict = {"q": self.module.params["data"].get("master")}
 
         elif parent == "rear_port" and self.endpoint == "front_ports":
             if isinstance(module_data.get("rear_port"), str):


### PR DESCRIPTION
Fixes #402 -> More than one result returned for virtual_chassis

**Task:**
```yaml
    - name: NetBox - Create virtual chassis
      netbox_virtual_chassis:
        netbox_url: '{{ netbox_url }}'
        netbox_token: '{{ netbox_token }}'
        data:
          name: '{{ inventory_hostname }}'
          master: '{{ inventory_hostname + "-1" }}'
        state: present
```

**Virtual chassis creation error:***
```yaml
TASK [NetBox - Create virtual chassis] *********************************************************************************************************************************************************
fatal: [NET-LIT-SWI-001]: FAILED! => changed=false 
  msg: More than one result returned for NET-LIT-SWI-001
fatal: [NET-LIT-SWI-DIST]: FAILED! => changed=false 
  msg: More than one result returned for NET-LIT-SWI-DIST
```

**Output after fix:**
```yaml
PLAY [Netbox add devices from inventory] *******************************************************************************************************************************************************

TASK [NETBOX >> query devices before] **********************************************************************************************************************************************************
ok: [NET-SWI-DIST]
ok: [NET-SWI-001]

TASK [NETBOX >> Create devices] ****************************************************************************************************************************************************************
changed: [NET-SWI-001] => (item=OS6560-P48X4)
changed: [NET-SWI-DIST] => (item=OS6860E-P24)
changed: [NET-SWI-001] => (item=OS6560-P48X4)
changed: [NET-SWI-001] => (item=OS6560-P48X4)
changed: [NET-SWI-001] => (item=OS6560-P48X4)

TASK [NetBox - Create virtual chassis] *********************************************************************************************************************************************************
changed: [NET-SWI-DIST]
changed: [NET-SWI-001]

TASK [NetBox - Add devices to Virtual chassis] *************************************************************************************************************************************************
ok: [NET-SWI-DIST] => (item={'type': 'OS6860E-P24', 'unit': 1})
ok: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 1})
changed: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 2})
changed: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 3})
changed: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 4})

TASK [NETBOX >> query devices after] ***********************************************************************************************************************************************************
ok: [NET-SWI-001]
ok: [NET-SWI-DIST]

TASK [NETBOX >> devices list added] ************************************************************************************************************************************************************
ok: [NET-SWI-DIST] => 
  msg:
  - NET-SWI-001-1
  - NET-SWI-001-2
  - NET-SWI-001-3
  - NET-SWI-001-4
  - NET-SWI-DIST-1
ok: [NET-SWI-001] => 
  msg:
  - NET-SWI-001-1
  - NET-SWI-001-2
  - NET-SWI-001-3
  - NET-SWI-001-4
  - NET-SWI-DIST-1

PLAY RECAP *************************************************************************************************************************************************************************************
NET-SWI-001            : ok=6    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
NET-SWI-DIST           : ok=6    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```