### PR TITLE
Fix #821: Allow more than slug in a site query

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -443,7 +443,7 @@ ALLOWED_QUERY_PARAMS = {
     "role": set(["slug"]),
     "route_target": set(["name"]),
     "services": set(["device", "virtual_machine", "name", "port", "protocol"]),
-    "site": set(["slug"]),
+    "site": set(["slug", "name"]),
     "site_group": set(["slug"]),
     "tags": set(["slug"]),
     "tagged_vlans": set(["group", "name", "site", "vid", "vlan_group", "tenant"]),

--- a/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
+++ b/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
@@ -282,6 +282,7 @@
             "contact_name": "John Smith"
         },
         "expected": {
+            "name": "Test Site",
             "slug": "test-site"
         }
     },


### PR DESCRIPTION
## Related Issue

#821 

## New Behavior

```
netbox_cluster:
  data:
    name: cluster name
    cluster_type: Cluster type
    site:
      name: CDC
```

## Contrast to Current Behavior

Previously is was not possible to filter on anything other than the slug when referencing a site. This should translate to other modules as well.

## Changes to the Documentation

None

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
