### PR TITLE
Correct readthedocs release process

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ import sys
 import re
 import stat
 from pathlib import Path
-from antsibull.cli import antsibull_docs
+from antsibull_docs.cli import antsibull_docs
 
 sys.path.insert(0, os.path.abspath("../"))
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 ansible
-antsibull
+antsibull==0.48.0
 sphinx==3.4.2


### PR DESCRIPTION
Thanks to @FragmentedPacket for the pointing me to a fix when all I needed was access to the RTD site to troubleshoot.  He goes above and beyond as always.

## Related Issue

Closes #850

## New Behavior

Fixes Read the Docs generation

## Contrast to Current Behavior

RTD has been broken for new releases for a few releases now.


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
