### PR TITLE
Update CI to Ansible 2.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
           cd ..
         if: matrix.VERSION == 'v3.4'
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: snok/install-poetry@v1.3.3
         with:
           virtualenvs-create: false
       - name: Install Python packages

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 DOCUMENTATION = """
-    name: nb_inventory
-    plugin_type: inventory
+    name: nb_inventory    
     author:
         - Remy Leone (@sieben)
         - Anthony Ruhier (@Anthony25)
@@ -139,6 +138,7 @@ DOCUMENTATION = """
                 - I(rack_group) is supported on NetBox versions 2.10 or lower only
                 - I(location) is supported on NetBox versions 2.11 or higher only
             type: list
+            elements: str
             choices:
                 - sites
                 - site
@@ -180,18 +180,21 @@ DOCUMENTATION = """
                 - List of parameters passed to the query string for both devices and VMs (Multiple values may be separated by commas).
                 - You can also use Jinja2 templates.
             type: list
+            elements: str
             default: []
         device_query_filters:
             description:
                 - List of parameters passed to the query string for devices (Multiple values may be separated by commas).
                 - You can also use Jinja2 templates.
             type: list
+            elements: str
             default: []
         vm_query_filters:
             description:
                 - List of parameters passed to the query string for VMs (Multiple values may be separated by commas).
                 - You can also use Jinja2 templates.
             type: list
+            elements: str
             default: []
         timeout:
             description: Timeout for NetBox requests in seconds

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -351,7 +351,7 @@ from typing import Iterable
 from itertools import chain
 from collections import defaultdict
 from ipaddress import ip_interface
-from packaging import specifiers, version
+
 
 from ansible.constants import DEFAULT_LOCAL_TMP
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
@@ -362,6 +362,13 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib import error as urllib_error
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.six import raise_from
+
+try:
+    from packaging import specifiers, version
+except ImportError as imp_exc:
+    PACKAGING_IMPORT_ERROR = imp_exc
+else:
+    PACKAGING_IMPORT_ERROR = None
 
 try:
     import pytz

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -11,36 +11,11 @@ A lookup function designed to return data from the NetBox application
 
 from __future__ import absolute_import, division, print_function
 
-import os
-import functools
-from pprint import pformat
-
-from ansible.errors import AnsibleError
-from ansible.plugins.lookup import LookupBase
-from ansible.parsing.splitter import parse_kv, split_args
-from ansible.utils.display import Display
-from ansible.module_utils.six import raise_from
-
-try:
-    import pynetbox
-except ImportError as imp_exc:
-    PYNETBOX_LIBRARY_IMPORT_ERROR = imp_exc
-else:
-    PYNETBOX_LIBRARY_IMPORT_ERROR = None
-
-try:
-    import requests
-except ImportError as imp_exc:
-    REQUESTS_LIBRARY_IMPORT_ERROR = imp_exc
-else:
-    REQUESTS_LIBRARY_IMPORT_ERROR = None
-
-
 __metaclass__ = type
 
 DOCUMENTATION = """
-    lookup: nb_lookup
     author: Chris Mills (@cpmills1975)
+    name: nb_lookup
     version_added: "0.1.0"
     short_description: Queries and returns elements from NetBox
     description:
@@ -150,6 +125,30 @@ RETURN = """
       - list of composed dictionaries with key and value
     type: list
 """
+
+import os
+import functools
+from pprint import pformat
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from ansible.parsing.splitter import parse_kv, split_args
+from ansible.utils.display import Display
+from ansible.module_utils.six import raise_from
+
+try:
+    import pynetbox
+except ImportError as imp_exc:
+    PYNETBOX_LIBRARY_IMPORT_ERROR = imp_exc
+else:
+    PYNETBOX_LIBRARY_IMPORT_ERROR = None
+
+try:
+    import requests
+except ImportError as imp_exc:
+    REQUESTS_LIBRARY_IMPORT_ERROR = imp_exc
+else:
+    REQUESTS_LIBRARY_IMPORT_ERROR = None
 
 
 def get_endpoint(netbox, term):

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -54,6 +54,7 @@ try:
     from packaging.version import Version
 
     HAS_PACKAGING = True
+    PACKAGING_IMPORT_ERROR = ""
 except ImportError as imp_exc:
     PACKAGING_IMPORT_ERROR = imp_exc
     HAS_PACKAGING = False

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,11 +39,11 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "ansible-core"
-version = "2.14.1"
+version = "2.13.7"
 description = "Radically simple IT automation"
 category = "main"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 
 [package.dependencies]
 cryptography = "*"
@@ -68,11 +68,11 @@ jinja2 = "*"
 
 [[package]]
 name = "antsibull-changelog"
-version = "0.18.0"
+version = "0.17.0"
 description = "Changelog tool for Ansible-base and Ansible collections"
 category = "main"
 optional = false
-python-versions = ">=3.9.0,<4.0.0"
+python-versions = ">=3.6.0,<4.0.0"
 
 [package.dependencies]
 docutils = "*"
@@ -326,7 +326,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "5.1.0"
+version = "5.2.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -336,7 +336,7 @@ python-versions = ">=3.7"
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
+docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "sphinx-lint", "jaraco.tidelift (>=1.4)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "pytest-flake8", "importlib-resources (>=1.3)"]
 
@@ -638,7 +638,7 @@ testing = ["filelock"]
 
 [[package]]
 name = "pytz"
-version = "2022.6"
+version = "2022.7"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -695,6 +695,7 @@ python-versions = ">=3.6.3,<4.0.0"
 [package.dependencies]
 commonmark = ">=0.9.0,<0.10.0"
 pygments = ">=2.6.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
@@ -882,8 +883,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-co
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "785fa3a586b49cbd1f647008b48a6d9b1e73d41b046108b7fb56f22d5cc93dc8"
+python-versions = "^3.8"
+content-hash = "c5b24ddacbd60f895db324daa9d774dafa890d25395cfb164d80ce10c45f5cb1"
 
 [metadata.files]
 aiofiles = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,18 +39,18 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "ansible-core"
-version = "2.12.10"
+version = "2.14.1"
 description = "Radically simple IT automation"
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 
 [package.dependencies]
 cryptography = "*"
-jinja2 = "*"
+jinja2 = ">=3.0.0"
 packaging = "*"
-PyYAML = "*"
-resolvelib = ">=0.5.3,<0.6.0"
+PyYAML = ">=5.1"
+resolvelib = ">=0.5.3,<0.9.0"
 
 [[package]]
 name = "antsibull"
@@ -68,11 +68,11 @@ jinja2 = "*"
 
 [[package]]
 name = "antsibull-changelog"
-version = "0.17.0"
+version = "0.18.0"
 description = "Changelog tool for Ansible-base and Ansible collections"
 category = "main"
 optional = false
-python-versions = ">=3.6.0,<4.0.0"
+python-versions = ">=3.9.0,<4.0.0"
 
 [package.dependencies]
 docutils = "*"
@@ -350,16 +350,16 @@ python-versions = "*"
 
 [[package]]
 name = "isort"
-version = "5.11.2"
+version = "5.11.3"
 description = "A Python utility / library to sort Python imports."
 category = "main"
 optional = false
 python-versions = ">=3.7.0"
 
 [package.extras]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
-requirements-deprecated-finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 
 [[package]]
@@ -537,7 +537,7 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pylint"
-version = "2.15.8"
+version = "2.15.9"
 description = "python code static checker"
 category = "main"
 optional = false
@@ -546,7 +546,10 @@ python-versions = ">=3.7.2"
 [package.dependencies]
 astroid = ">=2.12.13,<=2.14.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = ">=0.2"
+dill = [
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
@@ -669,17 +672,17 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "resolvelib"
-version = "0.5.5"
+version = "0.8.1"
 description = "Resolve abstract dependencies into concrete ones"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.extras]
-examples = ["html5lib", "packaging", "pygraphviz", "requests"]
-lint = ["black", "flake8"]
-release = ["setl", "towncrier"]
-test = ["commentjson", "packaging", "pytest"]
+test = ["pytest", "packaging", "commentjson"]
+release = ["twine", "towncrier", "build"]
+lint = ["types-requests", "isort", "mypy", "flake8", "black"]
+examples = ["requests", "pygraphviz", "packaging", "html5lib"]
 
 [[package]]
 name = "rich"
@@ -692,7 +695,6 @@ python-versions = ">=3.6.3,<4.0.0"
 [package.dependencies]
 commonmark = ">=0.9.0,<0.10.0"
 pygments = ">=2.6.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
@@ -880,8 +882,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-co
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "0627816c557f64c306cc66886b8dd70b174acddc83190a896bbb1efdb03b53ab"
+python-versions = "^3.9"
+content-hash = "785fa3a586b49cbd1f647008b48a6d9b1e73d41b046108b7fb56f22d5cc93dc8"
 
 [metadata.files]
 aiofiles = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["Mikhail Yohman <mikhail.yohman@gmail.com>"]
 license = "GPLv3"
 
 [tool.poetry.dependencies]
-python = "^3.8"
-ansible-core = "2.12.*"
+python = "^3.9"
+ansible-core = "2.14.*"
 black = "*"
 codecov = "*"
 coverage = "^4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["Mikhail Yohman <mikhail.yohman@gmail.com>"]
 license = "GPLv3"
 
 [tool.poetry.dependencies]
-python = "^3.9"
-ansible-core = "2.14.*"
+python = "^3.8"
+ansible-core = "2.13.*"
 black = "*"
 codecov = "*"
 coverage = "^4.0"


### PR DESCRIPTION
## New Behavior

Make sure the modules pass sanity tests for ansible 2.13.

## Discussion: Benefits and Drawbacks

Ansible 2.12 is expected to go EOL in May this year.

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
