### PR TITLE
Added custom-field-choice-sets to nb_lookup.py

### DIFF
--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -181,6 +181,7 @@ def get_endpoint(netbox, term):
         "console-server-ports": {"endpoint": netbox.dcim.console_server_ports},
         "content-types": {"endpoint": netbox.extras.content_types},
         "custom-fields": {"endpoint": netbox.extras.custom_fields},
+        "custom-field-choice-sets": {"endpoint": netbox.extras.custom_field_choice_sets},
         "custom-links": {"endpoint": netbox.extras.custom_links},
         "device-bay-templates": {"endpoint": netbox.dcim.device_bay_templates},
         "device-bays": {"endpoint": netbox.dcim.device_bays},

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -181,7 +181,9 @@ def get_endpoint(netbox, term):
         "console-server-ports": {"endpoint": netbox.dcim.console_server_ports},
         "content-types": {"endpoint": netbox.extras.content_types},
         "custom-fields": {"endpoint": netbox.extras.custom_fields},
-        "custom-field-choice-sets": {"endpoint": netbox.extras.custom_field_choice_sets},
+        "custom-field-choice-sets": {
+            "endpoint": netbox.extras.custom_field_choice_sets
+        },
         "custom-links": {"endpoint": netbox.extras.custom_links},
         "device-bay-templates": {"endpoint": netbox.dcim.device_bay_templates},
         "device-bays": {"endpoint": netbox.dcim.device_bays},


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1185 

## New Behavior

Since NetBox v3.6.0 there is an breaking change where the custom-fields and choices are split.


## Contrast to Current Behavior

Currently there is no way to access the custom field choices when using NetBox v3.6.0 or higher


## Discussion: Benefits and Drawbacks

_Why do you think this project and the community will benefit from your proposed change?_

Starting from NetBox v3.6.0 it is not possible to use the lookup module to get the custom field choices.

_What are the drawbacks of this change?_

I do not know what happens when someone using it with an NetBox version lower than v3.6.0.

_Is it backwards-compatible?_

NetBox <v3.6.0; Use `custom-fields` to get the choices.
Netbox >v3.6.0; Use `custom-field-choice-sets`

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->


## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

Added `custom-field-choice-sets` to the lookup plugin.

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
