### PR TITLE
Implements group_by "time_zone" and "time_zone_utc" in nb_inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To keep the code simple, we only officially support the two latest releases of N
 - NetBox 2.11+ or the two latest NetBox releases
 - Python 3.8+
 - Python modules:
+  - `pytz`
   - `pynetbox 5.0.4+`, `pynetbox 6.4.0+` if using 3.1 features
   - `packaging` if using Ansible < 2.10, as it's included in Ansible 2.10+
 - Ansible 2.10+

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -976,18 +976,25 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         def get_time_zone_utc_for_site(site):
             # Will fail if site does not have a time_zone defined in NetBox
             try:
-                utc = round(datetime.datetime.now(pytz.timezone(site["time_zone"])).utcoffset().total_seconds()/60/60)
+                utc = round(
+                    datetime.datetime.now(pytz.timezone(site["time_zone"]))
+                    .utcoffset()
+                    .total_seconds()
+                    / 60
+                    / 60
+                )
                 if utc < 0:
                     return (site["id"], str(utc).replace("-", "minus_"))
                 else:
-                    return (site["id"], f'plus_{utc}')
+                    return (site["id"], f"plus_{utc}")
             except Exception:
                 return (site["id"], None)
-        
+
         # Dictionary of site id to time_zone_utc name (if group by time_zone_utc is used)
         if "time_zone_utc" in self.group_by:
-            self.sites_time_zone_utc_lookup = dict(map(get_time_zone_utc_for_site, sites))
-
+            self.sites_time_zone_utc_lookup = dict(
+                map(get_time_zone_utc_for_site, sites)
+            )
     # Note: depends on the result of refresh_sites_lookup for self.sites_with_prefixes
     def refresh_prefixes(self):
         # Pull all prefixes defined in NetBox

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -245,16 +245,6 @@ device_query_filters:
 
 # has_primary_ip is a useful way to filter out patch panels and other passive devices
 
-# If you group by time_zone, utc_offset etc. it will group devices in ansible groups depending on time zone configured on site.
-# time_zone gives grouping like:
-# - "time_zone_Europe_Bucharest"
-# - "time_zone_Europe_Copenhagen"
-# - "time_zone_America_Denver"
-# utc_offset gives grouping like:
-# - "time_zone_utc_minus_7"
-# - "time_zone_utc_plus_1"
-# - "time_zone_utc_plus_10"
-
 # Query filters are passed directly as an argument to the fetching queries.
 # You can repeat tags in the query string.
 
@@ -308,6 +298,32 @@ required:
 env:
   NETBOX_API: '{{ NETBOX_API }}'
   NETBOX_TOKEN: '{{ NETBOX_TOKEN }}'
+
+# Example of time_zone and utc_offset usage
+
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:8000
+token: <insert token>
+validate_certs: True
+config_context: True
+group_by:
+  - site
+  - role
+  - time_zone
+  - utc_offset
+device_query_filters:
+  - has_primary_ip: 'true'
+  - manufacturer_id: 1
+
+# using group by time_zone, utc_offset it will group devices in ansible groups depending on time zone configured on site.
+# time_zone gives grouping like:
+# - "time_zone_Europe_Bucharest"
+# - "time_zone_Europe_Copenhagen"
+# - "time_zone_America_Denver"
+# utc_offset gives grouping like:
+# - "time_zone_utc_minus_7"
+# - "time_zone_utc_plus_1"
+# - "time_zone_utc_plus_10"
 """
 
 import json

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -315,7 +315,6 @@ import uuid
 import math
 import os
 import datetime
-import pytz
 from copy import deepcopy
 from functools import partial
 from sys import version as python_version
@@ -334,6 +333,14 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib import error as urllib_error
 from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.six import raise_from
+
+try:
+    import pytz
+except ImportError as imp_exc:
+    PYTZ_IMPORT_ERROR = imp_exc
+else:
+    PYTZ_IMPORT_ERROR = None
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
@@ -1823,6 +1830,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return master.get("id", None)
 
     def main(self):
+        # Check if pytz lib is install, and give error if not
+        if PYTZ_IMPORT_ERROR:
+            raise_from(
+                AnsibleError("pytz must be installed to use this plugin"),
+                PYTZ_IMPORT_ERROR,
+            )
+
         # Get info about the API - version, allowed query parameters
         self.fetch_api_docs()
 

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -981,14 +981,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     return (site["id"], str(utc).replace("-", "minus_"))
                 else:
                     return (site["id"], f'plus_{utc}')
-                # return (site["id"], site["time_zone"])
             except Exception:
                 return (site["id"], None)
         
         # Dictionary of site id to time_zone_utc name (if group by time_zone_utc is used)
         if "time_zone_utc" in self.group_by:
             self.sites_time_zone_utc_lookup = dict(map(get_time_zone_utc_for_site, sites))
-
 
     # Note: depends on the result of refresh_sites_lookup for self.sites_with_prefixes
     def refresh_prefixes(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pynetbox
 packaging
+pytz


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
Implements: "[Feature]: nb_inventory add group_by time_zone and time_zone_utc #788"

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

In the inventory source module, you can now group_by time_zone and time_zone_utc

<!--
Please describe in a few words the intentions of your PR.
-->
We needed a way to group our devices by time zone or by UTC time to easily schedule playbooks during the night.
...

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently we had to run the playbook on all hosts and then filter out the devices in the wrong time zone. This was proned to errors and accidental tasks being run that were not supposed to.
...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
Im sure that other people that uses AWX/Tower to push nightly tasks to devices will like this change as it simplifies the way you can filter devices in a particular time zone.

I dont see many drawbacks as if you dont use the time_zone or time_zone_utc group by it does not affect the existing setup. It will also detect if its not being used and not build the dicts hence no process overhead.

Only drawback I see is that it needs the pytz module to run.

grouping looks like this:

```
    "time_zone_Africa_Johannesburg": {
        "hosts": [
            "zahpf-core01",
            "zahpf-dmvpn01",
            "zancc-core01",
            "zancc-dmvpn01",
            "zazbx-dmvpn01",
            "zazcg-core01",
            "zazcg-dmvpn01"
        ]
    },
    "time_zone_Africa_Nairobi": {
        "hosts": [
            "keloy-dmvpn01",
            "kenbo-dmvpn01"
        ]
    },

-----

    "time_zone_utc_minus_7": {
        "hosts": [
            "uspdxapw-core01",
            "usqie-dmvpn01",
            "usrgj-as01",
            "usrgj-dr01",
            "usrtp-dr01",
            "uswc7-sw01"
        ]
    },
    "time_zone_utc_plus_1": {
        "hosts": [
            "iecas-dmvpn01",
            "iecos-core01",
            "ptldb-dr01",
            "ptldb-mdf01-srv-sw01",
            "ptldb-n-ff-i01-as01",
            "ptplg-dmvpn01"
        ]
    },

```

...

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

not much, just added the options in group_by. I think its pretty much self explanatory 

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
nb_inventory - implements group by time_zone and time_zone_utc #788
...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
