### PR TITLE
Support CustomField UI visibility in 3.8

### DIFF
--- a/docs/plugins/netbox_custom_field_module.rst
+++ b/docs/plugins/netbox_custom_field_module.rst
@@ -619,6 +619,98 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-data/ui_editable"></div>
+
+      .. _ansible_collections.netbox.netbox.netbox_custom_field_module__parameter-data/ui_editable:
+
+      .. rst-class:: ansible-option-title
+
+      **ui_editable**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-data/ui_editable" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      :ansible-option-versionadded:`added in netbox.netbox 3.17.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      Whether the custom field is editable in the UI
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-choices:`Choices:`
+
+      - :ansible-option-choices-entry:`"yes"`
+      - :ansible-option-choices-entry:`"no"`
+      - :ansible-option-choices-entry:`"hidden"`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-data/ui_visible"></div>
+
+      .. _ansible_collections.netbox.netbox.netbox_custom_field_module__parameter-data/ui_visible:
+
+      .. rst-class:: ansible-option-title
+
+      **ui_visible**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-data/ui_visible" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      :ansible-option-versionadded:`added in netbox.netbox 3.17.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      Whether the custom field is displayed in the UI
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-choices:`Choices:`
+
+      - :ansible-option-choices-entry:`"always"`
+      - :ansible-option-choices-entry:`"if-set"`
+      - :ansible-option-choices-entry:`"hidden"`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-data/ui_visibility"></div>
 
       .. _ansible_collections.netbox.netbox.netbox_custom_field_module__parameter-data/ui_visibility:

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -106,9 +106,30 @@ options:
         required: false
         type: str      
         version_added: "3.10.0"
+      ui_editable:
+         description:
+           - Whether the custom field is editable in the UI
+         required: false
+         choices: 
+           - yes
+           - no
+           - hidden
+         type: str      
+         version_added: "3.17.0"
+      ui_visible:
+         description:
+           - Whether the custom field is displayed in the UI
+         required: false
+         choices: 
+           - always
+           - if-set
+           - hidden
+         type: str      
+         version_added: "3.17.0"
       ui_visibility:
          description:
            - The UI visibility of the custom field
+           - Replaced by C(ui_visible) and C(ui_editabl)e in NetBox 3.7
          required: false
          choices: 
            - read-write
@@ -245,6 +266,24 @@ def main():
                     weight=dict(required=False, type="int"),
                     search_weight=dict(required=False, type="int"),
                     group_name=dict(required=False, type="str"),
+                    ui_editable=dict(
+                        required=False,
+                        choices=[
+                            "yes",
+                            "no",
+                            "hidden",
+                        ],
+                        type="str",
+                    ),
+                    ui_visible=dict(
+                        required=False,
+                        choices=[
+                            "always",
+                            "if-set",
+                            "hidden",
+                        ],
+                        type="str",
+                    ),
                     ui_visibility=dict(
                         required=False,
                         choices=[

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -111,8 +111,8 @@ options:
            - Whether the custom field is editable in the UI
          required: false
          choices: 
-           - yes
-           - no
+           - "yes"
+           - "no"
            - hidden
          type: str      
          version_added: "3.17.0"

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -129,7 +129,7 @@ options:
       ui_visibility:
          description:
            - The UI visibility of the custom field
-           - Replaced by C(ui_visible) and C(ui_editabl)e in NetBox 3.7
+           - Replaced by O(ui_visible) and O(ui_editable) in NetBox 3.7
          required: false
          choices: 
            - read-write


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->
#1135

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->
Add to CustomField the 2 new UI visibility parameters.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Add ui_editable and ui_visible parameters that are new in NetBox 3.8.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Just add the new parameters and keep the old `ui_visibility` for backwards
compatibility with pre-3.7.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

Added the 2 new parameters to module documentation.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Support CustomField UI visibility in NetBox 3.8.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
