### PR TITLE
Add name as filter to location

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -437,7 +437,7 @@ ALLOWED_QUERY_PARAMS = {
     ),
     "l2vpn": set(["name"]),
     "lag": set(["name"]),
-    "location": set(["slug", "site"]),
+    "location": set(["name", "slug", "site"]),
     "module_type": set(["model"]),
     "manufacturer": set(["slug"]),
     "master": set(["name"]),

--- a/plugins/modules/netbox_aggregate.py
+++ b/plugins/modules/netbox_aggregate.py
@@ -55,6 +55,12 @@ options:
         required: false
         type: str
         version_added: "3.10.0"
+      tenant:
+        description:
+          - Tenant the aggregate will be assigned to.
+        required: false
+        type: raw
+        version_added: "3.12.0"
       tags:
         description:
           - "Any tags that the aggregate may need to be associated with"
@@ -145,6 +151,7 @@ def main():
                     date_added=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     comments=dict(required=False, type="str"),
+                    tenant=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
                 ),


### PR DESCRIPTION
## Related Issue #964 

## New Behavior

Enable the use of `name` in location filter. Example:

```
netbox_rack:
  data:
    name: Rack One
    site: site1
    location:
      name: Office Building
      site: site1
```

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
