### PR TITLE
Decrypt ansible-vault strings in nb_inventory

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -453,7 +453,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 )
 
             try:
-                results = json.loads(raw_data)
+                results = self.loader.load(raw_data, json_only=True)
             except ValueError:
                 raise AnsibleError("Incorrect JSON payload: %s" % raw_data)
 


### PR DESCRIPTION
This allows storing secrets in config context data.

## Related Issue

#551

## New Behavior

This allows storing ansible-vault secrets in a NetBox config context, like this:

    {
        "plain_var": "value",
        "secret_var": {
            "__ansible_vault": "$ANSIBLE_VAULT;1.1;AES256\n123456…"
        }
    }

## Contrast to Current Behavior

Currently encrypted values are returned as is, and cannot be used directly in Ansible playbooks or templates without the workaround described in #551.

## Discussion: Benefits and Drawbacks

The change should have no effect on existing installations; the workaround in #551 will still work but do nothing, as the values are now decrpyted earlier. Other possible workarounds (e.g. decrypting values in a playbook) might break if they expect an ansible-vault string.

Replacing `json.loads` with `self.loader.load` makes `nb_inventory` work more like [the builtin `script` plugin](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/inventory/script.py#L106-L115), so I believe it is a better solution. If additional functionality is added to the `DataLoader` class in Ansible, it should work with `nb_inventory` with no changes to the plugin.

## Changes to the Documentation

No changes. Please let me know if I should add a note somewhere.

## Proposed Release Note Entry

Support ansible-vault encrypted values in NetBox config contexts

## Double Check

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
