### PR TITLE
Revert "Fix plugins/inventory -> options/group_by"

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -126,7 +126,7 @@ DOCUMENTATION = """
                 - I(rack_group) is supported on NetBox versions 2.10 or lower only
                 - I(location) is supported on NetBox versions 2.11 or higher only
             type: list
-            elements:
+            choices:
                 - sites
                 - site
                 - location


### PR DESCRIPTION
Reverts netbox-community/ansible_modules#537

See the original PR for my comments.  This should be ripped out for now.