### PR TITLE
Fix #562 Change vCPU on Virtual Machine to float

### DIFF
--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -72,7 +72,7 @@ options:
         description:
           - Number of vcpus of the virtual machine
         required: false
-        type: int
+        type: float
       tenant:
         description:
           - The tenant that the virtual machine will be assigned to
@@ -236,7 +236,7 @@ def main():
                     site=dict(required=False, type="raw"),
                     cluster=dict(required=False, type="raw"),
                     virtual_machine_role=dict(required=False, type="raw"),
-                    vcpus=dict(required=False, type="int"),
+                    vcpus=dict(required=False, type="float"),
                     tenant=dict(required=False, type="raw"),
                     platform=dict(required=False, type="raw"),
                     primary_ip4=dict(required=False, type="raw"),

--- a/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
@@ -62,14 +62,14 @@
   assert:
     that:
       - test_three is changed
-      - test_three['diff']['after']['vcpus'] == 8.5
+      - test_three['diff']['after']['vcpus'] == "8.50"
       - test_three['diff']['after']['memory'] == 8
       - test_three['diff']['after']['status'] == "planned"
       - test_three['diff']['after']['role'] == 2
       - test_three['diff']['after']['tags'][0] == 4
       - test_three['virtual_machine']['name'] == "Test VM One"
       - test_three['virtual_machine']['cluster'] == 1
-      - test_three['virtual_machine']['vcpus'] == 8.5
+      - test_three['virtual_machine']['vcpus'] == "8.50"
       - test_three['virtual_machine']['memory'] == 8
       - test_three['virtual_machine']['status'] == "planned"
       - test_three['virtual_machine']['role'] == 2
@@ -91,7 +91,7 @@
       - test_four is changed
       - test_four['virtual_machine']['name'] == "Test VM One"
       - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == 8.5
+      - test_four['virtual_machine']['vcpus'] == "8.50"
       - test_four['virtual_machine']['memory'] == 8
       - test_four['virtual_machine']['status'] == "planned"
       - test_four['virtual_machine']['role'] == 2

--- a/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
@@ -62,14 +62,14 @@
   assert:
     that:
       - test_three is changed
-      - test_three['diff']['after']['vcpus'] == "8.50"
+      - test_three['diff']['after']['vcpus'] == 8.5
       - test_three['diff']['after']['memory'] == 8
       - test_three['diff']['after']['status'] == "planned"
       - test_three['diff']['after']['role'] == 2
       - test_three['diff']['after']['tags'][0] == 4
       - test_three['virtual_machine']['name'] == "Test VM One"
       - test_three['virtual_machine']['cluster'] == 1
-      - test_three['virtual_machine']['vcpus'] == "8.50"
+      - test_three['virtual_machine']['vcpus'] == 8.5
       - test_three['virtual_machine']['memory'] == 8
       - test_three['virtual_machine']['status'] == "planned"
       - test_three['virtual_machine']['role'] == 2
@@ -91,7 +91,7 @@
       - test_four is changed
       - test_four['virtual_machine']['name'] == "Test VM One"
       - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == "8.50"
+      - test_four['virtual_machine']['vcpus'] == 8.5
       - test_four['virtual_machine']['memory'] == 8
       - test_four['virtual_machine']['status'] == "planned"
       - test_four['virtual_machine']['role'] == 2

--- a/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
@@ -49,7 +49,7 @@
     data:
       name: "Test VM One"
       cluster: "Test Cluster"
-      vcpus: 8
+      vcpus: 8.5
       memory: 8
       status: "Planned"
       virtual_machine_role: "Test VM Role"
@@ -62,14 +62,14 @@
   assert:
     that:
       - test_three is changed
-      - test_three['diff']['after']['vcpus'] == 8
+      - test_three['diff']['after']['vcpus'] == 8.5
       - test_three['diff']['after']['memory'] == 8
       - test_three['diff']['after']['status'] == "planned"
       - test_three['diff']['after']['role'] == 2
       - test_three['diff']['after']['tags'][0] == 4
       - test_three['virtual_machine']['name'] == "Test VM One"
       - test_three['virtual_machine']['cluster'] == 1
-      - test_three['virtual_machine']['vcpus'] == 8
+      - test_three['virtual_machine']['vcpus'] == 8.5
       - test_three['virtual_machine']['memory'] == 8
       - test_three['virtual_machine']['status'] == "planned"
       - test_three['virtual_machine']['role'] == 2
@@ -91,7 +91,7 @@
       - test_four is changed
       - test_four['virtual_machine']['name'] == "Test VM One"
       - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == "8.00"
+      - test_four['virtual_machine']['vcpus'] == 8.5
       - test_four['virtual_machine']['memory'] == 8
       - test_four['virtual_machine']['status'] == "planned"
       - test_four['virtual_machine']['role'] == 2

--- a/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v2.11/tasks/netbox_virtual_machine.yml
@@ -91,7 +91,7 @@
       - test_four is changed
       - test_four['virtual_machine']['name'] == "Test VM One"
       - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == 8.5
+      - test_four['virtual_machine']['vcpus'] == "8.50"
       - test_four['virtual_machine']['memory'] == 8
       - test_four['virtual_machine']['status'] == "planned"
       - test_four['virtual_machine']['role'] == 2

--- a/tests/integration/targets/v3.0/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v3.0/tasks/netbox_virtual_machine.yml
@@ -49,7 +49,7 @@
     data:
       name: "Test VM One"
       cluster: "Test Cluster"
-      vcpus: 8
+      vcpus: 8.5
       memory: 8
       status: "Planned"
       virtual_machine_role: "Test VM Role"
@@ -62,7 +62,7 @@
   assert:
     that:
       - test_three is changed
-      - test_three['diff']['after']['vcpus'] == 8
+      - test_three['diff']['after']['vcpus'] == 8.5
       - test_three['diff']['after']['memory'] == 8
       - test_three['diff']['after']['status'] == "planned"
       - test_three['diff']['after']['role'] == 2
@@ -91,7 +91,7 @@
       - test_four is changed
       - test_four['virtual_machine']['name'] == "Test VM One"
       - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == "8.00"
+      - test_four['virtual_machine']['vcpus'] == 8.5
       - test_four['virtual_machine']['memory'] == 8
       - test_four['virtual_machine']['status'] == "planned"
       - test_four['virtual_machine']['role'] == 2


### PR DESCRIPTION
- Change option `vcpu` on module `netbox_virtual_machine` from `int` to `float`
- Adjust `netbox_virtual_machine` test on 2.11 to use fractional vCPU

This change is backwards compatible and corrects behaviour after NetBox 2.11's change of the vCPU attribute to float.