### PR TITLE
Add facility option to group_by in Inventory Plugin

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -764,7 +764,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             return self.sites_utc_offset_lookup[host["site"]["id"]]
         except Exception:
             return
-        
+
     def extract_site_facility(self, host):
         try:
             return self.sites_facility_lookup[host["site"]["id"]]
@@ -1076,7 +1076,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 return (site["id"], site["facility"])
             except Exception:
                 return (site["id"], None)
-            
+
         # Dictionary of site id to facility (if group by facility is used)
         if "facility" in self.group_by:
             self.sites_facility_lookup = dict(map(get_facility_for_site, sites))


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1060

## New Behavior

Allows Hosts to be sorted by their site's facility data.

## Contrast to Current Behavior

Not possible.

## Discussion: Benefits and Drawbacks

Enables more options for sorting devices and objects depending on specific needs.

## Changes to the Documentation

Included in change.

## Proposed Release Note Entry

Adds "facility" option to group_by in nb_inventory plugin. This allows objects to be grouped by their site's facility data.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
