### PR TITLE
add support to fetch cluster device information from netbox.

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -537,6 +537,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "custom_fields": self.extract_custom_fields,
             "region": self.extract_regions,
             "cluster": self.extract_cluster,
+            "cluster_device": self.extract_cluster_device,
             "cluster_group": self.extract_cluster_group,
             "cluster_type": self.extract_cluster_type,
             "is_virtual": self.extract_is_virtual,
@@ -940,6 +941,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         try:
             # cluster does not have a slug
             return host["cluster"]["name"]
+        except Exception:
+            return
+
+    def extract_cluster_device(self, host):
+        try:
+            # cluster device does not have a slug
+            return host["device"]["name"]
         except Exception:
             return
 


### PR DESCRIPTION
## Related Issue

#852 

## New Behavior

in ansible netbox inventory will exist a new hostvar with name cluster_device if corresponding information is set in netbox.

...

## Contrast to Current Behavior

currently the information is missing in the netbox inventory

...

## Discussion: Benefits and Drawbacks

Benefit: More Information can be used from netbox inventory
drawback: i see no one.
backwards-compatible: i think yes, but can't test how far in the past it gets.
i need this information to configure high availability and replication tasks in proxmox over api.

...

## Changes to the Documentation

no changes needed in my opinion

...

## Proposed Release Note Entry

add support to fetch cluster device information for virtual machine resources from netbox.

...

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
