### PR TITLE
Unmask "packaging module missing" error

### DIFF
--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -63,7 +63,7 @@ except ImportError as imp_exc:
 class NetboxDcimModule(NetboxModule):
     def __init__(self, module, endpoint):
         if not HAS_PACKAGING:
-            self.module.fail_json(
+            module.fail_json(
                 msg=missing_required_lib("packaging"), exception=PACKAGING_IMPORT_ERROR
             )
         super().__init__(module, endpoint)


### PR DESCRIPTION
When the `packaging` module is missing the error will be masked because we try to use `self.module` before it has been initialized

## Related Issue

NA - 

## New Behavior

This change make sure that the real error (missing `packaging` module) is not masked by an error arising from the use-before-initialization of the `self.module` attribute

## Contrast to Current Behavior

The old behavior masked the error and made troubleshooting harder

## Discussion: Benefits and Drawbacks

NA

## Changes to the Documentation

NA

## Proposed Release Note Entry

Fixed use-before-initialization for `self.module`

## Double Check

* [X ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ X] I have explained my PR according to the information in the comments or in a linked issue.
* [ X] My PR targets the `devel` branch.
