### PR TITLE
Add description to Rack Role

### DIFF
--- a/plugins/modules/netbox_rack_role.py
+++ b/plugins/modules/netbox_rack_role.py
@@ -45,6 +45,12 @@ options:
           - Hexidecimal code for a color, ex. FFFFFF
         required: false
         type: str
+      description:
+        description:
+          - Description of the rack role
+        required: false
+        type: str
+        version_added: "3.17.0"
       tags:
         description:
           - The tags to add/update
@@ -75,6 +81,16 @@ EXAMPLES = r"""
         data:
           name: Test rack role
           color: FFFFFF
+        state: present
+
+    - name: Create rack role within NetBox with a description
+      netbox.netbox.netbox_rack_role:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test rack role
+          color: FFFFFF
+          description: This is a test rack role
         state: present
 
     - name: Delete rack role within netbox
@@ -122,6 +138,7 @@ def main():
                     name=dict(required=True, type="str"),
                     slug=dict(required=False, type="str"),
                     color=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
                 ),

--- a/tests/integration/targets/v3.6/tasks/netbox_rack_role.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_rack_role.yml
@@ -50,6 +50,7 @@
     data:
       name: Rack Role
       color: "003EFF"
+      description: "This is a Rack Role test"
     state: present
   register: test_three
 
@@ -61,6 +62,7 @@
       - test_three['rack_role']['name'] == "Rack Role"
       - test_three['rack_role']['slug'] == "rack-role"
       - test_three['rack_role']['color'] == "003eff"
+      - test_three['rack_role']['description'] == "This is a Rack Role test"
       - test_three['msg'] == "rack_role Rack Role updated"
 
 - name: "RACK_ROLE 4: Delete"


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1142 

## New Behavior

Add the field `description` to `Rack Role`

## Contrast to Current Behavior

The field `description` is not able to be used in `Rack Role`

## Discussion: Benefits and Drawbacks

`Benefit`: Users will now be able to use `description` in `Rack Role`
`Drawbacks`: None
`Backwards Compatible`: Yes

## Changes to the Documentation

I believe the change is self-documenting. Let me know if I need to change something.

## Proposed Release Note Entry

Add the field `description` to `Rack Role`

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
