### PR TITLE
Ensure to only query the desired endpoint when only providing device or vm on nb_inventory

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1265,7 +1265,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # - If none of the filters are valid for VMs, do not fetch any VMs
         # If either device_query_filters or vm_query_filters are set,
         # device_query_parameters and vm_query_parameters will have > 1 element so will continue to be requested
-        if self.query_filters and isinstance(self.query_filters, Iterable):
+        #
+        # Also: When query_filters is empty and either device_query_filters or vm_query_filters are set,
+        # remove empty filters to only query one desired endpoint
+        # E.g.: query_filters & vm_query_filters empty, but device_query_filters set - do not query all VMs,
+        # but only filtered devices
+        if (self.query_filters and isinstance(self.query_filters, Iterable)) \
+           or len(device_query_parameters + vm_query_parameters) > 2:
             if len(device_query_parameters) <= 1:
                 device_url = None
 


### PR DESCRIPTION
Hello altogether,

this PR aims to fix #471 

Currently the logic in nb_inventory will fetch undesired hosts, when given only given a device/vm_query_filter.
For example with the following config:
Input:
```yaml
device_query_filters:
  - name: 'test'
```
The plugin will query `/dcim/devices/?name=test` and `/virtualization/virtual-machines/`.

There is no solution to circumvent this behaviour, so in our case for 1 device, all n-thousand VMs are queried as well.

Therefore I've added a simple condition to remove any non-filtered endpoint, if at least one endpoint has filter parameters set.

If the current behaviour is as intended, as users may want to fetch only n from one devices/vms and all from the other endpoint, I'd argue that the defaults on device/vm_query_filters should be changed from an empty list to null/None, so that users can explicitly set device/vm_query_filters to an empty list and this plugin knows that they want to fetch everything.
