### PR TITLE
Fix #864 - add device bay label support to device_bay module.

### DIFF
--- a/plugins/modules/netbox_device_bay.py
+++ b/plugins/modules/netbox_device_bay.py
@@ -45,9 +45,14 @@ options:
         type: str
       installed_device:
         description:
-          - The ddevice that will be installed into the bay. The device type must be "child".
+          - The device that will be installed into the bay. The device type must be "child".
         required: false
         type: raw
+      label:
+        description:
+          - Label for the device bay
+        required: false
+        type: str
       tags:
         description:
           - Any tags that the device bay may need to be associated with
@@ -132,6 +137,7 @@ def main():
                     name=dict(required=True, type="str"),
                     description=dict(required=False, type="str"),
                     installed_device=dict(required=False, type="raw"),
+                    label=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                 ),
             ),


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

Fixes issue #864 by adding label support.
Fixes typo in installed_device description.

## New Behavior

Adds label support to the device_bay module.

## Contrast to Current Behavior

No label support for a device bay.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
