### PR TITLE
feat: make `oob_ip` available regardless of `oob_ip_as_primary_ip`

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1875,8 +1875,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self.inventory.set_variable(hostname, "primary_ip6", extracted_primary_ip6)
 
         extracted_oob_ip = self.extract_oob_ip(host=host)
-        if extracted_oob_ip and self.oob_ip_as_primary_ip:
-            self.inventory.set_variable(hostname, "ansible_host", extracted_oob_ip)
+        if extracted_oob_ip:
+            self.inventory.set_variable(hostname, "oob_ip", extracted_oob_ip)
+            if self.oob_ip_as_primary_ip:
+                self.inventory.set_variable(hostname, "ansible_host", extracted_oob_ip)
 
         for attribute, extractor in self.group_extractors.items():
             extracted_value = extractor(host)


### PR DESCRIPTION
## Related Issue

Related to https://github.com/netbox-community/ansible_modules/pull/1081

## New Behavior

Makes `oob_ip` always available in the hostvars if it exists.

## Discussion: Benefits and Drawbacks

Not sure why we make `oob_ip` available only when `oob_ip_as_primary_ip` is set.

I believe there is value to access this property without altering `ansible_host`.

## Changes to the Documentation

None

## Proposed Release Note Entry

- `oob_ip` is now returned in hostvars if set
- Add the ability to set out of band IP as ansible host.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
