### PR TITLE
Add missing power port options

### DIFF
--- a/plugins/modules/netbox_power_port.py
+++ b/plugins/modules/netbox_power_port.py
@@ -50,6 +50,7 @@ options:
           - iec-60320-c14
           - iec-60320-c16
           - iec-60320-c20
+          - iec-60320-c22
           - iec-60309-p-n-e-4h
           - iec-60309-p-n-e-6h
           - iec-60309-p-n-e-9h
@@ -62,6 +63,10 @@ options:
           - iec-60309-3p-n-e-4h
           - iec-60309-3p-n-e-6h
           - iec-60309-3p-n-e-9h
+          - iec-60906-1
+          - nbr-14136-10a
+          - nbr-14136-20a
+          - nema-1-15p
           - nema-5-15p
           - nema-5-20p
           - nema-5-30p
@@ -70,23 +75,45 @@ options:
           - nema-6-20p
           - nema-6-30p
           - nema-6-50p
+          - nema-10-30p
+          - nema-10-50p
+          - nema-14-20p
+          - nema-14-30p
+          - nema-14-50p
+          - nema-14-60p
+          - nema-15-15p
+          - nema-15-20p
+          - nema-15-30p
+          - nema-15-50p
+          - nema-15-60p
+          - nema-l1-15p
           - nema-l5-15p
           - nema-l5-20p
           - nema-l5-30p
           - nema-l5-50p
+          - nema-l6-15p
           - nema-l6-20p
           - nema-l6-30p
           - nema-l6-50p
+          - nema-l10-30p
           - nema-l14-20p
           - nema-l14-30p
+          - nema-l14-50p
+          - nema-l14-60p
+          - nema-l15-20p
+          - nema-l15-30p
+          - nema-l15-50p
+          - nema-l15-60p
           - nema-l21-20p
           - nema-l21-30p
+          - nema-l22-30p
           - cs6361c
           - cs6365c
           - cs8165c
           - cs8265c
           - cs8365c
           - cs8465c
+          - ita-c
           - ita-e
           - ita-f
           - ita-ef
@@ -99,6 +126,25 @@ options:
           - ita-m
           - ita-n
           - ita-o
+          - usb-a
+          - usb-b
+          - usb-c
+          - usb-mini-a
+          - usb-mini-b
+          - usb-micro-a
+          - usb-micro-b
+          - usb-micro-ab
+          - usb-3-b
+          - usb-3-micro-b
+          - dc-terminal
+          - saf-d-grid
+          - neutrik-powercon-20
+          - neutrik-powercon-32
+          - neutrik-powercon-true1
+          - neutrik-powercon-true1-top
+          - ubiquiti-smartpower
+          - hardwired
+          - other
         required: false
         type: str
       allocated_draw:
@@ -206,6 +252,7 @@ def main():
                             "iec-60320-c14",
                             "iec-60320-c16",
                             "iec-60320-c20",
+                            "iec-60320-c22",
                             "iec-60309-p-n-e-4h",
                             "iec-60309-p-n-e-6h",
                             "iec-60309-p-n-e-9h",
@@ -218,6 +265,10 @@ def main():
                             "iec-60309-3p-n-e-4h",
                             "iec-60309-3p-n-e-6h",
                             "iec-60309-3p-n-e-9h",
+                            "iec-60906-1",
+                            "nbr-14136-10a",
+                            "nbr-14136-20a",
+                            "nema-1-15p",
                             "nema-5-15p",
                             "nema-5-20p",
                             "nema-5-30p",
@@ -226,23 +277,45 @@ def main():
                             "nema-6-20p",
                             "nema-6-30p",
                             "nema-6-50p",
+                            "nema-10-30p",
+                            "nema-10-50p",
+                            "nema-14-20p",
+                            "nema-14-30p",
+                            "nema-14-50p",
+                            "nema-14-60p",
+                            "nema-15-15p",
+                            "nema-15-20p",
+                            "nema-15-30p",
+                            "nema-15-50p",
+                            "nema-15-60p",
+                            "nema-l1-15p",
                             "nema-l5-15p",
                             "nema-l5-20p",
                             "nema-l5-30p",
                             "nema-l5-50p",
+                            "nema-l6-15p",
                             "nema-l6-20p",
                             "nema-l6-30p",
                             "nema-l6-50p",
+                            "nema-l10-30p",
                             "nema-l14-20p",
                             "nema-l14-30p",
+                            "nema-l14-50p",
+                            "nema-l14-60p",
+                            "nema-l15-20p",
+                            "nema-l15-30p",
+                            "nema-l15-50p",
+                            "nema-l15-60p",
                             "nema-l21-20p",
                             "nema-l21-30p",
+                            "nema-l22-30p",
                             "cs6361c",
                             "cs6365c",
                             "cs8165c",
                             "cs8265c",
                             "cs8365c",
                             "cs8465c",
+                            "ita-c",
                             "ita-e",
                             "ita-f",
                             "ita-ef",
@@ -255,6 +328,25 @@ def main():
                             "ita-m",
                             "ita-n",
                             "ita-o",
+                            "usb-a",
+                            "usb-b",
+                            "usb-c",
+                            "usb-mini-a",
+                            "usb-mini-b",
+                            "usb-micro-a",
+                            "usb-micro-b",
+                            "usb-micro-ab",
+                            "usb-3-b",
+                            "usb-3-micro-b",
+                            "dc-terminal",
+                            "saf-d-grid",
+                            "neutrik-powercon-20",
+                            "neutrik-powercon-32",
+                            "neutrik-powercon-true1",
+                            "neutrik-powercon-true1-top",
+                            "ubiquiti-smartpower",
+                            "hardwired",
+                            "other",
                         ],
                         type="str",
                     ),

--- a/plugins/modules/netbox_power_port_template.py
+++ b/plugins/modules/netbox_power_port_template.py
@@ -50,6 +50,7 @@ options:
           - iec-60320-c14
           - iec-60320-c16
           - iec-60320-c20
+          - iec-60320-c22
           - iec-60309-p-n-e-4h
           - iec-60309-p-n-e-6h
           - iec-60309-p-n-e-9h
@@ -62,6 +63,10 @@ options:
           - iec-60309-3p-n-e-4h
           - iec-60309-3p-n-e-6h
           - iec-60309-3p-n-e-9h
+          - iec-60906-1
+          - nbr-14136-10a
+          - nbr-14136-20a
+          - nema-1-15p
           - nema-5-15p
           - nema-5-20p
           - nema-5-30p
@@ -70,23 +75,45 @@ options:
           - nema-6-20p
           - nema-6-30p
           - nema-6-50p
+          - nema-10-30p
+          - nema-10-50p
+          - nema-14-20p
+          - nema-14-30p
+          - nema-14-50p
+          - nema-14-60p
+          - nema-15-15p
+          - nema-15-20p
+          - nema-15-30p
+          - nema-15-50p
+          - nema-15-60p
+          - nema-l1-15p
           - nema-l5-15p
           - nema-l5-20p
           - nema-l5-30p
           - nema-l5-50p
+          - nema-l6-15p
           - nema-l6-20p
           - nema-l6-30p
           - nema-l6-50p
+          - nema-l10-30p
           - nema-l14-20p
           - nema-l14-30p
+          - nema-l14-50p
+          - nema-l14-60p
+          - nema-l15-20p
+          - nema-l15-30p
+          - nema-l15-50p
+          - nema-l15-60p
           - nema-l21-20p
           - nema-l21-30p
+          - nema-l22-30p
           - cs6361c
           - cs6365c
           - cs8165c
           - cs8265c
           - cs8365c
           - cs8465c
+          - ita-c
           - ita-e
           - ita-f
           - ita-ef
@@ -99,6 +126,25 @@ options:
           - ita-m
           - ita-n
           - ita-o
+          - usb-a
+          - usb-b
+          - usb-c
+          - usb-mini-a
+          - usb-mini-b
+          - usb-micro-a
+          - usb-micro-b
+          - usb-micro-ab
+          - usb-3-b
+          - usb-3-micro-b
+          - dc-terminal
+          - saf-d-grid
+          - neutrik-powercon-20
+          - neutrik-powercon-32
+          - neutrik-powercon-true1
+          - neutrik-powercon-true1-top
+          - ubiquiti-smartpower
+          - hardwired
+          - other
         required: false
         type: str
       allocated_draw:
@@ -194,6 +240,7 @@ def main():
                             "iec-60320-c14",
                             "iec-60320-c16",
                             "iec-60320-c20",
+                            "iec-60320-c22",
                             "iec-60309-p-n-e-4h",
                             "iec-60309-p-n-e-6h",
                             "iec-60309-p-n-e-9h",
@@ -206,6 +253,10 @@ def main():
                             "iec-60309-3p-n-e-4h",
                             "iec-60309-3p-n-e-6h",
                             "iec-60309-3p-n-e-9h",
+                            "iec-60906-1",
+                            "nbr-14136-10a",
+                            "nbr-14136-20a",
+                            "nema-1-15p",
                             "nema-5-15p",
                             "nema-5-20p",
                             "nema-5-30p",
@@ -214,23 +265,45 @@ def main():
                             "nema-6-20p",
                             "nema-6-30p",
                             "nema-6-50p",
+                            "nema-10-30p",
+                            "nema-10-50p",
+                            "nema-14-20p",
+                            "nema-14-30p",
+                            "nema-14-50p",
+                            "nema-14-60p",
+                            "nema-15-15p",
+                            "nema-15-20p",
+                            "nema-15-30p",
+                            "nema-15-50p",
+                            "nema-15-60p",
+                            "nema-l1-15p",
                             "nema-l5-15p",
                             "nema-l5-20p",
                             "nema-l5-30p",
                             "nema-l5-50p",
+                            "nema-l6-15p",
                             "nema-l6-20p",
                             "nema-l6-30p",
                             "nema-l6-50p",
+                            "nema-l10-30p",
                             "nema-l14-20p",
                             "nema-l14-30p",
+                            "nema-l14-50p",
+                            "nema-l14-60p",
+                            "nema-l15-20p",
+                            "nema-l15-30p",
+                            "nema-l15-50p",
+                            "nema-l15-60p",
                             "nema-l21-20p",
                             "nema-l21-30p",
+                            "nema-l22-30p",
                             "cs6361c",
                             "cs6365c",
                             "cs8165c",
                             "cs8265c",
                             "cs8365c",
                             "cs8465c",
+                            "ita-c",
                             "ita-e",
                             "ita-f",
                             "ita-ef",
@@ -243,6 +316,25 @@ def main():
                             "ita-m",
                             "ita-n",
                             "ita-o",
+                            "usb-a",
+                            "usb-b",
+                            "usb-c",
+                            "usb-mini-a",
+                            "usb-mini-b",
+                            "usb-micro-a",
+                            "usb-micro-b",
+                            "usb-micro-ab",
+                            "usb-3-b",
+                            "usb-3-micro-b",
+                            "dc-terminal",
+                            "saf-d-grid",
+                            "neutrik-powercon-20",
+                            "neutrik-powercon-32",
+                            "neutrik-powercon-true1",
+                            "neutrik-powercon-true1-top",
+                            "ubiquiti-smartpower",
+                            "hardwired",
+                            "other",
                         ],
                         type="str",
                     ),


### PR DESCRIPTION
## Related Issue

[Discussion 1047](https://github.com/netbox-community/ansible_modules/discussions/1047)

## New Behavior

The power plugs support the newest options

...

## Contrast to Current Behavior

Some options were not available
...

## Discussion: Benefits and Drawbacks

Newest options will be available

...

## Changes to the Documentation



...

## Proposed Release Note Entry

Add support for the newest options for power plugs and power plugs templates
...

## Double Check


* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
