### PR TITLE
Fix #774: Add checks for NetBox version before pulling site groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ v3.7.1
 Bugfixes
 --------
 
+- nb_inventory - Ensure inventory works on NetBox versions without the site group model [#781](https://github.com/netbox-community/ansible_modules/pull/781)
 - nb_inventory - Fix netbox_inventory site_group group_by @ryanmerolle in [#780](https://github.com/netbox-community/ansible_modules/pull/780)
 
 v3.7.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -693,5 +693,5 @@ releases:
     changes:
       bugfixes:
         - nb_inventory - Fix netbox_inventory site_group group_by @ryanmerolle in [#780](https://github.com/netbox-community/ansible_modules/pull/780)
-        - nb_inventory - Ensure inventory works on NetBox versions without the site group model
+        - nb_inventory - Ensure inventory works on NetBox versions without the site group model [#781](https://github.com/netbox-community/ansible_modules/pull/781)
     release_date: '2022-04-26'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -693,4 +693,5 @@ releases:
     changes:
       bugfixes:
         - nb_inventory - Fix netbox_inventory site_group group_by @ryanmerolle in [#780](https://github.com/netbox-community/ansible_modules/pull/780)
+        - nb_inventory - Ensure inventory works on NetBox versions without the site group model
     release_date: '2022-04-26'

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -470,7 +470,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "local_context_data": self.extract_local_context_data,
             "custom_fields": self.extract_custom_fields,
             "region": self.extract_regions,
-            "site_group": self.extract_site_groups,
             "cluster": self.extract_cluster,
             "cluster_group": self.extract_cluster_group,
             "cluster_type": self.extract_cluster_type,
@@ -484,6 +483,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._pluralize_group_by("manufacturer"): self.extract_manufacturer,
         }
 
+        if self.api_version >= version.parse("2.11"):
+            extractors.update(
+                {
+                    "site_group": self.extract_site_groups,
+                }
+            )
         if self.racks:
             extractors.update(
                 {
@@ -979,6 +984,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         )
 
     def refresh_site_groups_lookup(self):
+        if self.api_version < version.parse("2.11"):
+            return
+
         url = self.api_endpoint + "/api/dcim/site-groups/?limit=0"
         site_groups = self.get_resource_list(api_url=url)
         self.site_groups_lookup = dict(
@@ -1790,7 +1798,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._add_region_groups()
 
         # Create groups for site_groups, containing the site groups
-        if "site_group" in self.group_by:
+        if "site_group" in self.group_by and self.api_version >= version.parse("2.11"):
             self._add_site_group_groups()
 
         for host in chain(self.devices_list, self.vms_list):


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Fix #774 

## New Behavior

Add some NetBox checks making sure we don't try pulling site groups on a NetBox version which does not support it.

## Contrast to Current Behavior
Bug fix.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
