### PR TITLE
Fix issue #927 - cable module compatibility with NetBox v3.3

### DIFF
--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -188,6 +188,20 @@ class NetboxDcimModule(NetboxModule):
                 self.nb_object = cables[0]
             else:
                 self._handle_errors(msg="More than one result returned for %s" % (name))
+
+            if Version(self.full_version) >= Version("3.3.0"):
+                data["a_terminations"] = [
+                    {
+                        "object_id": data.pop("termination_a_id"),
+                        "object_type": data.pop("termination_a_type"),
+                    }
+                ]
+                data["b_terminations"] = [
+                    {
+                        "object_id": data.pop("termination_b_id"),
+                        "object_type": data.pop("termination_b_type"),
+                    }
+                ]
         else:
             object_query_params = self._build_query_params(
                 endpoint_name, data, user_query_params


### PR DESCRIPTION
## Related Issue

[#927](https://github.com/netbox-community/ansible_modules/issues/927)

## New Behavior

Fields termination_a_id, termination_a_type, termination_b_id and termination_b_type will be converted into a_terminations and b_terminations lists for Netbox v3.3+

## Contrast to Current Behavior

The cable module will work in the Netbox v3.3+ in the same way it used to in previous versions

## Discussion: Benefits and Drawbacks

* The cable module will be backward compatible including idempotency.
* Many to many cable connections is not implemented and requires future development.

## Changes to the Documentation

Documentation changes are not required.

## Proposed Release Note Entry

Fixed cable module compatibility with Netbox v3.3+

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.