### PR TITLE
fix: use 'role' instead of 'device_role' with netbox >= 3.6.0 in netbox_device module

### DIFF
--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -210,6 +210,13 @@ class NetboxDcimModule(NetboxModule):
                 nb_endpoint, object_query_params, name
             )
 
+        if (
+            self.endpoint == "devices"
+            and data.get("device_role")
+            and Version(self.full_version) >= Version("3.6.0")
+        ):
+            data["role"] = data.pop("device_role")
+
         # This is logic to handle interfaces on a VC
         if self.endpoint == "interfaces" and self.nb_object:
             child = self.nb.dcim.devices.get(self.nb_object.device.id)


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

I have the same issue as what this PR was attempting to address:

https://github.com/netbox-community/ansible_modules/pull/1062

## New Behavior

When talking to Netbox >= 3.6.0 replace `device_role` parameters sent to the netbox API with `role`. This is needed due to breaking changes introduced in 3.6.0 where `device_role` was renamed to `role`. Ref: https://github.com/netbox-community/netbox/releases/tag/v3.6.0

## Contrast to Current Behavior

This not an attempt to explicitly add a new `role` parameter or deprecate `device_role` as a parameter. Instead this is a short-term fix for those of us who are using netbox >= 3.6 and want to continue to use this ansible collection with no changes to parameters passed. So basically we continue to pass `device_role` as a parameter even though this is technically no longer valid for for NB >= 3.6. This ensures backwards compatibility and no change in behavior for those on newer releases.

...

## Discussion: Benefits and Drawbacks

Benefits: allows the `netbox_device` module to work with NB 3.6 and later

Drawbacks: doesn't solve the problem of how to address this breaking change with a new parameter (`role`) to the ansible module directly while maintaining backwards comat. I defer to the collection authors for consensus on this (also happy to help if you can provide some guidance on how you would like this to work).



## Changes to the Documentation

N/A for now



## Proposed Release Note Entry

Make 'device_role' parameter compatible with Netbox >= 3.6.0 in netbox_device module



## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
