### PR TITLE
Fix #765: Add label to front and rear port modules

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1071,22 +1071,18 @@ class NetboxModule(object):
                 elif isinstance(v, list):
                     id_list = list()
                     for list_item in v:
-                        if (
-                            k
-                            in (
-                                "regions",
-                                "sites",
-                                "roles",
-                                "device_types",
-                                "platforms",
-                                "cluster_groups",
-                                "contact_groups",
-                                "tenant_groups",
-                                "tenants",
-                                "tags",
-                            )
-                            and isinstance(list_item, str)
-                        ):
+                        if k in (
+                            "regions",
+                            "sites",
+                            "roles",
+                            "device_types",
+                            "platforms",
+                            "cluster_groups",
+                            "contact_groups",
+                            "tenant_groups",
+                            "tenants",
+                            "tags",
+                        ) and isinstance(list_item, str):
                             temp_dict = {"slug": self._to_slug(list_item)}
                         elif isinstance(list_item, dict):
                             norm_data = self._normalize_data(list_item)

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1071,18 +1071,22 @@ class NetboxModule(object):
                 elif isinstance(v, list):
                     id_list = list()
                     for list_item in v:
-                        if k in (
-                            "regions",
-                            "sites",
-                            "roles",
-                            "device_types",
-                            "platforms",
-                            "cluster_groups",
-                            "contact_groups",
-                            "tenant_groups",
-                            "tenants",
-                            "tags",
-                        ) and isinstance(list_item, str):
+                        if (
+                            k
+                            in (
+                                "regions",
+                                "sites",
+                                "roles",
+                                "device_types",
+                                "platforms",
+                                "cluster_groups",
+                                "contact_groups",
+                                "tenant_groups",
+                                "tenants",
+                                "tags",
+                            )
+                            and isinstance(list_item, str)
+                        ):
                             temp_dict = {"slug": self._to_slug(list_item)}
                         elif isinstance(list_item, dict):
                             norm_data = self._normalize_data(list_item)

--- a/plugins/modules/netbox_front_port.py
+++ b/plugins/modules/netbox_front_port.py
@@ -81,6 +81,7 @@ options:
           - Label of the front port
         required: false
         type: str
+        version_added: "3.7.0"
       tags:
         description:
           - Any tags that the front port may need to be associated with

--- a/plugins/modules/netbox_front_port.py
+++ b/plugins/modules/netbox_front_port.py
@@ -76,6 +76,11 @@ options:
           - Description of the front port
         required: false
         type: str
+      label:
+        description:
+          - Label of the front port
+        required: false
+        type: str
       tags:
         description:
           - Any tags that the front port may need to be associated with
@@ -185,6 +190,7 @@ def main():
                     rear_port=dict(required=True, type="raw"),
                     rear_port_position=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
+                    label=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                 ),
             ),

--- a/plugins/modules/netbox_front_port_template.py
+++ b/plugins/modules/netbox_front_port_template.py
@@ -71,6 +71,16 @@ options:
           - The position of the rear port template this front port template is connected to
         required: false
         type: int
+      description:
+        description:
+          - Description of the front port
+        required: false
+        type: str
+      label:
+        description:
+          - Label of the front port
+        required: false
+        type: str
 """
 
 EXAMPLES = r"""
@@ -172,6 +182,8 @@ def main():
                     ),
                     rear_port_template=dict(required=True, type="raw"),
                     rear_port_template_position=dict(required=False, type="int"),
+                    description=dict(required=False, type="str"),
+                    label=dict(required=False, type="str"),
                 ),
             ),
         )

--- a/plugins/modules/netbox_front_port_template.py
+++ b/plugins/modules/netbox_front_port_template.py
@@ -76,11 +76,13 @@ options:
           - Description of the front port
         required: false
         type: str
+        version_added: "3.7.0"
       label:
         description:
           - Label of the front port
         required: false
         type: str
+        version_added: "3.7.0"
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/netbox_rear_port.py
+++ b/plugins/modules/netbox_rear_port.py
@@ -71,6 +71,11 @@ options:
           - Description of the rear port
         required: false
         type: str
+      label:
+        description:
+          - Label of the rear port
+        required: false
+        type: str
       tags:
         description:
           - Any tags that the rear port may need to be associated with
@@ -176,6 +181,7 @@ def main():
                     ),
                     positions=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
+                    label=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                 ),
             ),

--- a/plugins/modules/netbox_rear_port.py
+++ b/plugins/modules/netbox_rear_port.py
@@ -76,6 +76,7 @@ options:
           - Label of the rear port
         required: false
         type: str
+        version_added: "3.7.0"
       tags:
         description:
           - Any tags that the rear port may need to be associated with

--- a/plugins/modules/netbox_rear_port_template.py
+++ b/plugins/modules/netbox_rear_port_template.py
@@ -71,11 +71,13 @@ options:
           - Description of the rear port
         required: false
         type: str
+        version_added: "3.7.0"
       label:
         description:
           - Label of the rear port
         required: false
         type: str
+        version_added: "3.7.0"
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/netbox_rear_port_template.py
+++ b/plugins/modules/netbox_rear_port_template.py
@@ -66,6 +66,16 @@ options:
           - The number of front ports which may be mapped to each rear port
         required: false
         type: int
+      description:
+        description:
+          - Description of the rear port
+        required: false
+        type: str
+      label:
+        description:
+          - Label of the rear port
+        required: false
+        type: str
 """
 
 EXAMPLES = r"""
@@ -163,6 +173,8 @@ def main():
                         type="str",
                     ),
                     positions=dict(required=False, type="int"),
+                    description=dict(required=False, type="str"),
+                    label=dict(required=False, type="str"),
                 ),
             ),
         )


### PR DESCRIPTION
## Fixes #765 

## New Behavior

Add `label` as parameter for netbox_front_port, netbox_rear_port. Add `label` and `description` for netbox_front_port_template and netbox_rear_port_template.

## Contrast to Current Behavior
More parameters to align with NetBox functionality.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
