### PR TITLE
Allow netbox api access token to be templated

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1853,7 +1853,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.use_cache = cache
 
         # NetBox access
-        token = self.get_option("token")
+        token = self.templar.template(self.get_option("token"), fail_on_undefined=False)
         # Handle extra "/" from api_endpoint configuration and trim if necessary, see PR#49943
         self.api_endpoint = self.get_option("api_endpoint").strip("/")
         self.timeout = self.get_option("timeout")


### PR DESCRIPTION
## New Behavior

You can use jinja templating for the API access token in the nb_inventory 
config.

## Contrast to Current Behavior

The only possibility not to have the token in clear text in the config was to
use ansible vault.

## Discussion: Benefits and Drawbacks

This makes it possible to use a lookup() to retrieve the token, i.e. from a 
password-manager.

Idea is stolen from the hcloud inventory.

## Changes to the Documentation

token:  NetBox API token to be able to read against NetBox. This may be templated with jinja i.e. to use lookup().

## Proposed Release Note Entry

inventory token: can now use jinja templating i.e. to use lookup()

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
