### PR TITLE
#703 Handle "Failed to establish connection to NetBox" on older NetBox versions

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -591,7 +591,11 @@ class NetboxModule(object):
             self.nb = nb_client
             try:
                 self.version = self.nb.version
-                self.full_version = self.nb.status().get("netbox-version")
+                try:
+                    self.full_version = nb.status().get("netbox-version")
+                except Exception:
+                    # For NetBox versions without /api/status endpoint
+                    self.full_version = f"{self.version}.0"
             except AttributeError:
                 self.module.fail_json(msg="Must have pynetbox >=4.1.0")
 
@@ -640,7 +644,11 @@ class NetboxModule(object):
             nb.http_session = session
             try:
                 self.version = nb.version
-                self.full_version = nb.status().get("netbox-version")
+                try:
+                    self.full_version = nb.status().get("netbox-version")
+                except Exception:
+                    # For NetBox versions without /api/status endpoint
+                    self.full_version = f"{self.version}.0"
             except AttributeError:
                 self.module.fail_json(msg="Must have pynetbox >=4.1.0")
             except Exception:

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -592,7 +592,7 @@ class NetboxModule(object):
             try:
                 self.version = self.nb.version
                 try:
-                    self.full_version = nb.status().get("netbox-version")
+                    self.full_version = self.nb.status().get("netbox-version")
                 except Exception:
                     # For NetBox versions without /api/status endpoint
                     self.full_version = f"{self.version}.0"


### PR DESCRIPTION
Fixes: #703 

NetBox versions without the API endpoint /api/status currently fails because we extract the full_version variable from it. This fix will try to get the full_version from the endpoint, and upon failure construct the full_version using the short version (2.9) and add a .0 (so 2.9 will be 2.9.0). The full_version variable is used in some checks where functionality changed mid-NetBox version. 