### PR TITLE
This updates the console port and console server port modules for the v3.3 api.

### DIFF
--- a/plugins/modules/netbox_console_port.py
+++ b/plugins/modules/netbox_console_port.py
@@ -57,14 +57,45 @@ options:
           - usb-mini-b
           - usb-micro-a
           - usb-micro-b
+          - usb-micro-ab
           - other
         required: false
         type: str
+      cable:
+        description:
+          - cable to connect port to.
+        required: false
+        type: dict
+      custom_fields:
+        description:
+          - must exist in netbox
+        required: false
+        type: dict
       description:
         description:
           - Description of the console port
         required: false
         type: str
+      label:
+        description:
+          - label of the console port
+        required: false
+        type: str
+      mark_connected:
+        description:
+          - Treats as if a cable is connected to the port
+        required: false
+        type: bool
+      module:
+        description:
+          - module that provides the console port.
+        required: false
+        type: raw
+      speed:
+        description:
+          - the port speed
+        required: false
+        type: int
       tags:
         description:
           - Any tags that the console port may need to be associated with
@@ -153,6 +184,7 @@ def main():
                             "rj-11",
                             "rj-12",
                             "rj-45",
+                            "mini-din-8",
                             "usb-a",
                             "usb-b",
                             "usb-c",
@@ -160,11 +192,18 @@ def main():
                             "usb-mini-b",
                             "usb-micro-a",
                             "usb-micro-b",
+                            "usb-micro-ab",
                             "other",
                         ],
                         type="str",
                     ),
+                    cable=dict(required=False, type="dict"),
+                    custom_fields=dict(required=False, type="dict"),
                     description=dict(required=False, type="str"),
+                    module=dict(required=False, type="str"),
+                    label=dict(required=False, type="str"),
+                    mark_connected=dict(required=False, type="bool"),
+                    speed=dict(required=False, type="int"),
                     tags=dict(required=False, type="list", elements="raw"),
                 ),
             ),

--- a/plugins/modules/netbox_console_port.py
+++ b/plugins/modules/netbox_console_port.py
@@ -50,6 +50,7 @@ options:
           - rj-11
           - rj-12
           - rj-45
+          - mini-din-8
           - usb-a
           - usb-b
           - usb-c
@@ -90,7 +91,7 @@ options:
         description:
           - module that provides the console port.
         required: false
-        type: raw
+        type: int
       speed:
         description:
           - the port speed
@@ -200,7 +201,7 @@ def main():
                     cable=dict(required=False, type="dict"),
                     custom_fields=dict(required=False, type="dict"),
                     description=dict(required=False, type="str"),
-                    module=dict(required=False, type="str"),
+                    module=dict(required=False, type="int"),
                     label=dict(required=False, type="str"),
                     mark_connected=dict(required=False, type="bool"),
                     speed=dict(required=False, type="int"),

--- a/plugins/modules/netbox_console_server_port.py
+++ b/plugins/modules/netbox_console_server_port.py
@@ -50,6 +50,7 @@ options:
           - rj-11
           - rj-12
           - rj-45
+          - mini-din-8
           - usb-a
           - usb-b
           - usb-c
@@ -57,14 +58,40 @@ options:
           - usb-mini-b
           - usb-micro-a
           - usb-micro-b
+          - usb-micro-ab
           - other
         required: false
         type: str
+      cable:
+        description:
+          - cable to attach port to.  Must exist.
+        type: dict
+        required: false
+      custom_fields:
+        description:
+          - must exist in netbox
+        type: dict
+        required: false
       description:
         description:
           - Description of the console server port
         required: false
         type: str
+      label:
+        description:
+          - label of the conserver server port
+        required: false
+        type: str
+      mark_connected:
+        description:
+          - Treats as if a cable is connected to the port
+        required: false
+        type: bool
+      speed:
+        description:
+          - sets the port speed
+        required: false
+        type: int
       tags:
         description:
           - Any tags that the console server port may need to be associated with
@@ -97,6 +124,7 @@ EXAMPLES = r"""
           name: Test Console Server Port
           device: Test Device
           type: usb-a
+          speed: 11500
           description: console server port description
         state: present
 
@@ -153,6 +181,7 @@ def main():
                             "rj-11",
                             "rj-12",
                             "rj-45",
+                            "mini-din-8",
                             "usb-a",
                             "usb-b",
                             "usb-c",
@@ -160,11 +189,17 @@ def main():
                             "usb-mini-b",
                             "usb-micro-a",
                             "usb-micro-b",
+                            "usb-micro-ab",
                             "other",
                         ],
                         type="str",
                     ),
+                    cable=dict(required=False, type="dict"),
+                    custom_fields=dict(required=False, type="dict"),
                     description=dict(required=False, type="str"),
+                    label=dict(required=False, type="str"),
+                    speed=dict(required=False, type="int"),
+                    mark_connected=dict(required=False, type="bool"),
                     tags=dict(required=False, type="list", elements="raw"),
                 ),
             ),


### PR DESCRIPTION
## New Behavior

This adds to the netbox_console_port.py and netbox_console_port_server.py the following:

- attach cable to pre-existing cable.
- set custom_fields
- set port label
- set port speed
- mark the cable as connected.


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
