### PR TITLE
Fix 958: Location filter

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -435,7 +435,7 @@ ALLOWED_QUERY_PARAMS = {
     ),
     "l2vpn": set(["name"]),
     "lag": set(["name"]),
-    "location": set(["slug"]),
+    "location": set(["slug", "site"]),
     "module_type": set(["model"]),
     "manufacturer": set(["slug"]),
     "master": set(["name"]),

--- a/tests/integration/targets/regression-v3.4/tasks/main.yml
+++ b/tests/integration/targets/regression-v3.4/tasks/main.yml
@@ -264,3 +264,20 @@
         that:
           - test_results | community.general.json_query('results[?ip_address.address==`1.121.121.121/32`]') | length == 2
           - test_results | community.general.json_query('results[?ip_address.address==`121.121.121.121/32`]') | length == 2
+    
+    - name: "Issue #958 - Make sure we can add same location with different sites"
+      netbox.netbox.netbox_location:
+        netbox_url: "http://localhost:32768"
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data: 
+          name: Office Building
+          site: "{{ item }}"
+      loop:
+        - Test Site
+        - Test Site2
+      register: test_results
+
+    - name: "ASSERT ISSUE #957 - Location has different IDs"
+      ansible.builtin.assert:
+        that:
+          - test_results.results.0.location.id != test_results.results.1.location.id


### PR DESCRIPTION
# Fix #958
Add site as a possible filter when creating a location. You can now create a location named the same in two different sites.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
