### PR TITLE
Remove Jinja2 template delimeters from assert

### DIFF
--- a/tests/integration/targets/v3.5/tasks/netbox_tenant_group.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_tenant_group.yml
@@ -90,7 +90,7 @@
       - test_five['diff']['before']['state'] == "absent"
       - test_five['diff']['after']['state'] == "present"
       - test_five['tenant_group']['name'] == "Child Test Tenant Group"
-      - test_five['tenant_group']['parent'] == {{ test_four.tenant_group.id }}
+      - test_five['tenant_group']['parent'] == test_four.tenant_group.id
       - test_five['msg'] == "tenant_group Child Test Tenant Group created"
 
 - name: "6 - Test child tenant group deletion"

--- a/tests/integration/targets/v3.6/tasks/netbox_tenant_group.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_tenant_group.yml
@@ -90,7 +90,7 @@
       - test_five['diff']['before']['state'] == "absent"
       - test_five['diff']['after']['state'] == "present"
       - test_five['tenant_group']['name'] == "Child Test Tenant Group"
-      - test_five['tenant_group']['parent'] == {{ test_four.tenant_group.id }}
+      - test_five['tenant_group']['parent'] == test_four.tenant_group.id
       - test_five['msg'] == "tenant_group Child Test Tenant Group created"
 
 - name: "6 - Test child tenant group deletion"

--- a/tests/integration/targets/v3.7/tasks/netbox_tenant_group.yml
+++ b/tests/integration/targets/v3.7/tasks/netbox_tenant_group.yml
@@ -90,7 +90,7 @@
       - test_five['diff']['before']['state'] == "absent"
       - test_five['diff']['after']['state'] == "present"
       - test_five['tenant_group']['name'] == "Child Test Tenant Group"
-      - test_five['tenant_group']['parent'] == {{ test_four.tenant_group.id }}
+      - test_five['tenant_group']['parent'] == test_four.tenant_group.id
       - test_five['msg'] == "tenant_group Child Test Tenant Group created"
 
 - name: "6 - Test child tenant group deletion"


### PR DESCRIPTION
This clears an error with newer Ansible ansible core where conditionals with template tags are marked as unsafe and fail to evaluate

This is required for #1152 