### PR TITLE
Allow adding power port templates to modules

### DIFF
--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -212,6 +212,7 @@ def get_endpoint(netbox, term):
         "module-bays": {"endpoint": netbox.dcim.module_bays},
         "module-bay-templates": {"endpoint": netbox.dcim.module_bay_templates},
         "module-bay-types": {"endpoint": netbox.dcim.module_bay_types},
+        "module-types": {"endpoint": netbox.dcim.module_types},
         "modules": {"endpoint": netbox.dcim.modules},
         "object-changes": {"endpoint": netbox.extras.object_changes},
         "permissions": {"endpoint": netbox.users.permissions},

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -239,6 +239,7 @@ CONVERT_TO_ID = {
     "lag": "interfaces",
     "manufacturer": "manufacturers",
     "master": "devices",
+    "module_type": "module_types",
     "nat_inside": "ip_addresses",
     "nat_outside": "ip_addresses",
     "platform": "platforms",

--- a/tests/integration/targets/v3.5/tasks/netbox_power_port_template.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_power_port_template.yml
@@ -7,12 +7,21 @@
 ### NETBOX_POWER_PORT_TEMPLATE
 ##
 ##
-- name: "POWER_PORT_TEMPLATE 0: Create device type for testing power ports"
+- name: "POWER_PORT_TEMPLATE 0.1: Create device type for testing power ports on device types"
   netbox.netbox.netbox_device_type:
     netbox_url: http://localhost:32768
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       model: Device Type Power Tests
+      manufacturer: Test Manufacturer
+    state: present
+
+- name: "POWER_PORT_TEMPLATE 0.2: Create module type for testing power ports on module types"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: Module Type Power Tests
       manufacturer: Test Manufacturer
     state: present
 
@@ -118,3 +127,86 @@
       - test_five['diff']['before']['state'] == "present"
       - test_five['diff']['after']['state'] == "absent"
       - test_five['msg'] == "power_port_template Power Port Template 2 deleted"
+
+- name: "POWER_PORT_TEMPLATE 6: Necessary info creation"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: present
+  register: test_six
+
+- name: "POWER_PORT_TEMPLATE 6: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['power_port_template']['name'] == "Module Power Port Template"
+      - test_six['power_port_template']['module_type'] == 1
+      - test_six['msg'] == "power_port_template Module Power Port Template created"
+
+- name: "POWER_PORT_TEMPLATE 7: Create duplicate"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: present
+  register: test_seven
+
+- name: "POWER_PORT_TEMPLATE 7: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['power_port_template']['name'] == "Module Power Port Template"
+      - test_seven['power_port_template']['module_type'] == 1
+      - test_seven['msg'] == "power_port_template Module Power Port Template already exists"
+
+- name: "POWER_PORT_TEMPLATE 8: Update power_port_template with other fields"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+      type: ita-e
+      allocated_draw: 10
+      maximum_draw: 20
+    state: present
+  register: test_eight
+
+- name: "POWER_PORT_TEMPLATE 8: ASSERT - Update power_port_template with other fields"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['after']['type'] == "ita-e"
+      - test_eight['diff']['after']['allocated_draw'] == 10
+      - test_eight['diff']['after']['maximum_draw'] == 20
+      - test_eight['power_port_template']['name'] == "Module Power Port Template"
+      - test_eight['power_port_template']['module_type'] == 1
+      - test_eight['power_port_template']['type'] == "ita-e"
+      - test_eight['power_port_template']['allocated_draw'] == 10
+      - test_eight['power_port_template']['maximum_draw'] == 20
+      - test_eight['msg'] == "power_port_template Module Power Port Template updated"
+
+- name: "POWER_PORT_TEMPLATE 9: Delete Power Port Template"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: absent
+  register: test_nine
+
+- name: "POWER_PORT_TEMPLATE 9: ASSERT - Delete Power Port Template"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "present"
+      - test_nine['diff']['after']['state'] == "absent"
+      - test_nine['msg'] == "power_port_template Module Power Port Template deleted"

--- a/tests/integration/targets/v3.6/tasks/netbox_power_port_template.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_power_port_template.yml
@@ -7,12 +7,21 @@
 ### NETBOX_POWER_PORT_TEMPLATE
 ##
 ##
-- name: "POWER_PORT_TEMPLATE 0: Create device type for testing power ports"
+- name: "POWER_PORT_TEMPLATE 0.1: Create device type for testing power ports on device types"
   netbox.netbox.netbox_device_type:
     netbox_url: http://localhost:32768
     netbox_token: 0123456789abcdef0123456789abcdef01234567
     data:
       model: Device Type Power Tests
+      manufacturer: Test Manufacturer
+    state: present
+
+- name: "POWER_PORT_TEMPLATE 0.2: Create module type for testing power ports on module types"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      model: Module Type Power Tests
       manufacturer: Test Manufacturer
     state: present
 
@@ -118,3 +127,86 @@
       - test_five['diff']['before']['state'] == "present"
       - test_five['diff']['after']['state'] == "absent"
       - test_five['msg'] == "power_port_template Power Port Template 2 deleted"
+
+- name: "POWER_PORT_TEMPLATE 6: Necessary info creation"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: present
+  register: test_six
+
+- name: "POWER_PORT_TEMPLATE 6: ASSERT - Necessary info creation"
+  assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['power_port_template']['name'] == "Module Power Port Template"
+      - test_six['power_port_template']['module_type'] == 1
+      - test_six['msg'] == "power_port_template Module Power Port Template created"
+
+- name: "POWER_PORT_TEMPLATE 7: Create duplicate"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: present
+  register: test_seven
+
+- name: "POWER_PORT_TEMPLATE 7: ASSERT - Create duplicate"
+  assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['power_port_template']['name'] == "Module Power Port Template"
+      - test_seven['power_port_template']['module_type'] == 1
+      - test_seven['msg'] == "power_port_template Module Power Port Template already exists"
+
+- name: "POWER_PORT_TEMPLATE 8: Update power_port_template with other fields"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+      type: ita-e
+      allocated_draw: 10
+      maximum_draw: 20
+    state: present
+  register: test_eight
+
+- name: "POWER_PORT_TEMPLATE 8: ASSERT - Update power_port_template with other fields"
+  assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['after']['type'] == "ita-e"
+      - test_eight['diff']['after']['allocated_draw'] == 10
+      - test_eight['diff']['after']['maximum_draw'] == 20
+      - test_eight['power_port_template']['name'] == "Module Power Port Template"
+      - test_eight['power_port_template']['module_type'] == 1
+      - test_eight['power_port_template']['type'] == "ita-e"
+      - test_eight['power_port_template']['allocated_draw'] == 10
+      - test_eight['power_port_template']['maximum_draw'] == 20
+      - test_eight['msg'] == "power_port_template Module Power Port Template updated"
+
+- name: "POWER_PORT_TEMPLATE 9: Delete Power Port Template"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: 0123456789abcdef0123456789abcdef01234567
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: absent
+  register: test_nine
+
+- name: "POWER_PORT_TEMPLATE 9: ASSERT - Delete Power Port Template"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "present"
+      - test_nine['diff']['after']['state'] == "absent"
+      - test_nine['msg'] == "power_port_template Module Power Port Template deleted"


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

No issue, context described below.

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

NetBox allows adding components (like power ports) to module types, not only to device types. This PR will address this.
Some users want to use module bays, hosting power supplies. This power supplies have a module type, which has power port templates. E.g: https://www.netbox.net/dcim/module-types/1/power-ports/

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

This PR adds `module_type`, which allows adding a power port to an existing module type in NetBox. Therefor one of `device_type` or `module_type` is required.


## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

This PR adds a feature that is already implemented in the NetBox GUI, but missing in the Ansible collection/module. For example, the device library uses module types for PSU's: https://github.com/netbox-community/devicetype-library/blob/a7718d8d4b0a9d2f196166f5cbc4831bfb6be490/device-types/HPE/ProLiant-DL580-Gen10.yaml#L13 and we can add modules with a module type to this slot. With the power port assigned to the module type, there will be a power port created with the module assignment. No further need to create additional power ports in an extra step.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

All needed changes to the docs are included in the code.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Add the ability to create power ports for module types.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
