### PR TITLE
Add action_group to enable module defaults groups

### DIFF
--- a/docs/getting_started/how-to-use/advanced.rst
+++ b/docs/getting_started/how-to-use/advanced.rst
@@ -299,3 +299,35 @@ IP address to be within **Test VRF 2**.
 We can now see that the IP address is now within VRF with ID 2.
 
 Hopefully this shines some light on this useful feature to allow you, as the user, to define your specific needs for finding a unique object within your NetBox instance.
+
+
+Using Module defaults groups
+--------------------------------------------
+
+Ansible-core >= 2.12 provide a useful feature called [Module defaults groups](https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html#module-defaults-groups) that lets us specify default parameters for a group of modules in a single place. We can use the action_group ``netbox`` that contains all modules from this collection to avoid setting e.g. ``token`` and ``url`` on each task and thus reduce boilerplate code.
+
+.. code-block:: yaml
+
+   ---
+   - hosts: "localhost"
+
+     module_defaults:
+       group/netbox.netbox.netbox:
+         netbox_url: "http://netbox.local"
+         netbox_token: "thisIsMyToken"
+
+     tasks:
+       - name: "Create device type"
+         netbox.netbox.netbox_device_type:
+           data:
+             model: "test-device-type"
+             slug: "c9410r"
+
+       - name: "Create device"
+         netbox.netbox.netbox_device:
+           data:
+             name: "Test Device"
+             device_type: "C9410R"
+             device_role: "Core Switch"
+             site: "Main"
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -7,3 +7,73 @@ plugin_routing:
         removal_version: "0.1.0"
         warning_text: "netbox_interface has been superseceded by netbox.netbox.netbox_device_interface"
       redirect: netbox.netbox.plugins.modules.netbox_device_interface
+
+action_groups:
+  netbox:
+    - netbox_aggregate
+    - netbox_cable
+    - netbox_circuit
+    - netbox_circuit_termination
+    - netbox_circuit_type
+    - netbox_cluster
+    - netbox_cluster_group
+    - netbox_cluster_type
+    - netbox_config_context
+    - netbox_console_port
+    - netbox_console_port_template
+    - netbox_console_server_port
+    - netbox_console_server_port_template
+    - netbox_contact
+    - netbox_contact_group
+    - netbox_contact_role
+    - netbox_custom_field
+    - netbox_custom_link
+    - netbox_device
+    - netbox_device_bay
+    - netbox_device_bay_template
+    - netbox_device_interface
+    - netbox_device_interface_template
+    - netbox_device_role
+    - netbox_device_type
+    - netbox_export_template
+    - netbox_front_port
+    - netbox_front_port_template
+    - netbox_inventory_item
+    - netbox_ip_address
+    - netbox_ipam_role
+    - netbox_location
+    - netbox_manufacturer
+    - netbox_platform
+    - netbox_power_feed
+    - netbox_power_outlet
+    - netbox_power_outlet_template
+    - netbox_power_panel
+    - netbox_power_port
+    - netbox_power_port_template
+    - netbox_prefix
+    - netbox_provider
+    - netbox_provider_network
+    - netbox_rack
+    - netbox_rack_group
+    - netbox_rack_role
+    - netbox_rear_port
+    - netbox_rear_port_template
+    - netbox_region
+    - netbox_rir
+    - netbox_route_target
+    - netbox_service
+    - netbox_site
+    - netbox_site_group
+    - netbox_tag
+    - netbox_tenant
+    - netbox_tenant_group
+    - netbox_virtual_chassis
+    - netbox_virtual_machine
+    - netbox_vlan
+    - netbox_vlan_group
+    - netbox_vm_interface
+    - netbox_vrf
+    - netbox_webhook
+    - netbox_wireless_lan
+    - netbox_wireless_lan_group
+    - netbox_wireless_link


### PR DESCRIPTION


<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue


#799


## New Behavior


This enables support for the module defaults groups feature introduced in ansible-core 2.12. Using module defaults groups one can provide default values (e.g. token, url, etc.) for a group of modules instead of having to specify them for every used module. For more details see: https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html#module-defaults-groups

This commit adds all modules available in this collection to an action group called 'netbox'. This change is backwards compatible. Older versions of Ansible just ignore this.

## Contrast to Current Behavior

Currently, user has to specify module defaults (e.g. url, token) for every module in use.


## Discussion: Benefits and Drawbacks


This change potentially reduces the amount of boilerplate code using this collection as required parameters like e.g. ``url`` or ``token`` need to be provided once and can be specified in a central place.


## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

Might add a hint to the documentation about the usage of this feature.

## Proposed Release Note Entry


Support module defaults groups


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ x] I have explained my PR according to the information in the comments or in a linked issue.
* [ x] My PR targets the `devel` branch.
