### PR TITLE
Fixes site group lookup by using the correct key

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -995,9 +995,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.sites_region_lookup = dict(map(get_region_for_site, sites))
 
         def get_site_group_for_site(site):
-            # Will fail if site does not have a site_group defined in NetBox
+            # Will fail if site does not have a group defined in NetBox
             try:
-                return (site["id"], site["site_group"]["id"])
+                return (site["id"], site["group"]["id"])
             except Exception:
                 return (site["id"], None)
 


### PR DESCRIPTION
Netbox returns the group association via a `group` key rather than a `site_group` key. This code erroneously looks for `site_group` which will always fail.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
#871 

## New Behavior
`site_group` parent group is created containing associated `sites` as `children` host groups.
...

## Contrast to Current Behavior
The old behavior results in no such group created and an empty host list is eventually created.
...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change? Bug Fix
- What are the drawbacks of this change? None
- Is it backwards-compatible? Unsure, those unaware might end up with a larger host list than currently expected if they used `group_by: site_group` in their inventory file.
- Anything else that you think is relevant to the discussion of this PR.
  I tested only using my own use case as I couldn't go through the entire describe testing process.
...

## Changes to the Documentation
Don't believe there is a change necessary unless there is an errata somewhere.

...

## Proposed Release Note Entry

...

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
