### PR TITLE
Fix bug in nb_lookup if api_filter contains multiple `id`

### DIFF
--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -439,7 +439,7 @@ class LookupModule(LookupBase):
             if netbox_api_filter:
                 filter = build_filters(netbox_api_filter)
 
-                if "id" in filter:
+                if "id" in filter and len(filter["id"]) == 1:
                     Display().vvvv(
                         "Filter is: %s and includes id, will use .get instead of .filter"
                         % (filter)


### PR DESCRIPTION
## Related Issue

 - #370
 - #376

## New Behavior

In the `nb_lookup` plugin, when supplying multiple `id` fields to the `api_filter` parameter, it will return a list of items.

## Contrast to Current Behavior

In the `nb_lookup` plugin, if we provide an `api_filter` containing the `id` field, it will use `.get()` instead of `.filter()`, thus returning the item instead of a list. See PR #376 for more information.

This is fine if you supply only one id. But let's say you want to get a list of items by ids?

For example: `id=1 id=5`

I would expect to get a list of 2 items. But at the moment, it will return the first item only.

This change adds a simple check to see if we're supplying multiple ids.

## Discussion: Benefits and Drawbacks

This fixes a bug where supplying multiple ids in the `api_filter` ends up returning only one item.

In fact, I'd even expect that supplying a single id would return a list of one item, since we're querying a collection. So maybe a `many=True|False` parameter would be better?

This bugfix as it is is backward-compatible.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
