### PR TITLE
Ensure netbox_service selects the right IP address

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -383,7 +383,9 @@ ALLOWED_QUERY_PARAMS = {
     "inventory_item": set(["name", "device"]),
     "ip_address": set(["address", "vrf", "device", "interface", "assigned_object"]),
     "ip_addresses": set(["address", "vrf", "device", "interface", "assigned_object"]),
-    "ipaddresses": set(["address", "vrf", "device", "interface", "assigned_object", "virtual_machine"]),
+    "ipaddresses": set(
+        ["address", "vrf", "device", "interface", "assigned_object", "virtual_machine"]
+    ),
     "lag": set(["name"]),
     "location": set(["slug"]),
     "manufacturer": set(["slug"]),

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -383,7 +383,7 @@ ALLOWED_QUERY_PARAMS = {
     "inventory_item": set(["name", "device"]),
     "ip_address": set(["address", "vrf", "device", "interface", "assigned_object"]),
     "ip_addresses": set(["address", "vrf", "device", "interface", "assigned_object"]),
-    "ipaddresses": set(["address", "vrf", "device", "interface", "assigned_object"]),
+    "ipaddresses": set(["address", "vrf", "device", "interface", "assigned_object", "virtual_machine"]),
     "lag": set(["name"]),
     "location": set(["slug"]),
     "manufacturer": set(["slug"]),


### PR DESCRIPTION
## Fixes #470 

## New Behaviour

Allow the filtering of `ipaddresses` in `netbox_service` to use `virtual_machine` as query params. Example:

```
netbox.netbox.netbox_service:
  data:
    virtual_machine: VM One
    port: 443
    protocol: tcp
    name: https
    ipaddresses:
      - address: 127.0.0.1/8
        virtual_machine: VM One
```

## Contrast to Current Behavior

Current functionality does not allow `virtual_machine` as a query param.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
