### PR TITLE
Inventory module site and prefix data extended

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -847,7 +847,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 # Used by refresh_prefixes()
 
         def get_region_for_site(site):
-            # Will fail if site does not have a region defined in Netbox
+            # Will fail if site does not have a region defined in NetBox
             try:
                 return (site["id"], site["region"]["id"])
             except Exception:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -456,26 +456,36 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Locations were added in 2.11 replacing rack-groups.
         if self.api_version >= version.parse("2.11"):
             extractors.update(
-                {"location": self.extract_location,}
+                {
+                    "location": self.extract_location,
+                }
             )
         else:
             extractors.update(
-                {"rack_group": self.extract_rack_group,}
+                {
+                    "rack_group": self.extract_rack_group,
+                }
             )
 
         if self.services:
             extractors.update(
-                {"services": self.extract_services,}
+                {
+                    "services": self.extract_services,
+                }
             )
 
         if self.interfaces:
             extractors.update(
-                {"interfaces": self.extract_interfaces,}
+                {
+                    "interfaces": self.extract_interfaces,
+                }
             )
 
         if self.interfaces or self.dns_name or self.ansible_host_dns_name:
             extractors.update(
-                {"dns_name": self.extract_dns_name,}
+                {
+                    "dns_name": self.extract_dns_name,
+                }
             )
 
         return extractors
@@ -602,7 +612,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def extract_site(self, host):
         try:
             site = self.sites_lookup[host["site"]["id"]]
-            if self.prefixes:  # If prefixes have been pulled, attach prefix to its assigned site
+            if (
+                self.prefixes
+            ):  # If prefixes have been pulled, attach prefix to its assigned site
                 prefix_id = self.prefixes_sites_lookup[site["id"]]
                 prefix = self.prefixes_lookup[prefix_id]
                 site["prefix"] = prefix
@@ -859,7 +871,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     # Note: depends on the result of refresh_sites_lookup for self.sites_with_prefixes
     def refresh_prefixes(self):
         # Pull prefixes with "active" status only
-        url = (self.api_endpoint + "/api/ipam/prefixes?status=active")
+        url = self.api_endpoint + "/api/ipam/prefixes?status=active"
 
         if self.fetch_all:
             prefixes = self.get_resource_list(url)
@@ -1487,7 +1499,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Map site id to transformed group names
         self.site_group_names = dict()
 
-        for site_id, site_name in self.sites_lookup_slug.items():  # "Slug" only. Data not used even if pulled
+        for (
+            site_id,
+            site_name,
+        ) in (
+            self.sites_lookup_slug.items()
+        ):  # "Slug" only. Data not used even if pulled
             site_group_name = self.generate_group_name(
                 self._pluralize_group_by("site"), site_name
             )
@@ -1697,7 +1714,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             elif getattr(self, "site_group_names", None) and host.get("site"):
                 # Add host to site group when host is NOT assigned to a location
                 self.inventory.add_host(
-                    group=self.site_group_names[host["site"]["id"]], host=hostname,
+                    group=self.site_group_names[host["site"]["id"]],
+                    host=hostname,
                 )
 
     def parse(self, inventory, loader, path, cache=True):

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1489,9 +1489,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.site_group_names = dict()
 
         for (site_id, site_name) in (self.sites_lookup_slug.items()):  # "Slug" only. Data not used for grouping
-            site_group_name = self.generate_group_name(self._pluralize_group_by("site"), site_name)
+            site_group_name = self.generate_group_name(
+                self._pluralize_group_by("site"), site_name
+            )
             # Add the site group to get its transformed name
-            site_transformed_group_name = self.inventory.add_group(group=site_group_name)
+            site_transformed_group_name = self.inventory.add_group(
+                group=site_group_name
+            )
             self.site_group_names[site_id] = site_transformed_group_name
 
     def _add_region_groups(self):

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -456,36 +456,26 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Locations were added in 2.11 replacing rack-groups.
         if self.api_version >= version.parse("2.11"):
             extractors.update(
-                {
-                    "location": self.extract_location,
-                }
+                {"location": self.extract_location,}
             )
         else:
             extractors.update(
-                {
-                    "rack_group": self.extract_rack_group,
-                }
+                {"rack_group": self.extract_rack_group,}
             )
 
         if self.services:
             extractors.update(
-                {
-                    "services": self.extract_services,
-                }
+                {"services": self.extract_services,}
             )
 
         if self.interfaces:
             extractors.update(
-                {
-                    "interfaces": self.extract_interfaces,
-                }
+                {"interfaces": self.extract_interfaces,}
             )
 
         if self.interfaces or self.dns_name or self.ansible_host_dns_name:
             extractors.update(
-                {
-                    "dns_name": self.extract_dns_name,
-                }
+                {"dns_name": self.extract_dns_name,}
             )
 
         return extractors
@@ -1713,8 +1703,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             elif getattr(self, "site_group_names", None) and host.get("site"):
                 # Add host to site group when host is NOT assigned to a location
                 self.inventory.add_host(
-                    group=self.site_group_names[host["site"]["id"]],
-                    host=hostname,
+                    group=self.site_group_names[host["site"]["id"]], host=hostname,
                 )
 
     def parse(self, inventory, loader, path, cache=True):

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -456,26 +456,36 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Locations were added in 2.11 replacing rack-groups.
         if self.api_version >= version.parse("2.11"):
             extractors.update(
-                {"location": self.extract_location,}
+                {
+                    "location": self.extract_location,
+                }
             )
         else:
             extractors.update(
-                {"rack_group": self.extract_rack_group,}
+                {
+                    "rack_group": self.extract_rack_group,
+                }
             )
 
         if self.services:
             extractors.update(
-                {"services": self.extract_services,}
+                {
+                    "services": self.extract_services,
+                }
             )
 
         if self.interfaces:
             extractors.update(
-                {"interfaces": self.extract_interfaces,}
+                {
+                    "interfaces": self.extract_interfaces,
+                }
             )
 
         if self.interfaces or self.dns_name or self.ansible_host_dns_name:
             extractors.update(
-                {"dns_name": self.extract_dns_name,}
+                {
+                    "dns_name": self.extract_dns_name,
+                }
             )
 
         return extractors
@@ -602,7 +612,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def extract_site(self, host):
         try:
             site = self.sites_lookup[host["site"]["id"]]
-            if self.prefixes:  # If prefixes have been pulled, attach prefix to its assigned site
+            if (
+                self.prefixes
+            ):  # If prefixes have been pulled, attach prefix to its assigned site
                 prefix_id = self.prefixes_sites_lookup[site["id"]]
                 prefix = self.prefixes_lookup[prefix_id]
                 site["prefix"] = prefix
@@ -1488,7 +1500,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Map site id to transformed group names
         self.site_group_names = dict()
 
-        for (site_id, site_name) in (self.sites_lookup_slug.items()):  # "Slug" only. Data not used for grouping
+        for (
+            site_id,
+            site_name,
+        ) in self.sites_lookup_slug.items():  # "Slug" only. Data not used for grouping
             site_group_name = self.generate_group_name(
                 self._pluralize_group_by("site"), site_name
             )
@@ -1698,7 +1713,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             elif getattr(self, "site_group_names", None) and host.get("site"):
                 # Add host to site group when host is NOT assigned to a location
                 self.inventory.add_host(
-                    group=self.site_group_names[host["site"]["id"]], host=hostname,
+                    group=self.site_group_names[host["site"]["id"]],
+                    host=hostname,
                 )
 
     def parse(self, inventory, loader, path, cache=True):

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -97,7 +97,6 @@ DOCUMENTATION = """
                 - If True, it adds the device or virtual machine prefixes to hostvars nested under "site".
             default: False
             type: boolean
-            version_added: "0.1.7"
         services:
             description:
                 - If True, it adds the device or virtual machine services information in host vars.
@@ -106,8 +105,8 @@ DOCUMENTATION = """
             version_added: "0.2.0"
         fetch_all:
             description:
-                - By default, fetching interfaces and services will get all of the contents of NetBox regardless of query_filters applied to devices and VMs.
-                - When set to False, separate requests will be made fetching interfaces, services, and IP addresses for each device_id and virtual_machine_id.
+                - By default, fetching interfaces, services and prefixes will get all of the contents of NetBox regardless of query_filters applied to devices and VMs.
+                - When set to False, separate requests will be made fetching only interfaces, services, IP Addresses and Prefixes that are actually assigned to the filtered device set.
                 - If you are using the various query_filters options to reduce the number of devices, you may find querying Netbox faster with fetch_all set to False.
                 - For efficiency, when False, these requests will be batched, for example /api/dcim/interfaces?limit=0&device_id=1&device_id=2&device_id=3
                 - These GET request URIs can become quite large for a large number of devices. If you run into HTTP 414 errors, you can adjust the max_uri_length option to suit your web server.

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -456,36 +456,26 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Locations were added in 2.11 replacing rack-groups.
         if self.api_version >= version.parse("2.11"):
             extractors.update(
-                {
-                    "location": self.extract_location,
-                }
+                {"location": self.extract_location,}
             )
         else:
             extractors.update(
-                {
-                    "rack_group": self.extract_rack_group,
-                }
+                {"rack_group": self.extract_rack_group,}
             )
 
         if self.services:
             extractors.update(
-                {
-                    "services": self.extract_services,
-                }
+                {"services": self.extract_services,}
             )
 
         if self.interfaces:
             extractors.update(
-                {
-                    "interfaces": self.extract_interfaces,
-                }
+                {"interfaces": self.extract_interfaces,}
             )
 
         if self.interfaces or self.dns_name or self.ansible_host_dns_name:
             extractors.update(
-                {
-                    "dns_name": self.extract_dns_name,
-                }
+                {"dns_name": self.extract_dns_name,}
             )
 
         return extractors
@@ -612,9 +602,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def extract_site(self, host):
         try:
             site = self.sites_lookup[host["site"]["id"]]
-            if (
-                self.prefixes
-            ):  # If prefixes have been pulled, attach prefix to its assigned site
+            if self.prefixes:  # If prefixes have been pulled, attach prefix to its assigned site
                 prefix_id = self.prefixes_sites_lookup[site["id"]]
                 prefix = self.prefixes_lookup[prefix_id]
                 site["prefix"] = prefix
@@ -870,8 +858,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     # Note: depends on the result of refresh_sites_lookup for self.sites_with_prefixes
     def refresh_prefixes(self):
-        # Pull prefixes with "active" status only
-        url = self.api_endpoint + "/api/ipam/prefixes?status=active"
+        # Pull all prefixes defined in NetBox
+        url = self.api_endpoint + "/api/ipam/prefixes"
 
         if self.fetch_all:
             prefixes = self.get_resource_list(url)
@@ -884,6 +872,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.prefixes_sites_lookup = defaultdict(dict)
         self.prefixes_lookup = defaultdict(dict)
 
+        # We are only concerned with Prefixes that have actually been assigned to sites
         for prefix in prefixes:
             if prefix.get("site"):
                 prefix_id = prefix["id"]
@@ -1499,19 +1488,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Map site id to transformed group names
         self.site_group_names = dict()
 
-        for (
-            site_id,
-            site_name,
-        ) in (
-            self.sites_lookup_slug.items()
-        ):  # "Slug" only. Data not used even if pulled
-            site_group_name = self.generate_group_name(
-                self._pluralize_group_by("site"), site_name
-            )
+        for (site_id, site_name) in (self.sites_lookup_slug.items()):  # "Slug" only. Data not used for grouping
+            site_group_name = self.generate_group_name(self._pluralize_group_by("site"), site_name)
             # Add the site group to get its transformed name
-            site_transformed_group_name = self.inventory.add_group(
-                group=site_group_name
-            )
+            site_transformed_group_name = self.inventory.add_group(group=site_group_name)
             self.site_group_names[site_id] = site_transformed_group_name
 
     def _add_region_groups(self):
@@ -1714,8 +1694,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             elif getattr(self, "site_group_names", None) and host.get("site"):
                 # Add host to site group when host is NOT assigned to a location
                 self.inventory.add_host(
-                    group=self.site_group_names[host["site"]["id"]],
-                    host=hostname,
+                    group=self.site_group_names[host["site"]["id"]], host=hostname,
                 )
 
     def parse(self, inventory, loader, path, cache=True):


### PR DESCRIPTION
This PR satisfies **(Issue #640)** without causing any changes to default functionality.

Both the extension of Site Data and Prefix Data are enabled by additional parameters passed to the module.
`site_data: (boolean)`
`prefixes: (boolean)`
These changes follow the same methodology as the interfaces option.

No changes in the default behavior of the module in order to guarantee legacy applications will continue working as intended.

The site_data parameter will cause the entire data structure returned by the /api/dcim/sites API call to be captured and inserted into hostvars appropriately for each device in inventory, instead of just the slug that is collected currently.

The prefixes option extends this section of the hostvars further by nesting the datastructure of the prefix assigned to the site as well. This is done by a calling an additional endpoint /api/ipam/prefixes. 
Current optimizations are maintained with the "fetch_all" option.
Only ACTIVE prefixes, that are assigned to a site are pulled; and only for the sites that have at least one queried device assigned to them.

