### PR TITLE
netbox_custom_field: add datetime type

### DIFF
--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -45,6 +45,7 @@ options:
           - decimal
           - boolean
           - date
+          - datetime
           - url
           - json
           - select
@@ -223,6 +224,7 @@ def main():
                             "decimal",
                             "boolean",
                             "date",
+                            "datetime",
                             "url",
                             "json",
                             "select",


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->
Fixes #1018 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->
Add `datetime` as `type` in `netbox_custom_field`.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->
The `datetime` type that was added in NetBox 3.5 should be supported in this module as well.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
Bring feature parity to the Ansible module.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->
The module doc was updated.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
Feature: support datetime as custom_field type

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
