### PR TITLE
Add cluster host to the plugins response

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -538,6 +538,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "cluster": self.extract_cluster,
             "cluster_group": self.extract_cluster_group,
             "cluster_type": self.extract_cluster_type,
+            "cluster_device": self.extract_cluster_device,
             "is_virtual": self.extract_is_virtual,
             "serial": self.extract_serial,
             "asset_tag": self.extract_asset_tag,
@@ -946,6 +947,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             return self.clusters_type_lookup[host["cluster"]["id"]]
         except Exception:
             return
+
+    def extract_cluster_device(self, host):
+        return host.get("device")
 
     def extract_is_virtual(self, host):
         return host.get("is_virtual")


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->
N/A

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->
Adds the GUI information `Cluster -> Device` to the plugin's response. See output of `ansible-inventory`:
```
    "cluster_device": {
        "display": "proxmox-host-01",
        "id": 01,
        "name": "proxmox-host-01",
        "url": "https://net.box/api/dcim/devices/01/"
    },
```

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->
So far, the inventory plugin does not return any information about the "Device" a VM is assigned to. Only the cluster name or type are available.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
This change allows defining a Device/Host a VM should run on. Sometimes specific VMs must run on a specific host. Ansible may pick up that information, for example creating the VM on that host.
In general, if that information is available in the UI, it will be beneficial to have it returned to Ansible as well.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->
Since this is not supposed to be a `group_by` parameter, no changes are required.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
Add the cluster.device information to the plugin response.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
