### PR TITLE
Change u_height to float

### DIFF
--- a/docs/plugins/netbox_device_type_module.rst
+++ b/docs/plugins/netbox_device_type_module.rst
@@ -1087,7 +1087,7 @@ Examples
               model: ws-test-3750
               manufacturer: Test Manufacturer
               part_number: ws-3750g-v2
-              u_height: 1
+              u_height: 1.5
               is_full_depth: False
               subdevice_role: parent
             state: present

--- a/plugins/modules/netbox_device_type.py
+++ b/plugins/modules/netbox_device_type.py
@@ -54,7 +54,7 @@ options:
         description:
           - The height of the device type in rack units
         required: false
-        type: int
+        type: float
       weight:
         description:
           - The weight of the device type
@@ -159,7 +159,7 @@ EXAMPLES = r"""
           model: ws-test-3750
           manufacturer: Test Manufacturer
           part_number: ws-3750g-v2
-          u_height: 1
+          u_height: 1.5
           is_full_depth: False
           subdevice_role: parent
         state: present
@@ -210,7 +210,7 @@ def main():
                     model=dict(required=True, type="raw"),
                     slug=dict(required=False, type="str"),
                     part_number=dict(required=False, type="str"),
-                    u_height=dict(required=False, type="int"),
+                    u_height=dict(required=False, type="float"),
                     weight=dict(required=False, type="float"),
                     weight_unit=dict(
                         required=False,

--- a/plugins/modules/netbox_rack.py
+++ b/plugins/modules/netbox_rack.py
@@ -106,7 +106,7 @@ options:
         description:
           - The height of the rack in rack units
         required: false
-        type: int
+        type: float
       desc_units:
         description:
           - Rack units will be numbered top-to-bottom
@@ -298,7 +298,7 @@ def main():
                             23,
                         ],
                     ),
-                    u_height=dict(required=False, type="int"),
+                    u_height=dict(required=False, type="float"),
                     desc_units=dict(required=False, type="bool"),
                     outer_width=dict(required=False, type="int"),
                     outer_depth=dict(required=False, type="int"),

--- a/tests/integration/targets/v3.5/tasks/netbox_device_type.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_device_type.yml
@@ -55,7 +55,7 @@
       model: ws-test-3750
       manufacturer: Test Manufacturer
       part_number: ws-3750g-v2
-      u_height: 1
+      u_height: 1.5
       is_full_depth: false
       subdevice_role: parent
     state: present

--- a/tests/integration/targets/v3.6/tasks/netbox_device_type.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_device_type.yml
@@ -55,7 +55,7 @@
       model: ws-test-3750
       manufacturer: Test Manufacturer
       part_number: ws-3750g-v2
-      u_height: 1
+      u_height: 1.5
       is_full_depth: false
       subdevice_role: parent
     state: present

--- a/tests/integration/targets/v3.7/tasks/netbox_device_type.yml
+++ b/tests/integration/targets/v3.7/tasks/netbox_device_type.yml
@@ -55,7 +55,7 @@
       model: ws-test-3750
       manufacturer: Test Manufacturer
       part_number: ws-3750g-v2
-      u_height: 1
+      u_height: 1.5
       is_full_depth: false
       subdevice_role: parent
     state: present


### PR DESCRIPTION
Some devices have a non-integer size, such as 1.5U, indicating that they occupy an intermediate space. Netbox accepts float variables, allowing for precise representation of these non-integer sizes.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

...

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
