### PR TITLE
Multiple prefix per site - BUG #732

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -648,10 +648,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             site = self.sites_lookup[host["site"]["id"]]
             if (
                 self.prefixes
-            ):  # If prefixes have been pulled, attach prefix to its assigned site
-                prefix_id = self.prefixes_sites_lookup[site["id"]]
-                prefix = self.prefixes_lookup[prefix_id]
-                site["prefix"] = prefix
+            ):  # If prefixes have been pulled, attach prefix list to its assigned site
+                prefixes = self.prefixes_sites_lookup[site["id"]]
+                site["prefixes"] = prefixes
             return self._pluralize(site)
         except Exception:
             return
@@ -915,16 +914,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 query_key="site",
                 query_values=list(self.sites_with_prefixes),
             )
-        self.prefixes_sites_lookup = defaultdict(dict)
-        self.prefixes_lookup = defaultdict(dict)
+        self.prefixes_sites_lookup = defaultdict(list)
 
         # We are only concerned with Prefixes that have actually been assigned to sites
         for prefix in prefixes:
             if prefix.get("site"):
-                prefix_id = prefix["id"]
-                site_id = prefix["site"]["id"]
-                self.prefixes_lookup[prefix_id] = prefix
-                self.prefixes_sites_lookup[site_id] = prefix_id
+                self.prefixes_sites_lookup[prefix['site']['id']].append(prefix)
             # Remove "site" attribute, as it's redundant when prefixes are assigned to site
             del prefix["site"]
 

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -919,7 +919,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # We are only concerned with Prefixes that have actually been assigned to sites
         for prefix in prefixes:
             if prefix.get("site"):
-                self.prefixes_sites_lookup[prefix['site']['id']].append(prefix)
+                self.prefixes_sites_lookup[prefix["site"]["id"]].append(prefix)
             # Remove "site" attribute, as it's redundant when prefixes are assigned to site
             del prefix["site"]
 


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue


<!--
 Issue #732 
-->

## New Behavior

<!--
Fixes inventory module to correctly pull a list() of multiple prefixes assigned to each site
-->

...

## Contrast to Current Behavior

<!--
Existing module will insert only the last prefix returned from the API. When multiple prefixes are assigned to a site, only one is properly pulled into inventory. (due to data being overwritten within a certain for loop) Currently the single prefix will be inserted as a dictionary into hostvars, but new behavior will ALWAYS produce a list regardless of the number of prefixes assigned.
-->

...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
This is required in order to provide the user with the full dataset they are expecting to see from their Netbox inventory.

- What are the drawbacks of this change?
  Is is possible that current users' workflows may be broken if they have taken advantage of the prefix data as it has been presented since PR#646.

- Is it backwards-compatible?
 This has the potential to break a users playbook that explicitly reference the nested prefix data in a way that expects to see a single dictionary for a site's single prefix.

- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

None

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Inventory module now properly includes the full list of prefixes assigned to a site.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ X ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ X ] I have explained my PR according to the information in the comments or in a linked issue.
* [ X ] My PR targets the `devel` branch.
