### PR TITLE
Fixes #752 - Add meta information for EE

### DIFF
--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,5 @@
+---
+version: 1
+
+dependencies:
+  python: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pynetbox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pynetbox
+packages


### PR DESCRIPTION
## Fixes #752 

## New Behavior
```
(builder) ➜  custom-awx-ee git:(main) ✗ ansible-builder introspect /Users/rodvand/collections/
# Dependency data for /Users/rodvand/collections/
---
python:
  netbox.netbox:
  - pynetbox
  - packages
system: {}
```

## Contrast to Current Behavior
```
(builder) ➜  custom-awx-ee git:(main) ✗ ansible-builder introspect /Users/rodvand/collections/
# Dependency data for /Users/rodvand/collections/
---
python: {}
system: {}
```
## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
