### PR TITLE
Dont extract null values from custom fields (nb_inventory)

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -867,7 +867,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def extract_custom_fields(self, host):
         try:
-            return host["custom_fields"]
+            return {
+                key: value
+                for key, value in host["custom_fields"].items()
+                if value is not None
+            }
         except Exception:
             return
 

--- a/tests/unit/inventory/test_data/extract_custom_fields/data.json
+++ b/tests/unit/inventory/test_data/extract_custom_fields/data.json
@@ -1,0 +1,21 @@
+[
+    {
+        "custom_fields": {
+            "a_text_value": "value1",
+            "a_bool_value": false
+        },
+        "expected": {
+            "a_text_value": "value1",
+            "a_bool_value": false
+        }
+    },
+    {
+        "custom_fields": {
+            "an_unset_value": null,
+            "a_set_value": false
+        },
+        "expected": {
+            "a_set_value": false
+        }
+    }
+]

--- a/tests/unit/inventory/test_nb_inventory.py
+++ b/tests/unit/inventory/test_nb_inventory.py
@@ -246,3 +246,14 @@ def test_new_token(inventory_fixture, templar_fixture):
 
     assert "Authorization" in inventory_fixture.headers
     assert inventory_fixture.headers["Authorization"] == "Foo bar"
+
+
+@pytest.mark.parametrize(
+    "custom_fields, expected", load_relative_test_data("extract_custom_fields")
+)
+def test_extract_custom_fields(inventory_fixture, custom_fields, expected):
+    extracted_custom_fields = inventory_fixture.extract_custom_fields(
+        {"custom_fields": custom_fields}
+    )
+
+    assert extracted_custom_fields == expected


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Only extract custom fields that are set. Netbox supports having non-required custom fields, and we don't want to set variables when the custom fields are not set in Netbox. This is particularly valuable if you are using flatten_custom_fields=True.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Custom fields that are not set in Netbox will be respected and not set in the Ansible module (e.g., they won't overwrite the variable if it's already set).

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
When flatten_custom_fields=False, the custom fields which are unset will be excluded from the custom_fields dictionary. I don't think this will cause any issues.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Unset custom fields, in combination with `flatten_custom_fields=True`, will no longer overwrite host variables.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
