### PR TITLE
Fix device_role to role breaking change in netbox_device module

### DIFF
--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -40,7 +40,7 @@ options:
           - Required if I(state=present) and the device does not exist yet
         required: false
         type: raw
-      device_role:
+      role:
         description:
           - Required if I(state=present) and the device does not exist yet
         required: false
@@ -190,7 +190,7 @@ EXAMPLES = r"""
         data:
           name: Test Device
           device_type: C9410R
-          device_role: Core Switch
+          role: Core Switch
           site: Main
         state: present
 
@@ -201,7 +201,7 @@ EXAMPLES = r"""
         data:
           name: ""
           device_type: C9410R
-          device_role: Core Switch
+          role: Core Switch
           site: Main
         state: present
 
@@ -220,7 +220,7 @@ EXAMPLES = r"""
         data:
           name: Another Test Device
           device_type: C9410R
-          device_role: Core Switch
+          role: Core Switch
           site: Main
           local_context_data:
             bgp: "65000"
@@ -276,7 +276,7 @@ def main():
                 options=dict(
                     name=dict(required=True, type="str"),
                     device_type=dict(required=False, type="raw"),
-                    device_role=dict(required=False, type="raw"),
+                    role=dict(required=False, type="raw"),
                     tenant=dict(required=False, type="raw"),
                     platform=dict(required=False, type="raw"),
                     serial=dict(required=False, type="str"),


### PR DESCRIPTION
Updated the Ansible NetBox module to accommodate recent breaking changes in the NetBox API where `device_role` has been renamed to `role`. Also made corresponding adjustments in the pynetbox library.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

...

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ ] I have explained my PR according to the information in the comments or in a linked issue.
* [ ] My PR targets the `devel` branch.
