### PR TITLE
Update for Ansible NetBox Collection to Support 'role' Field Change

### DIFF
--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -40,7 +40,7 @@ options:
           - Required if I(state=present) and the device does not exist yet
         required: false
         type: raw
-      device_role:
+      role:
         description:
           - Required if I(state=present) and the device does not exist yet
         required: false
@@ -196,7 +196,7 @@ EXAMPLES = r"""
         data:
           name: Test Device
           device_type: C9410R
-          device_role: Core Switch
+          role: Core Switch
           site: Main
         state: present
 
@@ -207,7 +207,7 @@ EXAMPLES = r"""
         data:
           name: ""
           device_type: C9410R
-          device_role: Core Switch
+          role: Core Switch
           site: Main
         state: present
 
@@ -226,7 +226,7 @@ EXAMPLES = r"""
         data:
           name: Another Test Device
           device_type: C9410R
-          device_role: Core Switch
+          role: Core Switch
           site: Main
           local_context_data:
             bgp: "65000"
@@ -282,7 +282,7 @@ def main():
                 options=dict(
                     name=dict(required=True, type="str"),
                     device_type=dict(required=False, type="raw"),
-                    device_role=dict(required=False, type="raw"),
+                    role=dict(required=False, type="raw"),
                     tenant=dict(required=False, type="raw"),
                     platform=dict(required=False, type="raw"),
                     serial=dict(required=False, type="str"),


### PR DESCRIPTION
## Issue

When attempting to add a new device into NetBox via Ansible, the task fails due to a change in NetBox v3.6.0. In this version, the device_role field on the Device model has been renamed to role. For backward compatibility the field name "device_role" still exist.

This change has not been reflected in the latest Ansible Galaxy NetBox Collection. As a result, when trying to use the updated "role" field, the module throws an error, insisting on using the "device_role" key.

NetBox version: v3.6.3
netbox.netbox collection version: v3.14.0
netbox.netbox version:  v0.1.0

## Behavior

While adding new device to NetBox via Ansible its throws the following error
fatal: [localhost]: FAILED! => {"changed": false, "msg": "{\"role\":[\"This field is required.\"]}"}

## Discussion: Benefits

Ensures compatibility with NetBox v3.6.0 and later.
Prevents unnecessary errors and confusion related to the changed field name.

## Changes to the Documentation

```yaml
- name: "Test NetBox modules"
  connection: local
  hosts: localhost
  gather_facts: False

  tasks:
    - name: Create device within NetBox with only required information
      netbox.netbox.netbox_device:
        netbox_url: http://netbox.local
        netbox_token: thisIsMyToken
        data:
          name: Test Device
          device_type: C9410R
          role: Core Switch # device_role to role
          site: Main
        state: present

    - name: Create device within NetBox with empty string name to generate UUID
      netbox.netbox.netbox_device:
        netbox_url: http://netbox.local
        netbox_token: thisIsMyToken
        data:
          name: ""
          device_type: C9410R
          role: Core Switch # device_role to role
          site: Main
        state: present
   - name: Delete device within netbox
      netbox.netbox.netbox_device:
        netbox_url: http://netbox.local
        netbox_token: thisIsMyToken
        data:
          name: Test Device
        state: absent
```

## Proposed Release Note Entry

Update netbox.netbox.netbox_device to support 'role' Field Change

* [x ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x ] I have explained my PR according to the information in the comments or in a linked issue.
* [x ] My PR targets the `devel` branch.
