### PR TITLE
Replace FileNotFoundError by OSError to stay compatible with Python 2

### DIFF
--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -380,7 +380,7 @@ class LookupModule(LookupBase):
                 private_key_file=netbox_private_key_file,
             )
             netbox.http_session = session
-        except FileNotFoundError:
+        except OSError:
             raise AnsibleError(
                 "%s cannot be found. Please make sure file exists."
                 % netbox_private_key_file


### PR DESCRIPTION
fixes #661

This still does not provide a sensible error message for a missing API endpoint as outlined in the steps to reproduce #661, but at least it does no longer try to raise an exception not available on Python 2.