### PR TITLE
vlan group option name is 'vlan_group' not 'group'

### DIFF
--- a/docs/plugins/netbox_vlan_module.rst
+++ b/docs/plugins/netbox_vlan_module.rst
@@ -796,7 +796,7 @@ Examples
               name: Test VLAN
               vid: 400
               site: Test Site
-              group: Test VLAN Group
+              vlan_group: Test VLAN Group
               tenant: Test Tenant
               status: Deprecated
               vlan_role: Test VLAN Role

--- a/plugins/modules/netbox_vlan.py
+++ b/plugins/modules/netbox_vlan.py
@@ -122,7 +122,7 @@ EXAMPLES = r"""
           name: Test VLAN
           vid: 400
           site: Test Site
-          group: Test VLAN Group
+          vlan_group: Test VLAN Group
           tenant: Test Tenant
           status: Deprecated
           vlan_role: Test VLAN Role


### PR DESCRIPTION
## Related Issue

#1137

## New Behavior

Correct option name for vlan groups in docs.  No change to operation.

## Contrast to Current Behavior

new behavior is the examples for vlan use the correct option name for vlan groups.

## Discussion: Benefits and Drawbacks

The benefit is a microscopic improvement in the documentation examples for creating VLANs

There are no known drawbacks.

## Changes to the Documentation

This is a change to the docs, so ...

## Proposed Release Note Entry

Corrected VLAN group option name in documentation.

## Double Check

* [X ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ X] I have explained my PR according to the information in the comments or in a linked issue.
* [ X] My PR targets the `devel` branch.
