### PR TITLE
added label to poweroutlet

### DIFF
--- a/plugins/modules/netbox_power_outlet.py
+++ b/plugins/modules/netbox_power_outlet.py
@@ -41,6 +41,11 @@ options:
           - The name of the power outlet
         required: true
         type: str
+      label:
+        description:
+          - The label of the power outlet
+        required: false
+        type: str
       type:
         description:
           - The type of the power outlet
@@ -202,6 +207,7 @@ def main():
                 options=dict(
                     device=dict(required=True, type="raw"),
                     name=dict(required=True, type="str"),
+                    label=dict(required=False, type="str"),
                     type=dict(
                         required=False,
                         choices=[


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
There are no open related issues.
<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior
Added label to the poweroutlet module.
<!--
Please describe in a few words the intentions of your PR.
-->

...

## Contrast to Current Behavior
Possible to add a label to a poweroutlets in NetBox.
<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

...

## Discussion: Benefits and Drawbacks
We use NetBox in my organisation and I need to create labels for poweroutlets.
Since the option to add a label is optional it should not be a problem with backward compatibility.
I did test it in NetBox v3.5.9 
<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Documentation
Added a description of the label option in plugins/modules/netbox_power_outlets.py 
<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ x] I have explained my PR according to the information in the comments or in a linked issue.
* [ x] My PR targets the `devel` branch.
