### PR TITLE
Closes #1052: Schema caching is broken

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1505,7 +1505,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         except Exception:
             openapi = {}
 
-        cached_api_version = ".".join(openapi.get("info", {}).get("version").split(".")[:2])
+        cached_api_version = ".".join(
+            openapi.get("info", {}).get("version").split(".")[:2]
+        )
 
         if netbox_api_version != cached_api_version:
             if version.parse(netbox_api_version) >= version.parse("3.5.0"):

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1505,7 +1505,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         except Exception:
             openapi = {}
 
-        cached_api_version = openapi.get("info", {}).get("version")
+        cached_api_version = ".".join(openapi.get("info", {}).get("version").split(".")[:2])
 
         if netbox_api_version != cached_api_version:
             if version.parse(netbox_api_version) >= version.parse("3.5.0"):

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1505,7 +1505,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         except Exception:
             openapi = {}
 
-        if cached_api_version := openapi.get("info", {}).get("version"):
+        cached_api_version = openapi.get("info", {}).get("version")
+        if cached_api_version:
             cached_api_version = ".".join(cached_api_version.split(".")[:2])
 
         if netbox_api_version != cached_api_version:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1505,9 +1505,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         except Exception:
             openapi = {}
 
-        cached_api_version = ".".join(
-            openapi.get("info", {}).get("version").split(".")[:2]
-        )
+        if cached_api_version := openapi.get("info", {}).get("version"):
+            cached_api_version = ".".join(cached_api_version.split(".")[:2])
 
         if netbox_api_version != cached_api_version:
             if version.parse(netbox_api_version) >= version.parse("3.5.0"):


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1052 

## New Behavior

Fix schema caching to align with intended behavior: download only once per major NetBox version.

...

## Contrast to Current Behavior

Schema caching is broken, i.e., re-fetches the (extremely large) schema on every playbook run.

...

## Discussion: Benefits and Drawbacks

The schema file is >6MB, so re-downloading it on every run is time-consuming, even on high performance networks.

...

## Changes to the Documentation

No changes, as this is fixing intended behavior.

...

## Proposed Release Note Entry

Fix API schema caching.

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
