### PR TITLE
add tenant to netbox_cable

### DIFF
--- a/plugins/modules/netbox_cable.py
+++ b/plugins/modules/netbox_cable.py
@@ -155,6 +155,12 @@ options:
         required: false
         type: dict
         version_added: "3.6.0"
+      tenant:
+        description:
+          - Tenant who the cable will be assigned to
+        required: false
+        type: raw
+        version_added: "3.13.0"
 """
 
 EXAMPLES = r"""
@@ -324,6 +330,7 @@ def main():
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
+                    tenant=dict(required=False, type="raw"),
                 ),
             ),
         )

--- a/tests/integration/targets/v3.3/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_cable.yml
@@ -82,6 +82,7 @@
       length_unit: m
       tags:
         - "Schnozzberry"
+      tenant: "Test Tenant"
     state: present
   register: test_three
 
@@ -96,6 +97,7 @@
       - test_three['diff']['after']['length'] == 30
       - test_three['diff']['after']['length_unit'] == "m"
       - test_three['diff']['after']['tags'][0] == 4
+      - test_three['diff']['after']['tenant'] == 1
       - test_three['cable']['termination_a_type'] == "dcim.interface"
       - test_three['cable']['termination_a_id'] == 15
       - test_three['cable']['termination_b_type'] == "dcim.interface"
@@ -107,6 +109,7 @@
       - test_three['cable']['length'] == 30
       - test_three['cable']['length_unit'] == "m"
       - test_three['cable']['tags'][0] == 4
+      - test_three['cable']['tenant'] == 1
       - test_three['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 updated"
 
 - name: "CABLE 4: ASSERT - Delete"

--- a/tests/integration/targets/v3.4/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_cable.yml
@@ -82,6 +82,7 @@
       length_unit: m
       tags:
         - "Schnozzberry"
+      tenant: "Test Tenant"
     state: present
   register: test_three
 
@@ -96,6 +97,7 @@
       - test_three['diff']['after']['length'] == 30
       - test_three['diff']['after']['length_unit'] == "m"
       - test_three['diff']['after']['tags'][0] == 4
+      - test_three['diff']['after']['tenant'] == 1
       - test_three['cable']['termination_a_type'] == "dcim.interface"
       - test_three['cable']['termination_a_id'] == 15
       - test_three['cable']['termination_b_type'] == "dcim.interface"
@@ -107,6 +109,7 @@
       - test_three['cable']['length'] == 30
       - test_three['cable']['length_unit'] == "m"
       - test_three['cable']['tags'][0] == 4
+      - test_three['cable']['tenant'] == 1
       - test_three['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 updated"
 
 - name: "CABLE 4: ASSERT - Delete"

--- a/tests/integration/targets/v3.5/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_cable.yml
@@ -82,6 +82,7 @@
       length_unit: m
       tags:
         - "Schnozzberry"
+      tenant: "Test Tenant"
     state: present
   register: test_three
 
@@ -96,6 +97,7 @@
       - test_three['diff']['after']['length'] == 30
       - test_three['diff']['after']['length_unit'] == "m"
       - test_three['diff']['after']['tags'][0] == 4
+      - test_three['diff']['after']['tenant'] == 1
       - test_three['cable']['termination_a_type'] == "dcim.interface"
       - test_three['cable']['termination_a_id'] == 15
       - test_three['cable']['termination_b_type'] == "dcim.interface"
@@ -107,6 +109,7 @@
       - test_three['cable']['length'] == 30
       - test_three['cable']['length_unit'] == "m"
       - test_three['cable']['tags'][0] == 4
+      - test_three['cable']['tenant'] == 1
       - test_three['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 updated"
 
 - name: "CABLE 4: ASSERT - Delete"


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1026 


## New Behavior

It would be possible to include a tenant parameter when using the module, e.g.
```
  tasks:
    - name: Create cable within NetBox with only required information
      netbox.netbox.netbox_cable:
        netbox_url: http://netbox.local
        netbox_token: thisIsMyToken
        data:
          tenant: tenant-slug
          termination_a_type: dcim.interface
          termination_a:
            device: Test Nexus Child One
            name: Ethernet2/2
          termination_b_type: dcim.interface
          termination_b:
            device: Test Nexus Child One
            name: Ethernet2/1
        state: present

```

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->
Currently rejected, "unsupported parameters for (netbox.netbox.netbox_cable) module: data.tenant."


## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Users of this module could set the tenant without resorting to the UI.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

Parameter documentation should be included in PR.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

add optional parameter tenant to netbox_cable

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
