### PR TITLE
Fix: NetBox v3.4 test inventory

### DIFF
--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-jinja2-filter.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-jinja2-filter.json
@@ -610,13 +610,367 @@
                 "tags": [],
                 "serial": "FAB01234567",
                 "asset_tag": "123456789"
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "enabled": true,
+                        "id": 7,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "enabled": true,
+                        "id": 9,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
             }
         }
     },
     "all": {
         "children": [
+            "cluster_Test_Cluster",
+            "cluster_group_test_cluster_group",
+            "cluster_type_test_cluster_type",
             "device_type_cisco_test",
             "device_type_nexus_parent",
+            "is_virtual",
             "manufacturer_cisco",
             "rack_Test_Rack",
             "region_other_region",
@@ -630,6 +984,38 @@
             "site_test_site2",
             "status_active",
             "ungrouped"
+        ]
+    },
+    "cluster_Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_group_test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_type_test_cluster_type": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
         ]
     },
     "device_type_cisco_test": {
@@ -705,6 +1091,12 @@
         ]
     },
     "site_test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],        
         "children": [
             "location_parent_rack_group"
         ]
@@ -713,7 +1105,11 @@
         "hosts": [
             "Test Nexus One",
             "TestDeviceR1",
-            "test100"
+            "test100",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-jinja2.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-jinja2.json
@@ -147,7 +147,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -162,7 +166,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -177,7 +185,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -192,7 +204,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -349,6 +365,12 @@
         ]
     },
     "test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],
         "children": [
             "parent_rack_group"
         ]

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-legacy.json
@@ -286,8 +286,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -305,8 +311,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -324,8 +336,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -343,8 +361,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-noracks.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-noracks.json
@@ -911,8 +911,14 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1064,8 +1070,14 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1086,8 +1098,14 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1108,8 +1126,14 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1258,6 +1282,12 @@
         ]
     },
     "sites_test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],
         "children": [
             "location_parent_rack_group"
         ]

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-options-flatten.json
@@ -874,8 +874,12 @@
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1021,8 +1025,12 @@
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1037,8 +1045,12 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1053,8 +1065,12 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1205,6 +1221,12 @@
         ]
     },
     "test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],
         "children": [
             "parent_rack_group"
         ]

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-options.json
@@ -147,7 +147,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -162,7 +166,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -177,7 +185,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -192,7 +204,11 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -349,6 +365,12 @@
         ]
     },
     "test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],
         "children": [
             "parent_rack_group"
         ]

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-plurals-flatten.json
@@ -194,7 +194,13 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -211,7 +217,13 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -228,7 +240,13 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -245,7 +263,13 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -397,6 +421,12 @@
         ]
     },
     "test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],
         "children": [
             "parent_rack_group"
         ]

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory-plurals.json
@@ -933,8 +933,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1087,8 +1093,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1110,8 +1122,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1133,8 +1151,14 @@
                     null
                 ],
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "sites": [
+                    "test-site"
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1302,6 +1326,12 @@
         ]
     },
     "sites_test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],
         "children": [
             "location_parent_rack_group"
         ]

--- a/tests/integration/targets/inventory-v3.4/files/test-inventory.json
+++ b/tests/integration/targets/inventory-v3.4/files/test-inventory.json
@@ -868,8 +868,12 @@
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1017,8 +1021,12 @@
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1035,8 +1043,12 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1053,8 +1065,12 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
                 "services": [],
+                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1236,6 +1252,12 @@
         ]
     },
     "site_test_site": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ],
         "children": [
             "location_parent_rack_group"
         ]


### PR DESCRIPTION
## Related Issue

#991

## New Behavior

Fix: NetBox v3.4 test inventory

## Contrast to Current Behavior

Tests for NetBox v3.4 have been failing because compare_inventory_json.py returning error that inventories do not match.
This PR fixes the issue.

## Double Check
* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
