### PR TITLE
Fix #574 VLAN group returning multiple results

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -452,7 +452,7 @@ ALLOWED_QUERY_PARAMS = {
     "virtual_machine": set(["name", "cluster"]),
     "vm_bridge": set(["name"]),
     "vlan": set(["group", "name", "site", "tenant", "vid", "vlan_group"]),
-    "vlan_group": set(["slug", "site", "scope"]),
+    "vlan_group": set(["name", "slug", "site", "scope"]),
     "vrf": set(["name", "tenant"]),
     "webhook": set(["name"]),
     "wireless_lan": set(["ssid"]),

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -853,7 +853,11 @@ class NetboxModule(object):
                     query_id = self._get_query_param_id(match, child)
                 else:
                     query_id = self._get_query_param_id(match, module_data)
-                query_dict.update({match + "_id": query_id})
+
+                if parent == "vlan_group" and match == "site":
+                    query_dict.update({match: query_id})
+                else:
+                    query_dict.update({match + "_id": query_id})
             else:
                 if child:
                     value = child.get(match)

--- a/tests/unit/module_utils/test_data/build_query_params_child/data.json
+++ b/tests/unit/module_utils/test_data/build_query_params_child/data.json
@@ -176,6 +176,7 @@
             "site": "Test Site"
         },
         "expected": {
+            "name": "Test VLAN Group",
             "slug": "test-vlan-group",
             "site_id": 1
         }

--- a/tests/unit/module_utils/test_data/build_query_params_child/data.json
+++ b/tests/unit/module_utils/test_data/build_query_params_child/data.json
@@ -178,7 +178,7 @@
         "expected": {
             "name": "Test VLAN Group",
             "slug": "test-vlan-group",
-            "site_id": 1
+            "site": 1
         }
     },
     {


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Fixes #574 

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

Tweak the filtering parameters when filtering on VLAN groups. 
Previously you could define a VLAN an associate it to a VLAN group by doing this:

```
netbox_vlan:
  data:
    vid: 10
    name: VLAN 10
    vlan_group: My VLAN Group
```

It would do a call to `/api/vlan-groups/?slug=my-vlan-group`. This did not work when you have multiple VLANs with the same slug. So you'd try:

```
netbox_vlan:
  data:
    vid: 10
    name: VLAN 10
    vlan_group: 
      slug: My VLAN Group
      site: Site No 3
```

And this would do a call to `/api/vlan-groups/?slug=my-vlan-group&site_id=11`. But the VLAN group filtering is using `?site=11` to filter, so this would again return multiple results. To remediate this we now check if we're filtering a VLAN group, and if we are, we omit the `_id` on the query parameter. 

In addition, I have added `name` as a valid query parameter.

## Changes to the Documentation

None

## Double Check
* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
