### PR TITLE
Add Config template to device and virtual machine

### DIFF
--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -183,6 +183,7 @@ options:
           - Configuration template
         required: false
         type: raw
+        version_added: "3.17.0"
     required: true
     type: dict
 """

--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -178,6 +178,11 @@ options:
           - Arbitrary JSON data to define the devices configuration variables.
         required: false
         type: dict
+      config_template:
+        description:
+          - Configuration template
+        required: false
+        type: raw
     required: true
     type: dict
 """
@@ -321,6 +326,7 @@ def main():
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     local_context_data=dict(required=False, type="dict"),
+                    config_template=dict(required=False, type="raw"),
                     custom_fields=dict(required=False, type="dict"),
                 ),
             ),

--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -122,6 +122,11 @@ options:
           - Comments of the virtual machine
         required: false
         type: str
+      config_template:
+        description:
+          - Configuration template
+        required: false
+        type: raw
     required: true
 """
 
@@ -223,6 +228,7 @@ def main():
                     custom_fields=dict(required=False, type="dict"),
                     local_context_data=dict(required=False, type="dict"),
                     description=dict(required=False, type="str"),
+                    config_template=dict(required=False, type="raw"),
                     comments=dict(required=False, type="str"),
                 ),
             ),

--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -127,6 +127,7 @@ options:
           - Configuration template
         required: false
         type: raw
+        version_added: "3.17.0"
     required: true
 """
 


### PR DESCRIPTION
Add config_template option on netbox_device and netbox_virtual_machine. Virtual machine is dependent on https://github.com/netbox-community/netbox/issues/15070

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
