### PR TITLE
Feature: Added module for FHRP groups

### DIFF
--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -20,6 +20,7 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
 
 NB_AGGREGATES = "aggregates"
 NB_ASNS = "asns"
+NB_FHRP_GROUPS = "fhrp_groups"
 NB_IP_ADDRESSES = "ip_addresses"
 NB_PREFIXES = "prefixes"
 NB_IPAM_ROLES = "roles"
@@ -150,6 +151,7 @@ class NetboxIpamModule(NetboxModule):
         Supported endpoints:
         - aggregates
         - asns
+        - fhrp_groups
         - ipam_roles
         - ip_addresses
         - l2vpns
@@ -186,6 +188,8 @@ class NetboxIpamModule(NetboxModule):
             name = data.get("prefix")
         elif self.endpoint == "asns":
             name = data.get("asn")
+        elif self.endpoint == "fhrp_groups":
+            name = data.get("group_id")
         else:
             name = data.get("name")
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -87,6 +87,7 @@ API_APPS_ENDPOINTS = dict(
     ipam=[
         "aggregates",
         "asns",
+        "fhrp_groups",
         "ip_addresses",
         "l2vpns",
         "l2vpn_terminations",
@@ -130,6 +131,7 @@ QUERY_TYPES = dict(
     device_type="slug",
     export_targets="name",
     export_template="name",
+    fhrp_groups="group_id",
     group="slug",
     installed_device="name",
     inventory_item_role="name",
@@ -313,6 +315,7 @@ ENDPOINT_NAME_MAPPING = {
     "device_roles": "device_role",
     "device_types": "device_type",
     "export_templates": "export_template",
+    "fhrp_groups": "fhrp_group",
     "front_ports": "front_port",
     "front_port_templates": "front_port_template",
     "interfaces": "interface",
@@ -413,6 +416,9 @@ ALLOWED_QUERY_PARAMS = {
     "device_role": set(["slug"]),
     "device_type": set(["slug"]),
     "export_template": set(["name"]),
+    "fhrp_group": set(
+        ["id", "group_id", "interface_type", "device", "virtual_machine"]
+    ),
     "front_port": set(["name", "device", "rear_port"]),
     "front_port_template": set(["name", "device_type", "rear_port"]),
     "installed_device": set(["name"]),

--- a/plugins/modules/netbox_fhrp_group.py
+++ b/plugins/modules/netbox_fhrp_group.py
@@ -1,0 +1,172 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, Andrii Konts (@andrii-konts) <andrew.konts@uk2group.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: netbox_fhrp_group
+short_description: Create, update or delete FHRP groups within NetBox
+description:
+  - Creates, updates or removes FHRP groups from NetBox
+notes:
+  - Tags should be defined as a YAML list
+  - This should be ran with connection C(local) and hosts C(localhost)
+author:
+  - Andrii Konts (@andrii-konts)
+requirements:
+  - pynetbox
+version_added: '3.12.0'
+extends_documentation_fragment:
+  - netbox.netbox.common
+options:
+  data:
+    type: dict
+    description:
+      - Defines the FHRP group configuration
+    suboptions:
+      protocol:
+        description:
+          - Protocol
+        required: False
+        type: str
+        choices:
+          - vrrp2
+          - vrrp3
+          - carp
+          - clusterxl
+          - hsrp
+          - glbp
+          - other
+      group_id:
+        description:
+          - Group ID (0 .. 32767)
+        type: int
+        required: true
+      auth_type:
+        description:
+          - Authentication type
+        choices:
+          - plaintext
+          - md5
+        type: str
+      auth_key:
+        description:
+          - Authentication key (max length 255)
+        type: str
+      description:
+        description:
+          - Description (max length 200)
+        required: false
+        type: str
+      tags:
+        description:
+          - Any tags that the FHRP group may need to be associated with
+        required: false
+        type: list
+        elements: raw
+      custom_fields:
+        description:
+          - Must exist in NetBox
+        required: false
+        type: dict
+    required: true
+"""
+
+EXAMPLES = r"""
+- name: "Test NetBox modules"
+  connection: local
+  hosts: localhost
+  gather_facts: False
+
+  tasks:
+    - name: "Create FHRP group within netbox"
+      netbox_fhrp_group:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          protocol: "glbp"
+          group_id: 111
+          auth_type: md5
+          auth_key: 11111
+          description: test FHRP group
+        state: present
+
+    - name: Delete FHRP group within netbox
+      netbox_fhrp_group:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          group_id: 111
+        state: absent
+
+"""
+
+RETURN = r"""
+fhrp_group:
+  description: Serialized object as created or already existent within NetBox
+  returned: success (when I(state=present))
+  type: dict
+msg:
+  description: Message indicating failure or info about what has been achieved
+  returned: always
+  type: str
+"""
+
+from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import (
+    NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
+)
+from ansible_collections.netbox.netbox.plugins.module_utils.netbox_ipam import (
+    NetboxIpamModule,
+    NB_FHRP_GROUPS,
+)
+
+from copy import deepcopy
+
+
+def main():
+    """
+    Main entry point for module execution
+    """
+    argument_spec = deepcopy(NETBOX_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    protocol=dict(
+                        type="str",
+                        choices=[
+                            "vrrp2",
+                            "vrrp3",
+                            "carp",
+                            "clusterxl",
+                            "hsrp",
+                            "glbp",
+                            "other",
+                        ],
+                    ),
+                    group_id=dict(required=True, type="int"),
+                    auth_type=dict(type="str", choices=["plaintext", "md5"]),
+                    auth_key=dict(type="str", no_log=True),
+                    description=dict(type="str"),
+                    tags=dict(required=False, type="list", elements="raw"),
+                    custom_fields=dict(required=False, type="dict"),
+                ),
+            ),
+        )
+    )
+    required_if = [("state", "present", ["protocol"])]
+    module = NetboxAnsibleModule(argument_spec=argument_spec, required_if=required_if)
+    netbox_fhrp_group = NetboxIpamModule(module, NB_FHRP_GROUPS)
+    netbox_fhrp_group.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/netbox_fhrp_group.py
+++ b/plugins/modules/netbox_fhrp_group.py
@@ -82,7 +82,7 @@ options:
 """
 
 EXAMPLES = r"""
-- hosts: "localhost"
+- hosts: localhost
   connection: local
   module_defaults:
     group/netbox.netbox.netbox:

--- a/plugins/modules/netbox_fhrp_group.py
+++ b/plugins/modules/netbox_fhrp_group.py
@@ -20,6 +20,10 @@ author:
   - Andrii Konts (@andrii-konts)
 requirements:
   - pynetbox
+seealso:
+  - name: FHRP Group Model reference
+    description: NetBox Documentation for FHRP Group Model.
+    link: https://docs.netbox.dev/en/stable/models/ipam/fhrpgroup/
 version_added: '3.12.0'
 extends_documentation_fragment:
   - netbox.netbox.common
@@ -78,16 +82,16 @@ options:
 """
 
 EXAMPLES = r"""
-- name: "Test NetBox modules"
+- hosts: "localhost"
   connection: local
-  hosts: localhost
-  gather_facts: False
+  module_defaults:
+    group/netbox.netbox.netbox:
+      netbox_url: "http://netbox.local"
+      netbox_token: "thisIsMyToken"
 
   tasks:
     - name: "Create FHRP group within netbox"
-      netbox_fhrp_group:
-        netbox_url: http://netbox.local
-        netbox_token: thisIsMyToken
+      netbox.netbox.netbox_fhrp_group:
         data:
           protocol: "glbp"
           group_id: 111
@@ -97,13 +101,10 @@ EXAMPLES = r"""
         state: present
 
     - name: Delete FHRP group within netbox
-      netbox_fhrp_group:
-        netbox_url: http://netbox.local
-        netbox_token: thisIsMyToken
+      netbox.netbox.netbox_fhrp_group:
         data:
           group_id: 111
         state: absent
-
 """
 
 RETURN = r"""

--- a/tests/integration/targets/v3.2/tasks/main.yml
+++ b/tests/integration/targets/v3.2/tasks/main.yml
@@ -238,3 +238,6 @@
 
 - name: "NETBOX_ASN TESTS"
   include_tasks: "netbox_asn.yml"
+
+- name: "NETBOX_FHRP_GROUP TESTS"
+  include_tasks: "netbox_fhrp_group.yml"

--- a/tests/integration/targets/v3.2/tasks/netbox_fhrp_group.yml
+++ b/tests/integration/targets/v3.2/tasks/netbox_fhrp_group.yml
@@ -1,0 +1,91 @@
+---
+##
+##
+### NETBOX_FHRP_GROUP
+##
+##
+- name: "FHRP group 1: Test FHRP group creation"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+    state: present
+  register: test_one
+
+- name: "FHRP group: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['fhrp_group']['group_id'] == 111
+      - test_one['fhrp_group']['protocol'] == "glbp"
+      - test_one['msg'] == "fhrp_group 111 created"
+
+- name: "FHRP group 2: Create duplicate"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+    state: present
+  register: test_two
+
+- name: "FHRP group 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['fhrp_group']['group_id'] == 111
+      - test_two['fhrp_group']['protocol'] == "glbp"
+      - test_two['msg'] == "fhrp_group 111 already exists"
+
+- name: "FHRP group 3: Update FHRP group with other fields"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+      auth_type: md5
+      auth_key: 11111
+      description: Test description
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_three
+
+- name: "FHRP group 3: ASSERT - Update FHRP group with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['auth_type'] == "md5"
+      - test_three['diff']['after']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['fhrp_group']['group_id'] == 111
+      - test_three['fhrp_group']['protocol'] == "glbp"
+      - test_three['fhrp_group']['auth_type'] == "md5"
+      - test_three['fhrp_group']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['fhrp_group']['description'] == "Test description"
+      - test_three['fhrp_group']['tags'][0] == 4
+      - test_three['msg'] == "fhrp_group 111 updated"
+
+- name: "FHRP group 4: ASSERT - Delete"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      group_id: 111
+    state: absent
+  register: test_four
+
+- name: "FHRP group 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "fhrp_group 111 deleted"

--- a/tests/integration/targets/v3.3/tasks/main.yml
+++ b/tests/integration/targets/v3.3/tasks/main.yml
@@ -267,3 +267,6 @@
 
 - name: "NETBOX_ASN TESTS"
   include_tasks: "netbox_asn.yml"
+
+- name: "NETBOX_FHRP_GROUP TESTS"
+  include_tasks: "netbox_fhrp_group.yml"

--- a/tests/integration/targets/v3.3/tasks/netbox_fhrp_group.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_fhrp_group.yml
@@ -1,0 +1,91 @@
+---
+##
+##
+### NETBOX_FHRP_GROUP
+##
+##
+- name: "FHRP group 1: Test FHRP group creation"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+    state: present
+  register: test_one
+
+- name: "FHRP group: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['fhrp_group']['group_id'] == 111
+      - test_one['fhrp_group']['protocol'] == "glbp"
+      - test_one['msg'] == "fhrp_group 111 created"
+
+- name: "FHRP group 2: Create duplicate"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+    state: present
+  register: test_two
+
+- name: "FHRP group 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['fhrp_group']['group_id'] == 111
+      - test_two['fhrp_group']['protocol'] == "glbp"
+      - test_two['msg'] == "fhrp_group 111 already exists"
+
+- name: "FHRP group 3: Update FHRP group with other fields"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+      auth_type: md5
+      auth_key: 11111
+      description: Test description
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_three
+
+- name: "FHRP group 3: ASSERT - Update FHRP group with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['auth_type'] == "md5"
+      - test_three['diff']['after']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['fhrp_group']['group_id'] == 111
+      - test_three['fhrp_group']['protocol'] == "glbp"
+      - test_three['fhrp_group']['auth_type'] == "md5"
+      - test_three['fhrp_group']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['fhrp_group']['description'] == "Test description"
+      - test_three['fhrp_group']['tags'][0] == 4
+      - test_three['msg'] == "fhrp_group 111 updated"
+
+- name: "FHRP group 4: ASSERT - Delete"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      group_id: 111
+    state: absent
+  register: test_four
+
+- name: "FHRP group 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "fhrp_group 111 deleted"

--- a/tests/integration/targets/v3.4/tasks/main.yml
+++ b/tests/integration/targets/v3.4/tasks/main.yml
@@ -276,3 +276,6 @@
 
 - name: "NETBOX_ASN TESTS"
   include_tasks: "netbox_asn.yml"
+
+- name: "NETBOX_FHRP_GROUP TESTS"
+  include_tasks: "netbox_fhrp_group.yml"

--- a/tests/integration/targets/v3.4/tasks/netbox_fhrp_group.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_fhrp_group.yml
@@ -1,0 +1,91 @@
+---
+##
+##
+### NETBOX_FHRP_GROUP
+##
+##
+- name: "FHRP group 1: Test FHRP group creation"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+    state: present
+  register: test_one
+
+- name: "FHRP group: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['fhrp_group']['group_id'] == 111
+      - test_one['fhrp_group']['protocol'] == "glbp"
+      - test_one['msg'] == "fhrp_group 111 created"
+
+- name: "FHRP group 2: Create duplicate"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+    state: present
+  register: test_two
+
+- name: "FHRP group 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['fhrp_group']['group_id'] == 111
+      - test_two['fhrp_group']['protocol'] == "glbp"
+      - test_two['msg'] == "fhrp_group 111 already exists"
+
+- name: "FHRP group 3: Update FHRP group with other fields"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      protocol: "glbp"
+      group_id: 111
+      auth_type: md5
+      auth_key: 11111
+      description: Test description
+      tags:
+        - "Schnozzberry"
+    state: present
+  register: test_three
+
+- name: "FHRP group 3: ASSERT - Update FHRP group with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['auth_type'] == "md5"
+      - test_three['diff']['after']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['fhrp_group']['group_id'] == 111
+      - test_three['fhrp_group']['protocol'] == "glbp"
+      - test_three['fhrp_group']['auth_type'] == "md5"
+      - test_three['fhrp_group']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['fhrp_group']['description'] == "Test description"
+      - test_three['fhrp_group']['tags'][0] == 4
+      - test_three['msg'] == "fhrp_group 111 updated"
+
+- name: "FHRP group 4: ASSERT - Delete"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      group_id: 111
+    state: absent
+  register: test_four
+
+- name: "FHRP group 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "fhrp_group 111 deleted"


### PR DESCRIPTION
## New Behavior

Added module for FHRP groups

## Contrast to Current Behavior

- The ability to add, update or delete FHRP groups using ansible modules.
- Added tests for netbox_fhrp_group

## Proposed Release Note Entry

netbox.netbox.netbox_fhrp_group - Create, update or delete FHRP groups in NetBox

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
