### PR TITLE
feat: Add support for default_platform on device_types

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -216,6 +216,7 @@ CONVERT_TO_ID = {
     "dcim.poweroutlet": "power_outlets",
     "dcim.powerport": "power_ports",
     "dcim.rearport": "rear_ports",
+    "default_platform": "platforms",
     "device": "devices",
     "device_role": "device_roles",
     "device_type": "device_types",

--- a/plugins/modules/netbox_device_type.py
+++ b/plugins/modules/netbox_device_type.py
@@ -112,6 +112,12 @@ options:
           - Comments that may include additional information in regards to the device_type
         required: false
         type: str
+      default_platform:
+        description: 
+          - Set the default platform used by the device
+        required: false
+        type: raw
+        version_added: "3.15.0"
       tags:
         description:
           - Any tags that the device type may need to be associated with
@@ -237,6 +243,7 @@ def main():
                     ),
                     description=dict(required=False, type="str"),
                     comments=dict(required=False, type="str"),
+                    default_platform=dict(required=False, type="raw"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
                 ),


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## New Behavior

Add the option default_platform on the device_type resource

## Contrast to Current Behavior

The option is missing and does not allow the definition of the default platform

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The platform will be able to be set by default and thus defining default configuration templates for a device for example. 

## Proposed Release Note Entry

Add support for the default_plaform on device_type

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
