### PR TITLE
added power outlet type iec-60320-c21 to template

### DIFF
--- a/plugins/modules/netbox_power_outlet_template.py
+++ b/plugins/modules/netbox_power_outlet_template.py
@@ -50,6 +50,7 @@ options:
           - iec-60320-c13
           - iec-60320-c15
           - iec-60320-c19
+          - iec-60320-c21
           - iec-60309-p-n-e-4h
           - iec-60309-p-n-e-6h
           - iec-60309-p-n-e-9h
@@ -198,6 +199,7 @@ def main():
                             "iec-60320-c13",
                             "iec-60320-c15",
                             "iec-60320-c19",
+                            "iec-60320-c21",
                             "iec-60309-p-n-e-4h",
                             "iec-60309-p-n-e-6h",
                             "iec-60309-p-n-e-9h",


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->
#1229

## New Behavior
Ability to use power outlet of type iec-60320-c21 with power outlet templates.

<!--
Please describe in a few words the intentions of your PR.
-->

...

## Contrast to Current Behavior
Power outlet type iec-60320-c21 is supporter by NetBox but is missing from the power outlet templates module.
<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry
Added power outlet type iec-60320-c21 to netbox_power_outlet_template module.
<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ x] I have explained my PR according to the information in the comments or in a linked issue.
* [ x] My PR targets the `devel` branch.
