### PR TITLE
This allows the addition of the parent to an interface.

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -177,6 +177,7 @@ CONVERT_TO_ID = {
     "nat_inside": "ip_addresses",
     "nat_outside": "ip_addresses",
     "platform": "platforms",
+    "parent": "interfaces",
     "parent_region": "regions",
     "parent_tenant_group": "tenant_groups",
     "power_panel": "power_panels",
@@ -314,6 +315,7 @@ ALLOWED_QUERY_PARAMS = {
     "manufacturer": set(["slug"]),
     "master": set(["name"]),
     "nat_inside": set(["vrf", "address"]),
+    "parent": set(["name"]),
     "parent_region": set(["slug"]),
     "parent_tenant_group": set(["slug"]),
     "platform": set(["slug"]),
@@ -733,6 +735,15 @@ class NetboxModule(object):
             # This is to skip any potential changes using module_data when the user
             # provides user_query_params
             pass
+
+        elif parent == "parent":
+            if not child:
+                query_dict["name"] = module_data["parent"]
+            if isntance(module_data["device"], int):
+                query_dict.update({"device_id": module_data["device"]})
+            else:
+                query_dict.update({"device": module_data["device"]})
+
         elif parent == "lag":
             if not child:
                 query_dict["name"] = module_data["lag"]
@@ -937,6 +948,7 @@ class NetboxModule(object):
                 else:
                     if k in [
                         "lag",
+                        "parent",
                         "rear_port",
                         "rear_port_template",
                         "power_port",

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -736,7 +736,7 @@ class NetboxModule(object):
             # provides user_query_params
             pass
 
-        elif parent == "parent":
+        elif parent == "parent" and module_data.get("device"):
             if not child:
                 query_dict["name"] = module_data["parent"]
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -178,7 +178,7 @@ CONVERT_TO_ID = {
     "nat_outside": "ip_addresses",
     "platform": "platforms",
     "parent_interface": "interfaces",
-    "parent_vm_interface": "interfaces,
+    "parent_vm_interface": "interfaces",
     "parent_region": "regions",
     "parent_tenant_group": "tenant_groups",
     "power_panel": "power_panels",

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -755,11 +755,11 @@ class NetboxModule(object):
         elif parent == "parent_vm_interface" and module_data.get("virtual_machine"):
             if not child:
                 query_dict["name"] = module_data["parent_vm_interface"]
-            if isinstance(module_data["virtual_machine"], int):
-                query_dict.update({"virtual_machine": module_data["virtual_machine"]})
-            else:
-                query_dict.update({"virtual_machine": module_data["virtual_machine"]})
-
+#            if isinstance(module_data["virtual_machine"], int):
+#                query_dict.update({"virtual_machine": module_data["virtual_machine"]})
+#            else:
+#                query_dict.update({"virtual_machine": module_data["virtual_machine"]})
+#
         elif parent == "lag":
             if not child:
                 query_dict["name"] = module_data["lag"]

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -177,7 +177,7 @@ CONVERT_TO_ID = {
     "nat_inside": "ip_addresses",
     "nat_outside": "ip_addresses",
     "platform": "platforms",
-    "parent": "interfaces",
+    "parent_interface": "interfaces",
     "parent_region": "regions",
     "parent_tenant_group": "tenant_groups",
     "power_panel": "power_panels",
@@ -315,7 +315,7 @@ ALLOWED_QUERY_PARAMS = {
     "manufacturer": set(["slug"]),
     "master": set(["name"]),
     "nat_inside": set(["vrf", "address"]),
-    "parent": set(["name"]),
+    "parent_interface": set(["name"]),
     "parent_region": set(["slug"]),
     "parent_tenant_group": set(["slug"]),
     "platform": set(["slug"]),
@@ -408,6 +408,7 @@ CONVERT_KEYS = {
     "circuit_type": "type",
     "cluster_type": "type",
     "cluster_group": "group",
+    "parent_interface": "parent",
     "parent_region": "parent",
     "parent_tenant_group": "parent",
     "power_port_template": "power_port",
@@ -736,9 +737,12 @@ class NetboxModule(object):
             # provides user_query_params
             pass
 
-        elif parent == "parent" and module_data.get("device"):
+        elif parent == "prefix" and module_data.get("parent"):
+            query_dict.update({"prefix": module_data["parent"]})
+
+        elif parent == "parent_interface":
             if not child:
-                query_dict["name"] = module_data["parent"]
+                query_dict["name"] = module_data.get("parent_interface")
 
             if isinstance(module_data.get("device"), int):
                 query_dict.update({"device_id": module_data.get("device")})
@@ -756,9 +760,6 @@ class NetboxModule(object):
                 query_dict.update({"device_id": module_data["device"]})
             else:
                 query_dict.update({"device": module_data["device"]})
-
-        elif parent == "prefix" and module_data.get("parent"):
-            query_dict.update({"prefix": module_data["parent"]})
 
         elif parent == "ip_addresses":
             if isinstance(module_data["device"], int):
@@ -949,7 +950,7 @@ class NetboxModule(object):
                 else:
                     if k in [
                         "lag",
-                        "parent",
+                        "parent_interface",
                         "rear_port",
                         "rear_port_template",
                         "power_port",

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -739,7 +739,7 @@ class NetboxModule(object):
         elif parent == "parent":
             if not child:
                 query_dict["name"] = module_data["parent"]
-            if instance(module_data["device"], int):
+            if isnstance(module_data["device"], int):
                 query_dict.update({"device_id": module_data["device"]})
             else:
                 query_dict.update({"device": module_data["device"]})

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -739,10 +739,11 @@ class NetboxModule(object):
         elif parent == "parent":
             if not child:
                 query_dict["name"] = module_data["parent"]
+
             if isinstance(module_data["device"], int):
-                query_dict.update({"device_id": module_data["device"]})
+                query_dict.update({"device_id": module_data.get("device")})
             else:
-                query_dict.update({"device": module_data["device"]})
+                query_dict.update({"device": module_data.get("device")})
 
         elif parent == "lag":
             if not child:

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -739,7 +739,7 @@ class NetboxModule(object):
         elif parent == "parent":
             if not child:
                 query_dict["name"] = module_data["parent"]
-            if isnstance(module_data["device"], int):
+            if isinstance(module_data["device"], int):
                 query_dict.update({"device_id": module_data["device"]})
             else:
                 query_dict.update({"device": module_data["device"]})

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -739,7 +739,7 @@ class NetboxModule(object):
         elif parent == "parent":
             if not child:
                 query_dict["name"] = module_data["parent"]
-            if isntance(module_data["device"], int):
+            if instance(module_data["device"], int):
                 query_dict.update({"device_id": module_data["device"]})
             else:
                 query_dict.update({"device": module_data["device"]})

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -755,11 +755,7 @@ class NetboxModule(object):
         elif parent == "parent_vm_interface" and module_data.get("virtual_machine"):
             if not child:
                 query_dict["name"] = module_data["parent_vm_interface"]
-#            if isinstance(module_data["virtual_machine"], int):
-#                query_dict.update({"virtual_machine": module_data["virtual_machine"]})
-#            else:
-#                query_dict.update({"virtual_machine": module_data["virtual_machine"]})
-#
+
         elif parent == "lag":
             if not child:
                 query_dict["name"] = module_data["lag"]

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -740,7 +740,7 @@ class NetboxModule(object):
             if not child:
                 query_dict["name"] = module_data["parent"]
 
-            if isinstance(module_data["device"], int):
+            if isinstance(module_data.get("device"), int):
                 query_dict.update({"device_id": module_data.get("device")})
             else:
                 query_dict.update({"device": module_data.get("device")})

--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -114,6 +114,11 @@ options:
           - The mode of the interface
         required: false
         type: raw
+      parent:
+        description:
+          - the device's parent interface
+        required: false
+        type: raw
       untagged_vlan:
         description:
           - The untagged VLAN to be assigned to interface
@@ -313,6 +318,7 @@ def main():
                     mgmt_only=dict(required=False, type="bool"),
                     description=dict(required=False, type="str"),
                     mode=dict(required=False, type="raw"),
+                    parent=dict(required=False, type="raw"),
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),

--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -114,7 +114,7 @@ options:
           - The mode of the interface
         required: false
         type: raw
-      parent:
+      parent_interface:
         description:
           - the device's parent interface
         required: false
@@ -318,7 +318,7 @@ def main():
                     mgmt_only=dict(required=False, type="bool"),
                     description=dict(required=False, type="str"),
                     mode=dict(required=False, type="raw"),
-                    parent=dict(required=False, type="raw"),
+                    parent_interface=dict(required=False, type="raw"),
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),

--- a/plugins/modules/netbox_vm_interface.py
+++ b/plugins/modules/netbox_vm_interface.py
@@ -82,9 +82,9 @@ options:
           - The mode of the interface
         required: false
         type: raw
-      parent_interface:
+      parent_vm_interface:
         description:
-          - the interface's parent interface.
+          - the vm interface's parent interface.
         required: false
         type: raw
       untagged_vlan:
@@ -213,7 +213,7 @@ def main():
                     mac_address=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     mode=dict(required=False, type="raw"),
-                    parent_interface=dict(required=False, type="raw"),
+                    parent_vm_interface=dict(required=False, type="raw"),
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),

--- a/plugins/modules/netbox_vm_interface.py
+++ b/plugins/modules/netbox_vm_interface.py
@@ -82,9 +82,9 @@ options:
           - The mode of the interface
         required: false
         type: raw
-      parent:
+      parent_interface:
         description:
-          - the interface's parent.
+          - the interface's parent interface.
         required: false
         type: raw
       untagged_vlan:
@@ -213,7 +213,7 @@ def main():
                     mac_address=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     mode=dict(required=False, type="raw"),
-                    parent=dict(required=False, type="raw"),
+                    parent_interface=dict(required=False, type="raw"),
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),

--- a/plugins/modules/netbox_vm_interface.py
+++ b/plugins/modules/netbox_vm_interface.py
@@ -82,6 +82,11 @@ options:
           - The mode of the interface
         required: false
         type: raw
+      parent:
+        description:
+          - the interface's parent.
+        required: false
+        type: raw
       untagged_vlan:
         description:
           - The untagged VLAN to be assigned to interface
@@ -208,6 +213,7 @@ def main():
                     mac_address=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     mode=dict(required=False, type="raw"),
+                    parent=dict(required=False, type="raw"),
                     untagged_vlan=dict(required=False, type="raw"),
                     tagged_vlans=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),

--- a/tests/integration/targets/v2.11/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_device_interface.yml
@@ -311,3 +311,23 @@
       - test_twelve['interface']['name'] == "GigabitEthernet5"
       - test_twelve['interface']['device'] == 1
       - test_twelve['interface']['mark_connected'] == true
+
+- name: "13 - Create a child virtual device GigabitEthernet5."
+  netbox.netbox.netbox_device_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: Child1
+      type: virtual
+      parent_interface: GigabitEthernet5
+  register: test_thirteen
+
+- name: "13- ASSERT"
+  assert:
+    that:
+      - test_thirteen is changed
+      - test_thirteen['msg'] == "interface Child1 created"
+      - test_thirteen['diff']['before']['state'] == 'absent'
+      - test_thirteen['diff']['after']['state'] == 'present'
+      - test_thirteen['interface']['parent'] == test_twelve['interface']['id']

--- a/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
@@ -165,7 +165,6 @@
     data:
       virtual_machine: "test100-vm"
       name: Child1
-      type: virtual
       parent_interface: "Eth0"
   register: test_six
 

--- a/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
@@ -157,3 +157,24 @@
       - test_five['interface']['tagged_vlans'] == [2, 3]
       - test_five['interface']['tags'][0] == 4
       - test_five['msg'] == "interface Eth0 updated"
+
+- name: "NETBOX_VM_INTERFACE 6: Create a child virtual device Eth0."
+  netbox.netbox.netbox_vm_interface:
+    netbox_url: "http://localhost:32768"
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: "test100-vm"
+      name: Child1
+      type: virtual
+      parent_interface: "Eth0"
+  register: test_six
+
+- name: "NETBOX_VM_INTERFACE 6: ASSERT"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['msg'] == "interface Child1 created"
+      - test_six['diff']['before']['state'] == 'absent'
+      - test_six['diff']['after']['state'] == 'present'
+      - test_six['interface']['parent'] == test_five['interface']['id']
+

--- a/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
@@ -158,22 +158,33 @@
       - test_five['interface']['tags'][0] == 4
       - test_five['msg'] == "interface Eth0 updated"
 
-- name: "NETBOX_VM_INTERFACE 6: Create a child virtual device Eth0."
+- name: "NETBOX_VM_INTERFACE 6: Create a parent interface"
   netbox.netbox.netbox_vm_interface:
-    netbox_url: "http://localhost:32768"
-    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       virtual_machine: "test100-vm"
-      name: Child1
-      parent_interface: "Eth0"
-  register: test_six
+      name: "Eth10"
+    state: present
+  register: test_parent
+
+- name: "NETBOX_VM_INTERFACE 6: Create a child virtual device Eth10."
+  netbox.netbox.netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      virtual_machine: "test100-vm"
+      name: "Child1"
+      parent_interface: "Eth10"
+    state: present
+  register: test_child
 
 - name: "NETBOX_VM_INTERFACE 6: ASSERT"
   assert:
     that:
-      - test_six is changed
-      - test_six['msg'] == "interface Child1 created"
-      - test_six['diff']['before']['state'] == 'absent'
-      - test_six['diff']['after']['state'] == 'present'
-      - test_six['interface']['parent'] == test_five['interface']['id']
+      - test_child is changed
+      - test_child['msg'] == "interface Child1 created"
+      - test_child['diff']['before']['state'] == 'absent'
+      - test_child['diff']['after']['state'] == 'present'
+      - test_child['interface']['parent'] == test_parent['interface']['id']
 

--- a/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_vm_interface.yml
@@ -175,7 +175,7 @@
     data:
       virtual_machine: "test100-vm"
       name: "Child1"
-      parent_interface: "Eth10"
+      parent_vm_interface: "Eth10"
     state: present
   register: test_child
 


### PR DESCRIPTION
This fixes #549 and #507 

This allows the parent of a interface to be assigned.

Both virtual (vm) and real (device)

for real devices, the label is 'parent_interface'.

for vm devices, the label is 'parent_vm_interface'.

This is done this way for several reasons.

1) prevention of a collision with the 'parent' label in other modules.
2) assignment of the correct netbox API.

The parent can only be on the same device/VM. Trying to assign a different interface from a different device will fail.  The child interface also must be a virtual interface on real devices, they already are virtual on VM's.

This has been tested in my environment for several months now.

