### PR TITLE
Allow unracking devices by setting position = 0

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1297,6 +1297,9 @@ class NetboxModule(object):
             if k == "mac_address":
                 data[k] = v.upper()
 
+            if k == "position" and v == 0:
+                data[k] = None
+
         # We need to assign the correct type for the assigned object so the user doesn't have to worry about this.
         # We determine it by whether or not they pass in a device or virtual_machine
         if data.get("assigned_object"):


### PR DESCRIPTION
## Related Issue

No related issue.



## New Behavior

Allow setting a device as not racked by setting `position: 0` in the `data` structure.





## Contrast to Current Behavior

Currently it is not possible to set a device as _Not racked_ via the [netbox.netbox.netbox_device](https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_module.html) module.

Netbox ordinarily rejects an API call with position=0 since this is outside of the allowable range of values.
The way to ordinarily set a device as unracked is to send `null` for the particular field.
Since the module strips default fields that have null values (even if explicitly included in the `data`) it seems otherwise impossible to unrack a device.
Allowing a value that is otherwise rejected by the API seems to be a natural fit.





## Discussion: Benefits and Drawbacks

- Why do you think this project and the community will benefit from your
  proposed change?
Allows using module in a wider array of use cases.
My issue was that a device was moved to a particular rack, but the exact RU was not known. When updating the device with the new rack, I couldn't leave the device with the position populated as (1) it was incorrect and (2) it was already populated with another device. 

- What are the drawbacks of this change?
Not directly mirroring the API, but since `null` is problematic it seems OK.

- Is it backwards-compatible?
It seems backwards compatible since the value `0` is otherwise rejected by the Netbox API since position must be >=1.0.

- Anything else that you think is relevant to the discussion of this PR.
My attempts to get the module to pass `null` were originally foiled by the `_remove_arg_spec_default()` function. Originally having added a special case to that function, I decided that simply passing a non-null value (which ultimately results in `null` being sent) was best.

It is worth noting that the `position` field is one of many default fields that a user might need to set to null. It might we worth considering a more generic approach (perhaps in the future) that addresses any field. For example, one might want to disassociate a device from particular `rack`. In order to do this, similarly, sending out `null` is required, but ordinarily stripped even if explicitly included in the data with no value set.

Here is how a device without an assigned `position` looks:
![image](https://github.com/netbox-community/ansible_modules/assets/73103/65884d7c-31f4-497a-aa37-9e9e143bb60e)

Here is what a changelog entry looks like that actually unracks a device:
![image](https://github.com/netbox-community/ansible_modules/assets/73103/e4258f61-0142-457e-8358-826dc8e29cb4)

![image](https://github.com/netbox-community/ansible_modules/assets/73103/bad4c053-df0a-4d95-ac05-38b6a30f21ad)





## Changes to the Documentation

Not sure how to appropriately document this. I didn't find a spot where it would naturally fit but I do think that documentation is very important since the special meaning of `position: 0` is not otherwise known. Here is an example blurb:

---
## Setting Devices as "Not Racked"

A device can be designated as "Not Racked" using the `position` field in the `netbox_device` module. To do this, set the `position` value to `0`.

For example:

```yaml
---
- name: Set Device as Not Racked
  hosts: localhost
  tasks:
    - name: Set a device as "Not Racked"
      netbox.netbox.netbox_device:
        data:
          name: MyDevice
          rack: MyRack
          position: 0
        state: present
        server_url: http://netbox.example.com
        token: YourToken
```
---



## Proposed Release Note Entry

> feat: Set devices to _Not Racked_ by setting `position` within `data` to `0` in netbox_device module




## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
