### PR TITLE
695 inventory item documentation

### DIFF
--- a/plugins/modules/netbox_inventory_item.py
+++ b/plugins/modules/netbox_inventory_item.py
@@ -125,6 +125,17 @@ EXAMPLES = r"""
           asset_tag: "1234"
           description: "New SFP"
         state: present
+        
+    - name: Create inventory item with parent
+      netbox_inventory_item:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          parent_inventory_item:
+            name: "Line Card 1"
+            device: test100
+          name: "10G-SFP+"
+          device: test100
 
     - name: Delete inventory item within netbox
       netbox_inventory_item:

--- a/plugins/modules/netbox_inventory_item.py
+++ b/plugins/modules/netbox_inventory_item.py
@@ -136,6 +136,7 @@ EXAMPLES = r"""
             device: test100
           name: "10G-SFP+"
           device: test100
+        state: present
 
     - name: Delete inventory item within netbox
       netbox_inventory_item:


### PR DESCRIPTION
Fixes: #695 

Add an example of using parent_inventory_item in netbox_inventory_item.

If your parent inventory item is unique you can just use the name in parent_inventory_item:. If your inventory item is not unique (as I suspect is the case in most environments) you can use 
```
parent_inventory_item:
  name: inventory item name
  device: device name
```