### PR TITLE
add ALLOWED_QUERY_PARAMS module_bay by device

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -492,7 +492,7 @@ ALLOWED_QUERY_PARAMS = {
     "lag": set(["name"]),
     "location": set(["name", "slug", "site"]),
     "module": set(["device", "module_bay", "module_type"]),
-    "module_bay": set(["name"]),
+    "module_bay": set(["device", "name"]),
     "module_type": set(["model"]),
     "manufacturer": set(["slug"]),
     "master": set(["name"]),


### PR DESCRIPTION
## New Behavior

add ALLOWED_QUERY_PARAMS module_bay by device

## Contrast to Current Behavior

When adding a module, module bays are not uniquely identifiable by name only.

## Discussion: Benefits and Drawbacks

none

## Changes to the Documentation

none

## Proposed Release Note Entry

add ALLOWED_QUERY_PARAMS module_bay by device

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
