### PR TITLE
Change position type to float for netbox_device module

### DIFF
--- a/docs/plugins/netbox_device_module.rst
+++ b/docs/plugins/netbox_device_module.rst
@@ -846,7 +846,7 @@ Parameters
 
       .. ansible-option-type-line::
 
-        :ansible-option-type:`integer`
+        :ansible-option-type:`float`
 
       .. raw:: html
 
@@ -1602,7 +1602,7 @@ Examples
             data:
               name: Test Device
               rack: Test Rack
-              position: 10
+              position: 10.5
               face: Front
             state: present
 

--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -85,7 +85,7 @@ options:
         description:
           - The position of the device in the rack defined above
         required: false
-        type: int
+        type: float
       face:
         description:
           - Required if I(rack) is defined
@@ -247,7 +247,7 @@ EXAMPLES = r"""
         data:
           name: Test Device
           rack: Test Rack
-          position: 10
+          position: 10.5
           face: Front
         state: present
 """
@@ -296,7 +296,7 @@ def main():
                     site=dict(required=False, type="raw"),
                     location=dict(required=False, type="raw"),
                     rack=dict(required=False, type="raw"),
-                    position=dict(required=False, type="int"),
+                    position=dict(required=False, type="float"),
                     face=dict(
                         required=False,
                         type="str",

--- a/tests/integration/targets/v3.5/tasks/netbox_device.yml
+++ b/tests/integration/targets/v3.5/tasks/netbox_device.yml
@@ -129,7 +129,7 @@
       device_role: "Core Switch"
       site: "Test Site2"
       rack: "Test Rack Site 2"
-      position: 35
+      position: 35.5
       face: "Front"
       tags:
         - "schnozzberry"

--- a/tests/integration/targets/v3.6/tasks/netbox_device.yml
+++ b/tests/integration/targets/v3.6/tasks/netbox_device.yml
@@ -129,7 +129,7 @@
       device_role: "Core Switch"
       site: "Test Site2"
       rack: "Test Rack Site 2"
-      position: 35
+      position: 35.5
       face: "Front"
       tags:
         - "schnozzberry"

--- a/tests/integration/targets/v3.7/tasks/netbox_device.yml
+++ b/tests/integration/targets/v3.7/tasks/netbox_device.yml
@@ -129,7 +129,7 @@
       device_role: "Core Switch"
       site: "Test Site2"
       rack: "Test Rack Site 2"
-      position: 35
+      position: 35.5
       face: "Front"
       tags:
         - "schnozzberry"


### PR DESCRIPTION
Similarly, devices may occupy non-integer positions, such as 1.5, within a rack. Enabling float variables for position allows for accurate placement of devices at intermediate positions.

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

...

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
