### PR TITLE
Add check for prefix_count for older NetBox versions

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -876,7 +876,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.sites_with_prefixes = set()
 
         for site in sites:
-            if site["prefix_count"] > 0:
+            if site["prefix_count"] and site["prefix_count"] > 0:
                 self.sites_with_prefixes.add(site["slug"])
                 # Used by refresh_prefixes()
 


### PR DESCRIPTION
Fixes: #694 

In older NetBox versions the prefix_count attributes on /api/dcim/sites/<site> is null, not 0 as with later versions. Make sure the check is expanded to check that the prefix_count is not None.