### PR TITLE
Fix integration tests with v3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,9 @@ jobs:
           - python-version: 3.6
             VERSION: "v2.11"
             INTEGRATION_TESTS: "v2.11"
-          #- python-version: 3.6
-          #  VERSION: "v3.0"
-          #  INTEGRATION_TESTS: "v3.0"
+          - python-version: 3.6
+            VERSION: "v3.0"
+            INTEGRATION_TESTS: "v3.0"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,8 +156,8 @@ jobs:
         # Run regression and integration tests
         # Run the inventory test first, in case any of the other tests modify the data.
         run: |
-          ansible-test integration -v --coverage --python ${{ matrix.python-version }} inventory-${{ matrix.INTEGRATION_TESTS }}
-          ansible-test integration -v --coverage --python ${{ matrix.python-version }} regression-${{ matrix.INTEGRATION_TESTS }}
-          ansible-test integration -v --coverage --python ${{ matrix.python-version }} ${{ matrix.INTEGRATION_TESTS }}
+          ansible-test integration -v --color --coverage --python ${{ matrix.python-version }} inventory-${{ matrix.INTEGRATION_TESTS }}
+          ansible-test integration -v --color --coverage --python ${{ matrix.python-version }} regression-${{ matrix.INTEGRATION_TESTS }}
+          ansible-test integration -v --color --coverage --python ${{ matrix.python-version }} ${{ matrix.INTEGRATION_TESTS }}
           ansible-test coverage report --all --omit "tests/*,hacking/*,docs/*" --show-missing
         working-directory: /home/runner/.ansible/collections/ansible_collections/netbox/netbox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           - python-version: 3.8
             VERSION: "v2.11"
             INTEGRATION_TESTS: "v2.11"
-          - python-version: 3.6
+          - python-version: 3.8
             VERSION: "v3.0"
             INTEGRATION_TESTS: "v3.0"
     steps:

--- a/changelogs/fragments/619-v3.0-ci-fixes.yml
+++ b/changelogs/fragments/619-v3.0-ci-fixes.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - netbox.netbox - Fixed integration tests with v3.0

--- a/tests/integration/targets/inventory-v3.0/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-v3.0/files/test-inventory-legacy.json
@@ -63,7 +63,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
-                            "display_name": "Test Nexus One",
                             "id": 4,
                             "name": "Test Nexus One"
                         },
@@ -200,7 +199,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -223,7 +221,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },

--- a/tests/integration/targets/inventory-v3.0/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-v3.0/files/test-inventory-options-flatten.json
@@ -61,7 +61,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
-                            "display_name": "Test Nexus One",
                             "id": 4,
                             "name": "Test Nexus One"
                         },
@@ -122,7 +121,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus Child One",
-                            "display_name": "Test Nexus Child One",
                             "id": 5,
                             "name": "Test Nexus Child One"
                         },
@@ -189,7 +187,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
-                            "display_name": "Test Nexus One",
                             "id": 4,
                             "name": "Test Nexus One"
                         },
@@ -336,7 +333,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -397,7 +393,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -466,7 +461,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -489,7 +483,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },

--- a/tests/integration/targets/inventory-v3.0/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-v3.0/files/test-inventory-options.json
@@ -28,7 +28,6 @@
             "R1-Device": {
                 "custom_fields": {},
                 "device_type": "cisco-test",
-                "display": "R1-Device",
                 "is_virtual": false,
                 "locations": [],
                 "manufacturer": "cisco",
@@ -60,7 +59,6 @@
             "TestDeviceR1": {
                 "custom_fields": {},
                 "device_type": "cisco-test",
-                "display": "TestDeviceR1",
                 "is_virtual": false,
                 "locations": [
                     "test-rack-group",
@@ -85,7 +83,6 @@
                 "ansible_host": "nexus.example.com",
                 "custom_fields": {},
                 "device_type": "nexus-parent",
-                "display": "Test Nexus One",
                 "dns_name": "nexus.example.com",
                 "is_virtual": false,
                 "locations": [
@@ -109,7 +106,6 @@
             "test100": {
                 "custom_fields": {},
                 "device_type": "cisco-test",
-                "display": "test100",
                 "is_virtual": false,
                 "local_context_data": {
                     "ntp_servers": [

--- a/tests/integration/targets/inventory-v3.0/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-v3.0/files/test-inventory-options.yml
@@ -49,7 +49,6 @@ vm_query_filters:
 # https://docs.ansible.com/ansible/latest/plugins/inventory/constructed.html
 
 compose:
-  display: display_name
   rack_id: rack.id
   ntp_servers: config_context.ntp_servers
 

--- a/tests/integration/targets/inventory-v3.0/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-v3.0/files/test-inventory-plurals.json
@@ -63,7 +63,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
-                            "display_name": "Test Nexus One",
                             "id": 4,
                             "name": "Test Nexus One"
                         },
@@ -124,7 +123,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus Child One",
-                            "display_name": "Test Nexus Child One",
                             "id": 5,
                             "name": "Test Nexus Child One"
                         },
@@ -195,7 +193,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
-                            "display_name": "Test Nexus One",
                             "id": 4,
                             "name": "Test Nexus One"
                         },
@@ -381,7 +378,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -442,7 +438,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -516,7 +511,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -539,7 +533,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },

--- a/tests/integration/targets/inventory-v3.0/files/test-inventory.json
+++ b/tests/integration/targets/inventory-v3.0/files/test-inventory.json
@@ -41,7 +41,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
-                            "display_name": "Test Nexus One",
                             "id": 4,
                             "name": "Test Nexus One"
                         },
@@ -102,7 +101,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus Child One",
-                            "display_name": "Test Nexus Child One",
                             "id": 5,
                             "name": "Test Nexus Child One"
                         },
@@ -169,7 +167,6 @@
                         "description": "",
                         "device": {
                             "display": "Test Nexus One",
-                            "display_name": "Test Nexus One",
                             "id": 4,
                             "name": "Test Nexus One"
                         },
@@ -326,7 +323,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -387,7 +383,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -458,7 +453,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },
@@ -481,7 +475,6 @@
                         "description": "",
                         "device": {
                             "display": "test100",
-                            "display_name": "test100",
                             "id": 1,
                             "name": "test100"
                         },

--- a/tests/integration/targets/v3.0/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v3.0/tasks/netbox_lookup.yml
@@ -12,13 +12,13 @@
 
 - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   assert:
-    that: "{{ query_result|community.general.json_query('[?value.display_name==`Wibble`]')|count }} == 0"
+    that: "{{ query_result|community.general.json_query('[?value.display==`Wibble`]')|count }} == 0"
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
 - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   assert:
-    that: "{{ query_result|community.general.json_query('[?value.display_name==`TestDeviceR1`]')|count }} == 1"
+    that: "{{ query_result|community.general.json_query('[?value.display==`TestDeviceR1`]')|count }} == 1"
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
@@ -58,21 +58,21 @@
 
 - name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
   assert:
-    that: "{{ query_result|community.general.json_query('[?value.display_name==`L2`]')|count }} == 1"
+    that: "{{ query_result|community.general.json_query('[?value.display==`L2`]')|count }} == 1"
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') }}"
 
 - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   assert:
-    that: "{{ query_result|community.general.json_query('[?display_name==`L2`]')|count }} == 1"
+    that: "{{ query_result|community.general.json_query('[?display==`L2`]')|count }} == 1"
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567', raw_data=True) }}"
 
 - name: "NETBOX_LOOKUP 9: Device query specifying multiple sites, Make sure L1 and L2 are in the results"
   assert:
     that:
-      - "'L1' in {{ query_result |community.general.json_query('[*].display_name') }}"
-      - "'L2' in {{ query_result |community.general.json_query('[*].display_name') }}"
+      - "'L1' in {{ query_result |community.general.json_query('[*].display') }}"
+      - "'L2' in {{ query_result |community.general.json_query('[*].display') }}"
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch site=test-site site=test-site2', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567', raw_data=True) }}"
 

--- a/tests/integration/targets/v3.0/tasks/netbox_site.yml
+++ b/tests/integration/targets/v3.0/tasks/netbox_site.yml
@@ -142,6 +142,8 @@
   register: test_results
 
 - name: "NETBOX_SITE_IDEM: (ASSERT) Idempotency - Duplicate device site with all parameters"
+  # TODO fix idempotence with latitude and longitude
+  when: false
   assert:
     that:
       - test_results is not changed

--- a/tests/integration/targets/v3.0/tasks/netbox_site.yml
+++ b/tests/integration/targets/v3.0/tasks/netbox_site.yml
@@ -142,8 +142,6 @@
   register: test_results
 
 - name: "NETBOX_SITE_IDEM: (ASSERT) Idempotency - Duplicate device site with all parameters"
-  # TODO fix idempotence with latitude and longitude
-  when: false
   assert:
     that:
       - test_results is not changed

--- a/tests/integration/targets/v3.0/tasks/netbox_site.yml
+++ b/tests/integration/targets/v3.0/tasks/netbox_site.yml
@@ -107,8 +107,8 @@
       - test_four['site']['description'] == "This is a test description"
       - test_four['site']['physical_address'] == "Hollywood, CA, 90210"
       - test_four['site']['shipping_address'] == "Hollywood, CA, 90210"
-      - test_four['site']['latitude'] == "22.169141"
-      - test_four['site']['longitude'] == "-100.994041"
+      - test_four['site']['latitude'] == 22.169141
+      - test_four['site']['longitude'] == -100.994041
       - test_four['site']['contact_name'] == "Jenny"
       - test_four['site']['contact_phone'] == "867-5309"
       - test_four['site']['contact_email'] == "jenny@changednumber.com"
@@ -157,8 +157,8 @@
       - test_results['site']['description'] == "This is a test description"
       - test_results['site']['physical_address'] == "Hollywood, CA, 90210"
       - test_results['site']['shipping_address'] == "Hollywood, CA, 90210"
-      - test_results['site']['latitude'] == "22.169141"
-      - test_results['site']['longitude'] == "-100.994041"
+      - test_results['site']['latitude'] == 22.169141
+      - test_results['site']['longitude'] == -100.994041
       - test_results['site']['contact_name'] == "Jenny"
       - test_results['site']['contact_phone'] == "867-5309"
       - test_results['site']['contact_email'] == "jenny@changednumber.com"

--- a/tests/integration/targets/v3.0/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v3.0/tasks/netbox_virtual_machine.yml
@@ -69,7 +69,7 @@
       - test_three['diff']['after']['tags'][0] == 4
       - test_three['virtual_machine']['name'] == "Test VM One"
       - test_three['virtual_machine']['cluster'] == 1
-      - test_three['virtual_machine']['vcpus'] == 8
+      - test_three['virtual_machine']['vcpus'] == 8.5
       - test_three['virtual_machine']['memory'] == 8
       - test_three['virtual_machine']['status'] == "planned"
       - test_three['virtual_machine']['role'] == 2


### PR DESCRIPTION
Fixes #590 

This PR updates the integration tests to work with v3.0

I had to disable the `netbox_site` idempotency test because of #618. Therefore, I'm creating this PR as a draft.

Also, we should consider running integration tests with Python 3.8 or higher as Ansible 2.12 will require it.