### PR TITLE
Feat: Support config_template opt in platform

### DIFF
--- a/plugins/modules/netbox_platform.py
+++ b/plugins/modules/netbox_platform.py
@@ -50,6 +50,11 @@ options:
           - The manufacturer the platform will be tied to
         required: false
         type: raw
+      config_template:
+        description:
+          - The configuration template the platform will use
+        required: false
+        type: raw
       napalm_driver:
         description:
           - The name of the NAPALM driver to be used when using the NAPALM plugin
@@ -89,6 +94,15 @@ EXAMPLES = r"""
         netbox_token: thisIsMyToken
         data:
           name: Test Platform
+        state: present
+    
+    - name: Create platform within NetBox with a config template
+      netbox.netbox.netbox_platform:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test Platform
+          config_template: "my_config_template_slug"
         state: present
 
     - name: Create platform within NetBox with only required information
@@ -149,6 +163,7 @@ def main():
                     slug=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     manufacturer=dict(required=False, type="raw"),
+                    config_template=dict(required=False, type="raw"),
                     napalm_driver=dict(required=False, type="str"),
                     napalm_args=dict(required=False, type="dict"),
                     tags=dict(required=False, type="list", elements="raw"),


### PR DESCRIPTION
## New Behavior

This PR add support for the parameter `config_template` in platform entity

## Contrast to Current Behavior

The option is not currently supported


## Proposed Release Note Entry

> Add support for `config_template` in platform module

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
