### PR TITLE
Ignore custom certificates if not set

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -542,7 +542,9 @@ class NetboxModule(object):
         try:
             session = requests.Session()
             session.verify = ssl_verify
-            session.cert = tuple(i for i in cert)
+            # Ignore custom certficates if not present
+            if cert:
+                session.cert = tuple(i for i in cert)
             nb = pynetbox.api(url, token=token)
             nb.http_session = session
             try:


### PR DESCRIPTION
Hi,

The following commit from the beginning of June forces you to specify a certificate when trying to open up a new connection to the Netbox API: https://github.com/netbox-community/ansible_modules/commit/c959009dbdb9713e01b69251b8d53b6f6a329629

If you don't specify one, you get the default exception as fallback since `cert` isn't iterable/not set. 

This PR unblocks the devel branch. 