### PR TITLE
Fix two idempotency issues when updating VMs.

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1298,7 +1298,7 @@ class NetboxModule(object):
                         data_after[key] = updated_obj[key]
                 except KeyError:
                     if key == "form_factor":
-                        msg = "form_factor is not valid for NetBox 2.7 onword. Please use the type key instead."
+                        msg = "form_factor is not valid for NetBox 2.7 onward. Please use the type key instead."
                     else:
                         msg = (
                             "%s does not exist on existing object. Check to make sure valid field."

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -676,6 +676,8 @@ class NetboxModule(object):
         elif g_major == l_major and g_minor > l_minor:
             return True
 
+        return False
+
     def _connect_netbox_api(self, url, token, ssl_verify, cert):
         try:
             session = requests.Session()

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1257,12 +1257,28 @@ class NetboxModule(object):
         """
         serialized_nb_obj = self.nb_object.serialize()
         updated_obj = serialized_nb_obj.copy()
+
+        if serialized_nb_obj.get("custom_fields"):
+            serialized_nb_obj["custom_fields"] = {
+                key: value
+                for key, value in serialized_nb_obj["custom_fields"].items()
+                if value is not None
+            }
+
+        if updated_obj.get("custom_fields"):
+            updated_obj["custom_fields"] = {
+                key: value
+                for key, value in updated_obj["custom_fields"].items()
+                if value is not None
+            }
+
         updated_obj.update(data)
+
         if serialized_nb_obj.get("tags") and data.get("tags"):
             serialized_nb_obj["tags"] = set(serialized_nb_obj["tags"])
             updated_obj["tags"] = set(data["tags"])
 
-        # Ensure idempotency for site and virtual machine on version pre-3.0
+        # Ensure idempotency for site on older netbox versions
         version_pre_30 = self._version_check_greater("3.0", self.version)
         if (
             serialized_nb_obj.get("latitude")
@@ -1277,15 +1293,13 @@ class NetboxModule(object):
         ):
             updated_obj["longitude"] = str(data["longitude"])
 
-        if serialized_nb_obj.get("vcpus") and data.get("vcpus") and version_pre_30:
-            updated_obj["vcpus"] = "{0:.2f}".format(data["vcpus"])
-
-        if serialized_nb_obj.get("custom_fields"):
-            serialized_nb_obj["custom_fields"] = {
-                key: value
-                for key, value in serialized_nb_obj["custom_fields"].items()
-                if value is not None
-            }
+        # Ensure idempotency for virtual machine on older netbox versions
+        version_pre_211 = self._version_check_greater("2.11", self.version)
+        if serialized_nb_obj.get("vcpus") and data.get("vcpus"):
+            if version_pre_211:
+                updated_obj["vcpus"] = int(data["vcpus"])
+            else:
+                updated_obj["vcpus"] = float(data["vcpus"])
 
         if serialized_nb_obj == updated_obj:
             return serialized_nb_obj, None

--- a/tests/integration/targets/v3.1/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v3.1/tasks/netbox_virtual_machine.yml
@@ -76,24 +76,53 @@
       - test_three['virtual_machine']['tags'][0] == 4
       - test_three['msg'] == "virtual_machine Test VM One updated"
 
-- name: "VIRTUAL_MACHINE 4: Delete"
+- name: "VIRTUAL_MACHINE 4: Test idempotence"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+      vcpus: 8.5
+      memory: 8
+      status: "Planned"
+      virtual_machine_role: "Test VM Role"
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_four_idempotence
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Not changed"
+  assert:
+    that:
+      - test_four_idempotence is not changed
+      - test_four_idempotence['virtual_machine']['name'] == "Test VM One"
+      - test_four_idempotence['virtual_machine']['cluster'] == 1
+      - test_four_idempotence['virtual_machine']['vcpus'] == 8.5
+      - test_four_idempotence['virtual_machine']['memory'] == 8
+      - test_four_idempotence['virtual_machine']['status'] == "planned"
+      - test_four_idempotence['virtual_machine']['role'] == 2
+      - test_four_idempotence['virtual_machine']['tags'][0] == 4
+      - test_four_idempotence['msg'] == "virtual_machine Test VM One already exists"
+
+- name: "VIRTUAL_MACHINE 5: Delete"
   netbox.netbox.netbox_virtual_machine:
     netbox_url: http://localhost:32768
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "Test VM One"
     state: absent
-  register: test_four
+  register: test_five
 
-- name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
+- name: "VIRTUAL_MACHINE 5: ASSERT - Delete"
   assert:
     that:
-      - test_four is changed
-      - test_four['virtual_machine']['name'] == "Test VM One"
-      - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == 8.5
-      - test_four['virtual_machine']['memory'] == 8
-      - test_four['virtual_machine']['status'] == "planned"
-      - test_four['virtual_machine']['role'] == 2
-      - test_four['virtual_machine']['tags'][0] == 4
-      - test_four['msg'] == "virtual_machine Test VM One deleted"
+      - test_five is changed
+      - test_five['virtual_machine']['name'] == "Test VM One"
+      - test_five['virtual_machine']['cluster'] == 1
+      - test_five['virtual_machine']['vcpus'] == 8.5
+      - test_five['virtual_machine']['memory'] == 8
+      - test_five['virtual_machine']['status'] == "planned"
+      - test_five['virtual_machine']['role'] == 2
+      - test_five['virtual_machine']['tags'][0] == 4
+      - test_five['msg'] == "virtual_machine Test VM One deleted"

--- a/tests/integration/targets/v3.2/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v3.2/tasks/netbox_virtual_machine.yml
@@ -76,24 +76,53 @@
       - test_three['virtual_machine']['tags'][0] == 4
       - test_three['msg'] == "virtual_machine Test VM One updated"
 
-- name: "VIRTUAL_MACHINE 4: Delete"
+- name: "VIRTUAL_MACHINE 4: Test idempotence"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+      vcpus: 8.5
+      memory: 8
+      status: "Planned"
+      virtual_machine_role: "Test VM Role"
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_four_idempotence
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Not changed"
+  assert:
+    that:
+      - test_four_idempotence is not changed
+      - test_four_idempotence['virtual_machine']['name'] == "Test VM One"
+      - test_four_idempotence['virtual_machine']['cluster'] == 1
+      - test_four_idempotence['virtual_machine']['vcpus'] == 8.5
+      - test_four_idempotence['virtual_machine']['memory'] == 8
+      - test_four_idempotence['virtual_machine']['status'] == "planned"
+      - test_four_idempotence['virtual_machine']['role'] == 2
+      - test_four_idempotence['virtual_machine']['tags'][0] == 4
+      - test_four_idempotence['msg'] == "virtual_machine Test VM One already exists"
+
+- name: "VIRTUAL_MACHINE 5: Delete"
   netbox.netbox.netbox_virtual_machine:
     netbox_url: http://localhost:32768
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "Test VM One"
     state: absent
-  register: test_four
+  register: test_five
 
-- name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
+- name: "VIRTUAL_MACHINE 5: ASSERT - Delete"
   assert:
     that:
-      - test_four is changed
-      - test_four['virtual_machine']['name'] == "Test VM One"
-      - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == 8.5
-      - test_four['virtual_machine']['memory'] == 8
-      - test_four['virtual_machine']['status'] == "planned"
-      - test_four['virtual_machine']['role'] == 2
-      - test_four['virtual_machine']['tags'][0] == 4
-      - test_four['msg'] == "virtual_machine Test VM One deleted"
+      - test_five is changed
+      - test_five['virtual_machine']['name'] == "Test VM One"
+      - test_five['virtual_machine']['cluster'] == 1
+      - test_five['virtual_machine']['vcpus'] == 8.5
+      - test_five['virtual_machine']['memory'] == 8
+      - test_five['virtual_machine']['status'] == "planned"
+      - test_five['virtual_machine']['role'] == 2
+      - test_five['virtual_machine']['tags'][0] == 4
+      - test_five['msg'] == "virtual_machine Test VM One deleted"

--- a/tests/integration/targets/v3.3/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_virtual_machine.yml
@@ -76,24 +76,53 @@
       - test_three['virtual_machine']['tags'][0] == 4
       - test_three['msg'] == "virtual_machine Test VM One updated"
 
-- name: "VIRTUAL_MACHINE 4: Delete"
+- name: "VIRTUAL_MACHINE 4: Test idempotence"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: "Test VM One"
+      cluster: "Test Cluster"
+      vcpus: 8.5
+      memory: 8
+      status: "Planned"
+      virtual_machine_role: "Test VM Role"
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_four_idempotence
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Not changed"
+  assert:
+    that:
+      - test_four_idempotence is not changed
+      - test_four_idempotence['virtual_machine']['name'] == "Test VM One"
+      - test_four_idempotence['virtual_machine']['cluster'] == 1
+      - test_four_idempotence['virtual_machine']['vcpus'] == 8.5
+      - test_four_idempotence['virtual_machine']['memory'] == 8
+      - test_four_idempotence['virtual_machine']['status'] == "planned"
+      - test_four_idempotence['virtual_machine']['role'] == 2
+      - test_four_idempotence['virtual_machine']['tags'][0] == 4
+      - test_four_idempotence['msg'] == "virtual_machine Test VM One already exists"
+
+- name: "VIRTUAL_MACHINE 5: Delete"
   netbox.netbox.netbox_virtual_machine:
     netbox_url: http://localhost:32768
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "Test VM One"
     state: absent
-  register: test_four
+  register: test_five
 
-- name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
+- name: "VIRTUAL_MACHINE 5: ASSERT - Delete"
   assert:
     that:
-      - test_four is changed
-      - test_four['virtual_machine']['name'] == "Test VM One"
-      - test_four['virtual_machine']['cluster'] == 1
-      - test_four['virtual_machine']['vcpus'] == 8.5
-      - test_four['virtual_machine']['memory'] == 8
-      - test_four['virtual_machine']['status'] == "planned"
-      - test_four['virtual_machine']['role'] == 2
-      - test_four['virtual_machine']['tags'][0] == 4
-      - test_four['msg'] == "virtual_machine Test VM One deleted"
+      - test_five is changed
+      - test_five['virtual_machine']['name'] == "Test VM One"
+      - test_five['virtual_machine']['cluster'] == 1
+      - test_five['virtual_machine']['vcpus'] == 8.5
+      - test_five['virtual_machine']['memory'] == 8
+      - test_five['virtual_machine']['status'] == "planned"
+      - test_five['virtual_machine']['role'] == 2
+      - test_five['virtual_machine']['tags'][0] == 4
+      - test_five['msg'] == "virtual_machine Test VM One deleted"


### PR DESCRIPTION
## Related Issue

#823

## New Behavior

Using `netbox.netbox.netbox_virtual_machine` to update the vCPU count of a VM in netbox is now idempotent from version 2.10 onward.
Using `netbox.netbox.netbox_virtual_machine` to update a VM in netbox that has custom_fields with no values is also idempotent from version 2.10 onward.

Plus a couple of pretty minor changes (that can be removed easily if undesired):
* Method `_version_check_greater` now returns a type consistent value (i.e. False instead of None by default).
* Fix for a typo in an error message.

## Contrast to Current Behavior

In the current behaviour, I'd get a float value replacing my integer value on the `vcpus` field every time (netbox 2.10).
And if I had a `custom_fields` with value `None`, the module would systematically return a `state: changed` with an empty diff (netbox 2.10 and 3.2).

## Discussion: Benefits and Drawbacks

To do that, I dropped the use of a formatted string and instead use the same types as pynetbox, i.e. integer / float, depending on the situation. The user can use either type and it'll work fine, so long as pynetbox and the targeted netbox are able to handle it. Otherwise, an error is raised, e.g. `pynetbox.core.query.RequestError: The request failed with code 400 Bad Request: {'vcpus': ['Ensure that there are no more than 6 digits in total.']}`

I manually tested on 2.10 and 3.2 instances, with different `vcpus` values (2, 2.0, 2.1, 2.10, 2.12), and I get a consistent, idempotent behaviour.

Additionally, there was a piece of code that would always generate diffs if the original or updated objects contained a custom field with a value of None.
I chose to replicate the existing behaviour on the updated object rather than delete the loop over the original object. But admittedly, I do not understand the purpose of this piece of code. If anyone has knowledge about this, I'd be happy to learn more.

Existing tests pass, and I've also added an idempotence test on the execution of the `netbox_virtual_machine` module.

## Proposed Release Note Entry

Fix #823: Fix idempotence of netbox_virtual_machine module.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
