### PR TITLE
Remove unused imports

### DIFF
--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -6,10 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 # Import necessary packages
-import traceback
 from ipaddress import ip_interface
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import missing_required_lib
 
 from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import (
     NetboxModule,


### PR DESCRIPTION
This was uncovered by dependabot using a new version of ansible-core where I guess the sanity tests now check for unused imports.

https://github.com/netbox-community/ansible_modules/actions/runs/7515500523/job/20459479535