### PR TITLE
Adds hidden-ifunset option to ui_visibility argument of custom_fields

### DIFF
--- a/docs/plugins/netbox_custom_field_module.rst
+++ b/docs/plugins/netbox_custom_field_module.rst
@@ -655,6 +655,7 @@ Parameters
       - :ansible-option-choices-entry:`"read-write"`
       - :ansible-option-choices-entry:`"read-only"`
       - :ansible-option-choices-entry:`"hidden"`
+      - :ansible-option-choices-entry:`"hidden-ifunset"`
 
 
       .. raw:: html

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -114,6 +114,7 @@ options:
            - read-write
            - read-only
            - hidden
+           - hidden-ifunset
          type: str      
          version_added: "3.10.0"
       validation_minimum:
@@ -250,6 +251,7 @@ def main():
                             "read-write",
                             "read-only",
                             "hidden",
+                            "hidden-ifunset",
                         ],
                         type="str",
                     ),

--- a/tests/integration/targets/v3.5/tasks/netbox_custom_field.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_custom_field.yml
@@ -106,3 +106,23 @@
       - test_five['diff']['after']['state'] == "absent"
       - test_five['custom_field']['name'] == "A_CustomField"
       - test_five['msg'] == "custom_field A_CustomField deleted"
+
+- name: "CUSTOM_FIELD 6: UI Visibility (hidden-ifunset)"
+  netbox.netbox.netbox_custom_field:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      content_types:
+        - "dcim.device"
+      name: A_CustomField
+      type: text
+      ui_visibility: hidden-ifunset
+    state: present
+  register: test_six
+
+- name: "CUSTOM_FIELD 6: UI Visibility (hidden-ifunset)"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['custom_field']['name'] == "A_CustomField"
+      - test_six['custom_field']['ui_visibility'] == "hidden-ifunset"


### PR DESCRIPTION
## Related Issue

#1045 

## New Behavior

This adds the `hidden-ifunset` option to the `ui_visibility` argument of the custom_fields module.

...

## Contrast to Current Behavior

The current version of the custom_fields module does not allow users to create custom fields with their UI visibility set to "Hidden (if unset)" which is a valid option in the current version of NetBox.

...

## Discussion: Benefits and Drawbacks

- This change is backward-compatible.
- This change will allow users to make full use of the UI visibility options available in the current version of NetBox.

...

## Changes to the Documentation

The docs have been updated in this file [docs/plugins/netbox_custom_field_module.rst](https://github.com/netbox-community/ansible_modules/compare/devel...aaron-iles:feature/1045-hidden-ifunset?expand=1#diff-5382d74858449f3904d8570b5bf117c7bf5c9d2bf356e3133cc7e9a3b636ea8a)

...

## Proposed Release Note Entry

- Adds `hidden-ifunset` option to `ui_visibility` argument of custom_fields

...

## Double Check


* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
