### PR TITLE
Add site_group to Config Context module

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -359,6 +359,7 @@ ALLOWED_QUERY_PARAMS = {
         [
             "name",
             "regions",
+            "site_groups",
             "sites",
             "roles",
             "device_types",

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -250,6 +250,7 @@ CONVERT_TO_ID = {
     "scope": "sites",
     "services": "services",
     "site": "sites",
+    "site_groups": "site_groups",
     "site_group": "site_groups",
     "sites": "sites",
     "tags": "tags",

--- a/plugins/modules/netbox_config_context.py
+++ b/plugins/modules/netbox_config_context.py
@@ -62,6 +62,12 @@ options:
         elements: str
       sites:
         description:
+          - List of site groups where configuration context applies
+        required: false
+        type: list
+        elements: str
+      sites:
+        description:
           - List of sites where configuration context applies
         required: false
         type: list
@@ -197,6 +203,7 @@ def main():
                     is_active=dict(required=False, type="bool"),
                     regions=dict(required=False, type="list", elements="str"),
                     sites=dict(required=False, type="list", elements="str"),
+                    site_groups=dict(required=False, type="list", elements="str"),
                     roles=dict(required=False, type="list", elements="str"),
                     device_types=dict(required=False, type="list", elements="str"),
                     platforms=dict(required=False, type="list", elements="str"),

--- a/plugins/modules/netbox_config_context.py
+++ b/plugins/modules/netbox_config_context.py
@@ -60,7 +60,7 @@ options:
         required: false
         type: list
         elements: str
-      sites:
+      site_groups:
         description:
           - List of site groups where configuration context applies
         required: false


### PR DESCRIPTION
## Related Issue
https://github.com/netbox-community/ansible_modules/issues/789 - [Feature]: Add site_groups to config_context module

## New Behavior
This PR includes the `site_groups` model as an assignment option in the NetBox Config Context module.

## Contrast to Current Behavior
It is currently not possible to assign a Config Context to a Site Group via the module.

## Discussion: Benefits and Drawbacks
In our case, we map Config Contexts to Site Groups and so this functionality is required to enable us to use the module.

## Changes to the Documentation
Done.

## Proposed Release Note Entry
- Add site_groups to config_context module

## Double Check
* [ X ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ X ] I have explained my PR according to the information in the comments or in a linked issue.
* [ X ] My PR targets the `devel` branch.
