### PR TITLE
Enable faster lookups on Netbox version < 3.0.6

### DIFF
--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -160,14 +160,28 @@ class NetboxDcimModule(NetboxModule):
                     )
                 ]
             else:
-                cables = [
-                    cable
-                    for cable in nb_endpoint.all()
-                    if cable.termination_a_type == data["termination_a_type"]
-                    and cable.termination_a_id == data["termination_a_id"]
-                    and cable.termination_b_type == data["termination_b_type"]
-                    and cable.termination_b_id == data["termination_b_id"]
-                ]
+                cables = []
+
+                # Attempt to find the exact cable via the interface
+                # relationship
+                interface_a = self.nb.dcim.interfaces.get(
+                    data["termination_a_id"])
+                interface_b = self.nb.dcim.interfaces.get(
+                    data["termination_b_id"])
+                if (interface_a.cable and interface_b.cable
+                    and interface_a.cable.id == interface_b.cable.id):
+                    cables = [self.nb.dcim.cables.get(interface_a.cable.id)]
+                else:
+                    # Fall back to the old behavior of scanning the entire
+                    # database. WARNING: this does not scale
+                    cables = [
+                        cable
+                        for cable in nb_endpoint.all()
+                        if cable.termination_a_type == data["termination_a_type"]
+                        and cable.termination_a_id == data["termination_a_id"]
+                        and cable.termination_b_type == data["termination_b_type"]
+                        and cable.termination_b_id == data["termination_b_id"]
+                    ]
             if len(cables) == 0:
                 self.nb_object = None
             elif len(cables) == 1:

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -164,12 +164,13 @@ class NetboxDcimModule(NetboxModule):
 
                 # Attempt to find the exact cable via the interface
                 # relationship
-                interface_a = self.nb.dcim.interfaces.get(
-                    data["termination_a_id"])
-                interface_b = self.nb.dcim.interfaces.get(
-                    data["termination_b_id"])
-                if (interface_a.cable and interface_b.cable
-                    and interface_a.cable.id == interface_b.cable.id):
+                interface_a = self.nb.dcim.interfaces.get(data["termination_a_id"])
+                interface_b = self.nb.dcim.interfaces.get(data["termination_b_id"])
+                if (
+                    interface_a.cable
+                    and interface_b.cable
+                    and interface_a.cable.id == interface_b.cable.id
+                ):
                     cables = [self.nb.dcim.cables.get(interface_a.cable.id)]
                 else:
                     # Fall back to the old behavior of scanning the entire

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -160,8 +160,6 @@ class NetboxDcimModule(NetboxModule):
                     )
                 ]
             else:
-                cables = []
-
                 # Attempt to find the exact cable via the interface
                 # relationship
                 interface_a = self.nb.dcim.interfaces.get(data["termination_a_id"])
@@ -173,16 +171,7 @@ class NetboxDcimModule(NetboxModule):
                 ):
                     cables = [self.nb.dcim.cables.get(interface_a.cable.id)]
                 else:
-                    # Fall back to the old behavior of scanning the entire
-                    # database. WARNING: this does not scale
-                    cables = [
-                        cable
-                        for cable in nb_endpoint.all()
-                        if cable.termination_a_type == data["termination_a_type"]
-                        and cable.termination_a_id == data["termination_a_id"]
-                        and cable.termination_b_type == data["termination_b_type"]
-                        and cable.termination_b_id == data["termination_b_id"]
-                    ]
+                    cables = []
             if len(cables) == 0:
                 self.nb_object = None
             elif len(cables) == 1:


### PR DESCRIPTION
This attempts to fix the performance when using NetBox versions < 3.0.6 and is a continuation of the work done in #608