### PR TITLE
Fix #848: Add device to netbox_virtual_machine

### DIFF
--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -84,6 +84,11 @@ options:
           - Disk of the virtual machine (GB)
         required: false
         type: int
+      device:
+        description:
+          - The device the virtual machine is pinned to in the cluster
+        required: false
+        type: raw
       status:
         description:
           - The status of the virtual machine
@@ -205,6 +210,7 @@ def main():
                     primary_ip6=dict(required=False, type="raw"),
                     memory=dict(required=False, type="int"),
                     disk=dict(required=False, type="int"),
+                    device=dict(required=False, type="raw"),
                     status=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),


### PR DESCRIPTION
## Related Issue #848 

## New Behavior
Add device field to netbox_virtual_machine to stay up to date with NetBox 3.3

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
