### PR TITLE
Fix attribute Type (for tenant and vlan_group) to Accept int only

### DIFF
--- a/plugins/modules/netbox_aggregate.py
+++ b/plugins/modules/netbox_aggregate.py
@@ -59,7 +59,7 @@ options:
         description:
           - Tenant the aggregate will be assigned to.
         required: false
-        type: raw
+        type: int
         version_added: "3.12.0"
       tags:
         description:
@@ -151,7 +151,7 @@ def main():
                     date_added=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     comments=dict(required=False, type="str"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
                 ),

--- a/plugins/modules/netbox_asn.py
+++ b/plugins/modules/netbox_asn.py
@@ -43,7 +43,7 @@ options:
         description:
           - Tenant
         required: false
-        type: raw
+        type: int
       description:
         description:
           - Description
@@ -127,7 +127,7 @@ def main():
                 options=dict(
                     asn=dict(required=True, type="int"),
                     rir=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),

--- a/plugins/modules/netbox_cable.py
+++ b/plugins/modules/netbox_cable.py
@@ -159,7 +159,7 @@ options:
         description:
           - Tenant who the cable will be assigned to
         required: false
-        type: raw
+        type: int
         version_added: "3.14.0"
 """
 
@@ -330,7 +330,7 @@ def main():
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                 ),
             ),
         )

--- a/plugins/modules/netbox_circuit.py
+++ b/plugins/modules/netbox_circuit.py
@@ -54,7 +54,7 @@ options:
         description:
           - The tenant assigned to the circuit
         required: false
-        type: raw
+        type: int
       install_date:
         description:
           - The date the circuit was installed. e.g. YYYY-MM-DD
@@ -167,7 +167,7 @@ def main():
                     provider=dict(required=False, type="raw"),
                     circuit_type=dict(required=False, type="raw"),
                     status=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     install_date=dict(required=False, type="str"),
                     commit_rate=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),

--- a/plugins/modules/netbox_cluster.py
+++ b/plugins/modules/netbox_cluster.py
@@ -65,7 +65,7 @@ options:
         description:
           - Tenant the cluster will be assigned to.
         required: false
-        type: raw
+        type: int
       tags:
         description:
           - Any tags that the cluster may need to be associated with
@@ -163,7 +163,7 @@ def main():
                     cluster_type=dict(required=False, type="raw"),
                     cluster_group=dict(required=False, type="raw"),
                     site=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),

--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -49,7 +49,7 @@ options:
         description:
           - The tenant that the device will be assigned to
         required: false
-        type: raw
+        type: int
       platform:
         description:
           - The platform of the device
@@ -283,7 +283,7 @@ def main():
                     name=dict(required=True, type="str"),
                     device_type=dict(required=False, type="raw"),
                     device_role=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     platform=dict(required=False, type="raw"),
                     serial=dict(required=False, type="str"),
                     asset_tag=dict(required=False, type="str"),

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -68,7 +68,7 @@ options:
         description:
           - The tenant that the device will be assigned to
         required: false
-        type: raw
+        type: int
       status:
         description:
           - The status of the IP address
@@ -313,7 +313,7 @@ def main():
                     ),
                     prefix=dict(required=False, type="raw"),
                     vrf=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     status=dict(required=False, type="raw"),
                     role=dict(
                         required=False,

--- a/plugins/modules/netbox_l2vpn.py
+++ b/plugins/modules/netbox_l2vpn.py
@@ -71,7 +71,7 @@ options:
         description:
           - The tenant that the L2VPN will be assigned to
         required: false
-        type: raw
+        type: int
       tags:
         description:
           - Any tags that the L2VPN may need to be associated with
@@ -170,7 +170,7 @@ def main():
                     export_targets=dict(required=False, type="list", elements="raw"),
                     description=dict(required=False, type="str"),
                     comments=dict(required=False, type="str"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
                 ),

--- a/plugins/modules/netbox_location.py
+++ b/plugins/modules/netbox_location.py
@@ -54,7 +54,7 @@ options:
         description:
           - The tenant that the location will be associated with
         required: false
-        type: raw
+        type: int
         version_added: "3.8.0"
       description:
         description:
@@ -149,7 +149,7 @@ def main():
                     slug=dict(required=False, type="str"),
                     site=dict(required=False, type="raw"),
                     parent_location=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),

--- a/plugins/modules/netbox_prefix.py
+++ b/plugins/modules/netbox_prefix.py
@@ -67,7 +67,7 @@ options:
         description:
           - The tenant that the prefix will be assigned to
         required: false
-        type: raw
+        type: int
       vlan:
         description:
           - The VLAN the prefix will be assigned to
@@ -254,7 +254,7 @@ def main():
                     prefix_length=dict(required=False, type="int"),
                     site=dict(required=False, type="raw"),
                     vrf=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     vlan=dict(required=False, type="raw"),
                     status=dict(required=False, type="raw"),
                     prefix_role=dict(required=False, type="raw"),

--- a/plugins/modules/netbox_rack.py
+++ b/plugins/modules/netbox_rack.py
@@ -60,7 +60,7 @@ options:
         description:
           - The tenant that the device will be assigned to
         required: false
-        type: raw
+        type: int
       status:
         description:
           - The status of the rack
@@ -272,7 +272,7 @@ def main():
                         removed_in_version="5.0.0",
                         removed_from_collection="netbox.netbox",
                     ),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     status=dict(required=False, type="raw"),
                     rack_role=dict(required=False, type="raw"),
                     serial=dict(required=False, type="str"),

--- a/plugins/modules/netbox_route_target.py
+++ b/plugins/modules/netbox_route_target.py
@@ -38,7 +38,7 @@ options:
         description:
           - The tenant that the route target will be assigned to
         required: false
-        type: raw
+        type: int
       description:
         description:
           - Tag description
@@ -143,7 +143,7 @@ def main():
                 required=True,
                 options=dict(
                     name=dict(required=True, type="str"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),

--- a/plugins/modules/netbox_site.py
+++ b/plugins/modules/netbox_site.py
@@ -55,7 +55,7 @@ options:
         description:
           - The tenant the site will be assigned to
         required: false
-        type: raw
+        type: int
       facility:
         description:
           - Data center provider or facility, ex. Equinix NY7
@@ -220,7 +220,7 @@ def main():
                     status=dict(required=False, type="raw"),
                     region=dict(required=False, type="raw"),
                     site_group=dict(required=False, type="raw"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     facility=dict(required=False, type="str"),
                     asn=dict(required=False, type="int"),
                     time_zone=dict(required=False, type="str"),

--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -58,7 +58,7 @@ options:
         description:
           - The tenant that the virtual machine will be assigned to
         required: false
-        type: raw
+        type: int
       platform:
         description:
           - The platform of the virtual machine
@@ -211,7 +211,7 @@ def main():
                     cluster=dict(required=False, type="raw"),
                     virtual_machine_role=dict(required=False, type="raw"),
                     vcpus=dict(required=False, type="float"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     platform=dict(required=False, type="raw"),
                     primary_ip4=dict(required=False, type="raw"),
                     primary_ip6=dict(required=False, type="raw"),

--- a/plugins/modules/netbox_vlan.py
+++ b/plugins/modules/netbox_vlan.py
@@ -38,7 +38,7 @@ options:
         description:
           - The VLAN group the VLAN will be associated to
         required: false
-        type: raw
+        type: int
       vid:
         description:
           - The VLAN ID
@@ -53,7 +53,7 @@ options:
         description:
           - The tenant that the vlan will be assigned to
         required: false
-        type: raw
+        type: int
       status:
         description:
           - The status of the vlan
@@ -166,10 +166,10 @@ def main():
                 required=True,
                 options=dict(
                     site=dict(required=False, type="raw"),
-                    vlan_group=dict(required=False, type="raw"),
+                    vlan_group=dict(required=False, type="int"),
                     vid=dict(required=False, type="int"),
                     name=dict(required=True, type="str"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     status=dict(required=False, type="raw"),
                     vlan_role=dict(required=False, type="raw"),
                     description=dict(required=False, type="str"),

--- a/plugins/modules/netbox_vrf.py
+++ b/plugins/modules/netbox_vrf.py
@@ -43,7 +43,7 @@ options:
         description:
           - The tenant that the vrf will be assigned to
         required: false
-        type: raw
+        type: int
       enforce_unique:
         description:
           - Prevent duplicate prefixes/IP addresses within this VRF
@@ -165,7 +165,7 @@ def main():
                 options=dict(
                     name=dict(required=True, type="str"),
                     rd=dict(required=False, type="str"),
-                    tenant=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="int"),
                     enforce_unique=dict(required=False, type="bool"),
                     import_targets=dict(required=False, type="list", elements="str"),
                     export_targets=dict(required=False, type="list", elements="str"),

--- a/tests/integration/targets/v3.3/tasks/netbox_asn.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_asn.yml
@@ -49,7 +49,7 @@
     data:
       asn: 1111111111
       rir: Example RIR
-      tenant: Test Tenant
+      tenant: 1
       description: Test description
       tags:
         - "Schnozzberry"

--- a/tests/integration/targets/v3.3/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_cable.yml
@@ -82,7 +82,7 @@
       length_unit: m
       tags:
         - "Schnozzberry"
-      tenant: "Test Tenant"
+      tenant: 1
     state: present
   register: test_three
 

--- a/tests/integration/targets/v3.3/tasks/netbox_circuit.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_circuit.yml
@@ -55,7 +55,7 @@
       provider: Test Provider
       circuit_type: Test Circuit Type
       status: Planned
-      tenant: Test Tenant
+      tenant: 1
       install_date: "2018-12-25"
       commit_rate: 10000
       description: "Test circuit       "

--- a/tests/integration/targets/v3.3/tasks/netbox_cluster.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_cluster.yml
@@ -52,7 +52,7 @@
       cluster_group: "Test Cluster Group"
       site: "Test Site"
       comments: "Updated cluster"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - "Schnozzberry"
     state: present

--- a/tests/integration/targets/v3.3/tasks/netbox_device.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_device.yml
@@ -133,7 +133,7 @@
       face: "Front"
       tags:
         - "schnozzberry"
-      tenant: "Test Tenant"
+      tenant: 1
       asset_tag: "1234"
     state: present
   register: test_four

--- a/tests/integration/targets/v3.3/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_ip_address.yml
@@ -124,7 +124,7 @@
       family: 4
       address: 172.16.1.20/24
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       status: Reserved
       role: Loopback
       description: Test description

--- a/tests/integration/targets/v3.3/tasks/netbox_l2vpn.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_l2vpn.yml
@@ -49,7 +49,7 @@
     data:
       name: "Test L2VPN"
       type: vxlan
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"

--- a/tests/integration/targets/v3.3/tasks/netbox_prefix.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_prefix.yml
@@ -89,11 +89,11 @@
       prefix: 10.156.32.0/19
       site: Test Site
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       vlan:
         name: Test VLAN
         site: Test Site
-        tenant: Test Tenant
+        tenant: 1
         vlan_group: Test Vlan Group
       status: Reserved
       prefix_role: Network of care

--- a/tests/integration/targets/v3.3/tasks/netbox_rack.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_rack.yml
@@ -88,7 +88,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"
@@ -151,7 +151,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"

--- a/tests/integration/targets/v3.3/tasks/netbox_route_target.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_route_target.yml
@@ -7,7 +7,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -32,7 +32,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -56,7 +56,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -80,7 +80,7 @@
     data:
       name: "65000:65001"
       description: "NEW DESCRIPTION"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -106,7 +106,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first
@@ -132,7 +132,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first

--- a/tests/integration/targets/v3.3/tasks/netbox_site.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_site.yml
@@ -69,7 +69,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description
@@ -113,7 +113,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description

--- a/tests/integration/targets/v3.3/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_vlan.yml
@@ -51,7 +51,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: present
   register: test_three
 
@@ -74,8 +74,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -110,8 +110,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -135,7 +135,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group 2"
+      vlan_group: 2
     state: present
   register: new_vlan_group
 
@@ -174,7 +174,7 @@
     data:
       name: "Test VLAN 500"
       site: Test Site
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.3/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_vlan.yml
@@ -50,7 +50,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 1
     state: present
   register: test_three
@@ -134,7 +134,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 2
     state: present
   register: new_vlan_group

--- a/tests/integration/targets/v3.3/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_vrf.yml
@@ -44,7 +44,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: Test VRF One
-      tenant: Test Tenant
+      tenant: 1
     state: present
   register: test_three
 
@@ -120,7 +120,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "Test VRF One"
-      tenant: Test Tenant
+      tenant: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.3/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.3/tasks/netbox_vrf.yml
@@ -66,7 +66,7 @@
       name: "Test VRF One"
       rd: "65001:1"
       enforce_unique: False
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"

--- a/tests/integration/targets/v3.4/tasks/netbox_asn.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_asn.yml
@@ -49,7 +49,7 @@
     data:
       asn: 1111111111
       rir: Example RIR
-      tenant: Test Tenant
+      tenant: 1
       description: Test description
       tags:
         - "Schnozzberry"

--- a/tests/integration/targets/v3.4/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_cable.yml
@@ -82,7 +82,7 @@
       length_unit: m
       tags:
         - "Schnozzberry"
-      tenant: "Test Tenant"
+      tenant: 1
     state: present
   register: test_three
 

--- a/tests/integration/targets/v3.4/tasks/netbox_circuit.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_circuit.yml
@@ -55,7 +55,7 @@
       provider: Test Provider
       circuit_type: Test Circuit Type
       status: Planned
-      tenant: Test Tenant
+      tenant: 1
       install_date: "2018-12-25"
       commit_rate: 10000
       description: "Test circuit       "

--- a/tests/integration/targets/v3.4/tasks/netbox_cluster.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_cluster.yml
@@ -52,7 +52,7 @@
       cluster_group: "Test Cluster Group"
       site: "Test Site"
       comments: "Updated cluster"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - "Schnozzberry"
     state: present

--- a/tests/integration/targets/v3.4/tasks/netbox_device.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_device.yml
@@ -133,7 +133,7 @@
       face: "Front"
       tags:
         - "schnozzberry"
-      tenant: "Test Tenant"
+      tenant: 1
       asset_tag: "1234"
     state: present
   register: test_four

--- a/tests/integration/targets/v3.4/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_ip_address.yml
@@ -124,7 +124,7 @@
       family: 4
       address: 172.16.1.20/24
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       status: Reserved
       role: Loopback
       description: Test description

--- a/tests/integration/targets/v3.4/tasks/netbox_l2vpn.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_l2vpn.yml
@@ -49,7 +49,7 @@
     data:
       name: "Test L2VPN"
       type: vxlan
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"

--- a/tests/integration/targets/v3.4/tasks/netbox_prefix.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_prefix.yml
@@ -89,11 +89,11 @@
       prefix: 10.156.32.0/19
       site: Test Site
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       vlan:
         name: Test VLAN
         site: Test Site
-        tenant: Test Tenant
+        tenant: 1
         vlan_group: Test Vlan Group
       status: Reserved
       prefix_role: Network of care

--- a/tests/integration/targets/v3.4/tasks/netbox_rack.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_rack.yml
@@ -88,7 +88,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"
@@ -151,7 +151,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"

--- a/tests/integration/targets/v3.4/tasks/netbox_route_target.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_route_target.yml
@@ -7,7 +7,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -32,7 +32,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -56,7 +56,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -80,7 +80,7 @@
     data:
       name: "65000:65001"
       description: "NEW DESCRIPTION"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -106,7 +106,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first
@@ -132,7 +132,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first

--- a/tests/integration/targets/v3.4/tasks/netbox_site.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_site.yml
@@ -69,7 +69,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description
@@ -113,7 +113,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description

--- a/tests/integration/targets/v3.4/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_vlan.yml
@@ -51,7 +51,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: present
   register: test_three
 
@@ -74,8 +74,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -110,8 +110,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -135,7 +135,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group 2"
+      vlan_group: 2
     state: present
   register: new_vlan_group
 
@@ -174,7 +174,7 @@
     data:
       name: "Test VLAN 500"
       site: Test Site
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.4/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_vlan.yml
@@ -50,7 +50,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 1
     state: present
   register: test_three
@@ -134,7 +134,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 2
     state: present
   register: new_vlan_group

--- a/tests/integration/targets/v3.4/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_vrf.yml
@@ -44,7 +44,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: Test VRF One
-      tenant: Test Tenant
+      tenant: 1
     state: present
   register: test_three
 
@@ -120,7 +120,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "Test VRF One"
-      tenant: Test Tenant
+      tenant: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.4/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.4/tasks/netbox_vrf.yml
@@ -66,7 +66,7 @@
       name: "Test VRF One"
       rd: "65001:1"
       enforce_unique: False
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"

--- a/tests/integration/targets/v3.5/tasks/netbox_asn.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_asn.yml
@@ -49,7 +49,7 @@
     data:
       asn: 1111111111
       rir: Example RIR
-      tenant: Test Tenant
+      tenant: 1
       description: Test description
       tags:
         - "Schnozzberry"

--- a/tests/integration/targets/v3.5/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_cable.yml
@@ -82,7 +82,7 @@
       length_unit: m
       tags:
         - "Schnozzberry"
-      tenant: "Test Tenant"
+      tenant: 1
     state: present
   register: test_three
 

--- a/tests/integration/targets/v3.5/tasks/netbox_circuit.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_circuit.yml
@@ -55,7 +55,7 @@
       provider: Test Provider
       circuit_type: Test Circuit Type
       status: Planned
-      tenant: Test Tenant
+      tenant: 1
       install_date: "2018-12-25"
       commit_rate: 10000
       description: "Test circuit       "

--- a/tests/integration/targets/v3.5/tasks/netbox_cluster.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_cluster.yml
@@ -52,7 +52,7 @@
       cluster_group: "Test Cluster Group"
       site: "Test Site"
       comments: "Updated cluster"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - "Schnozzberry"
     state: present

--- a/tests/integration/targets/v3.5/tasks/netbox_device.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_device.yml
@@ -133,7 +133,7 @@
       face: "Front"
       tags:
         - "schnozzberry"
-      tenant: "Test Tenant"
+        tenant: 1
       asset_tag: "1234"
     state: present
   register: test_four

--- a/tests/integration/targets/v3.5/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_ip_address.yml
@@ -124,7 +124,7 @@
       family: 4
       address: 172.16.1.20/24
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       status: Reserved
       role: Loopback
       description: Test description

--- a/tests/integration/targets/v3.5/tasks/netbox_l2vpn.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_l2vpn.yml
@@ -49,7 +49,7 @@
     data:
       name: "Test L2VPN"
       type: vxlan
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"

--- a/tests/integration/targets/v3.5/tasks/netbox_prefix.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_prefix.yml
@@ -89,11 +89,11 @@
       prefix: 10.156.32.0/19
       site: Test Site
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       vlan:
         name: Test VLAN
         site: Test Site
-        tenant: Test Tenant
+        tenant: 1
         vlan_group: Test Vlan Group
       status: Reserved
       prefix_role: Network of care

--- a/tests/integration/targets/v3.5/tasks/netbox_rack.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_rack.yml
@@ -88,7 +88,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"
@@ -151,7 +151,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"

--- a/tests/integration/targets/v3.5/tasks/netbox_route_target.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_route_target.yml
@@ -7,7 +7,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -32,7 +32,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -56,7 +56,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -80,7 +80,7 @@
     data:
       name: "65000:65001"
       description: "NEW DESCRIPTION"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -106,7 +106,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first
@@ -132,7 +132,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first

--- a/tests/integration/targets/v3.5/tasks/netbox_site.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_site.yml
@@ -69,7 +69,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description
@@ -113,7 +113,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description

--- a/tests/integration/targets/v3.5/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_vlan.yml
@@ -51,7 +51,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: present
   register: test_three
 
@@ -74,8 +74,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -110,8 +110,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -135,7 +135,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group 2"
+      vlan_group: 2
     state: present
   register: new_vlan_group
 
@@ -174,7 +174,7 @@
     data:
       name: "Test VLAN 500"
       site: Test Site
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.5/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_vlan.yml
@@ -50,7 +50,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 1
     state: present
   register: test_three
@@ -134,7 +134,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 2
     state: present
   register: new_vlan_group

--- a/tests/integration/targets/v3.5/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_vrf.yml
@@ -44,7 +44,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: Test VRF One
-      tenant: Test Tenant
+      tenant: 1
     state: present
   register: test_three
 
@@ -120,7 +120,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "Test VRF One"
-      tenant: Test Tenant
+      tenant: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.5/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_vrf.yml
@@ -66,7 +66,7 @@
       name: "Test VRF One"
       rd: "65001:1"
       enforce_unique: False
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"

--- a/tests/integration/targets/v3.6/tasks/netbox_asn.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_asn.yml
@@ -49,7 +49,7 @@
     data:
       asn: 1111111111
       rir: Example RIR
-      tenant: Test Tenant
+      tenant: 1
       description: Test description
       tags:
         - "Schnozzberry"

--- a/tests/integration/targets/v3.6/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_cable.yml
@@ -82,7 +82,7 @@
       length_unit: m
       tags:
         - "Schnozzberry"
-      tenant: "Test Tenant"
+      tenant: 1
     state: present
   register: test_three
 

--- a/tests/integration/targets/v3.6/tasks/netbox_circuit.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_circuit.yml
@@ -55,7 +55,7 @@
       provider: Test Provider
       circuit_type: Test Circuit Type
       status: Planned
-      tenant: Test Tenant
+      tenant: 1
       install_date: "2018-12-25"
       commit_rate: 10000
       description: "Test circuit       "

--- a/tests/integration/targets/v3.6/tasks/netbox_cluster.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_cluster.yml
@@ -52,7 +52,7 @@
       cluster_group: "Test Cluster Group"
       site: "Test Site"
       comments: "Updated cluster"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - "Schnozzberry"
     state: present

--- a/tests/integration/targets/v3.6/tasks/netbox_device.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_device.yml
@@ -133,7 +133,7 @@
       face: "Front"
       tags:
         - "schnozzberry"
-      tenant: "Test Tenant"
+      tenant: 1
       asset_tag: "1234"
     state: present
   register: test_four

--- a/tests/integration/targets/v3.6/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_ip_address.yml
@@ -124,7 +124,7 @@
       family: 4
       address: 172.16.1.20/24
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       status: Reserved
       role: Loopback
       description: Test description

--- a/tests/integration/targets/v3.6/tasks/netbox_l2vpn.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_l2vpn.yml
@@ -49,7 +49,7 @@
     data:
       name: "Test L2VPN"
       type: vxlan
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"

--- a/tests/integration/targets/v3.6/tasks/netbox_prefix.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_prefix.yml
@@ -89,11 +89,11 @@
       prefix: 10.156.32.0/19
       site: Test Site
       vrf: Test VRF
-      tenant: Test Tenant
+      tenant: 1
       vlan:
         name: Test VLAN
         site: Test Site
-        tenant: Test Tenant
+        tenant: 1
         vlan_group: Test Vlan Group
       status: Reserved
       prefix_role: Network of care

--- a/tests/integration/targets/v3.6/tasks/netbox_rack.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_rack.yml
@@ -88,7 +88,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"
@@ -151,7 +151,7 @@
       rack_role: "Test Rack Role"
       location: "Test Rack Group"
       facility_id: "EQUI10291"
-      tenant: "Test Tenant"
+      tenant: 1
       status: Available
       serial: "FXS10001"
       asset_tag: "1234"

--- a/tests/integration/targets/v3.6/tasks/netbox_route_target.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_route_target.yml
@@ -7,7 +7,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -32,7 +32,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -56,7 +56,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -80,7 +80,7 @@
     data:
       name: "65000:65001"
       description: "NEW DESCRIPTION"
-      tenant: "Test Tenant"
+      tenant: 1
       tags:
         - first
         - second
@@ -106,7 +106,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first
@@ -132,7 +132,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "65000:65001"
-      tenant: "Test Tenant"
+      tenant: 1
       description: "NEW DESCRIPTION"
       tags:
         - first

--- a/tests/integration/targets/v3.6/tasks/netbox_site.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_site.yml
@@ -69,7 +69,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description
@@ -113,7 +113,7 @@
       status: Planned
       region: Test Region
       site_group: Test Site Group
-      tenant: Test Tenant
+      tenant: 1
       facility: EquinoxCA7
       time_zone: America/Los Angeles
       description: This is a test description

--- a/tests/integration/targets/v3.6/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_vlan.yml
@@ -51,7 +51,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: present
   register: test_three
 
@@ -74,8 +74,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -110,8 +110,8 @@
     data:
       name: "Test VLAN 500"
       vid: 500
-      tenant: "Test Tenant"
-      vlan_group: "Test VLAN Group"
+      tenant: 1
+      vlan_group: 1
       status: Reserved
       vlan_role: Network of care
       description: Updated description
@@ -135,7 +135,7 @@
       vid: 500
       site: Test Site
       tenant: Test Tenant
-      vlan_group: "Test VLAN Group 2"
+      vlan_group: 2
     state: present
   register: new_vlan_group
 
@@ -174,7 +174,7 @@
     data:
       name: "Test VLAN 500"
       site: Test Site
-      vlan_group: "Test VLAN Group"
+      vlan_group: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.6/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_vlan.yml
@@ -50,7 +50,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 1
     state: present
   register: test_three
@@ -134,7 +134,7 @@
       name: Test VLAN 500
       vid: 500
       site: Test Site
-      tenant: Test Tenant
+      tenant: 1
       vlan_group: 2
     state: present
   register: new_vlan_group

--- a/tests/integration/targets/v3.6/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_vrf.yml
@@ -44,7 +44,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: Test VRF One
-      tenant: Test Tenant
+      tenant: 1
     state: present
   register: test_three
 
@@ -120,7 +120,7 @@
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       name: "Test VRF One"
-      tenant: Test Tenant
+      tenant: 1
     state: absent
   register: test_six
 

--- a/tests/integration/targets/v3.6/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_vrf.yml
@@ -66,7 +66,7 @@
       name: "Test VRF One"
       rd: "65001:1"
       enforce_unique: False
-      tenant: "Test Tenant"
+      tenant: 1
       description: Updated description
       import_targets:
         - "4000:4000"


### PR DESCRIPTION
## Related Issue
#985

## New Behavior
Fix the related issue for the attributes tenant and vlan_group.

## Contrast to Current Behavior
Changing the data type of the tenant and vlan_group attribute to integer to meet NetboxAPI standards.
It should not affect the current Behaviour, only fixes the related issue.


## Discussion: Benefits and Drawbacks

This change will allow Ansible variables to be passed correctly using Jinja templating. For instance, with a variable tenantid initialized with the value 100, it can be passed as "tenant: {{ tenantid }}". Currently, Ansible would interpret is as a string and due to the parameter "raw" the module accept it as a string. With the propsed change, the module will convert/enforce the datatype to be an integer. 

Discussion
There are several more attributes with the datatype "raw". It should be investigated whether these can be simplified to a specific datatype.

## Changes to the Documentation
*[] Docs have been updated

## Proposed Release Note Entry
Changing data type to meet NetboxAPI standards.