### PR TITLE
Fix #860: Make sure inventory works with ansible < 2.11

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1950,10 +1950,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).parse(inventory, loader, path)
         self._read_config_data(path=path)
         self.use_cache = cache
-        self.templar.available_variables = self._vars
 
         # NetBox access
-        token = self.templar.template(self.get_option("token"), fail_on_undefined=False)
+        if version.parse(ansible_version) < version.parse("2.11"):
+            token = self.get_option("token")
+        else:
+            self.templar.available_variables = self._vars
+            token = self.templar.template(
+                self.get_option("token"), fail_on_undefined=False
+            )
+
         # Handle extra "/" from api_endpoint configuration and trim if necessary, see PR#49943
         self.api_endpoint = self.get_option("api_endpoint").strip("/")
         self.timeout = self.get_option("timeout")
@@ -1984,13 +1990,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Filter and group_by options
         self.group_by = self.get_option("group_by")
         self.group_names_raw = self.get_option("group_names_raw")
-        self.query_filters = self.templar.template(self.get_option("query_filters"))
-        self.device_query_filters = self.templar.template(
-            self.get_option("device_query_filters")
-        )
-        self.vm_query_filters = self.templar.template(
-            self.get_option("vm_query_filters")
-        )
+        if version.parse(ansible_version) < version.parse("2.11"):
+            self.query_filters = self.get_option("query_filters")
+            self.device_query_filters = self.get_option("device_query_filters")
+            self.vm_query_filters = self.get_option("vm_query_filters")
+        else:
+            self.query_filters = self.templar.template(self.get_option("query_filters"))
+            self.device_query_filters = self.templar.template(
+                self.get_option("device_query_filters")
+            )
+            self.vm_query_filters = self.templar.template(
+                self.get_option("vm_query_filters")
+            )
         self.virtual_chassis_name = self.get_option("virtual_chassis_name")
         self.dns_name = self.get_option("dns_name")
         self.ansible_host_dns_name = self.get_option("ansible_host_dns_name")


### PR DESCRIPTION
## Related Issue

#860 

## New Behavior

Test for ansible versions earlier than 2.11 in inventory plugin.

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
