### PR TITLE
Drop obsolete versions and fix ansible-test sanity Fixes #1241

### DIFF
--- a/docs/_extensions/pygments_lexer.py
+++ b/docs/_extensions/pygments_lexer.py
@@ -38,8 +38,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from pygments.lexer import (
-    LexerContext,
-    ExtendedRegexLexer,
     DelegatingLexer,
     RegexLexer,
     bygroups,
@@ -47,8 +45,6 @@ from pygments.lexer import (
 )
 from pygments.lexers import DiffLexer
 from pygments import token
-
-import re
 
 
 class AnsibleOutputPrimaryLexer(RegexLexer):

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">=2.9.10"
+requires_ansible: ">=2.15.0"
 plugin_routing:
   modules:
     netbox_interface:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -135,9 +135,9 @@ DOCUMENTATION = """
             description:
                 - By default, fetching interfaces and services will get all of the contents of NetBox regardless of query_filters applied to devices and VMs.
                 - When set to False, separate requests will be made fetching interfaces, services, and IP addresses for each device_id and virtual_machine_id.
-                - If you are using the various query_filters options to reduce the number of devices, you may find querying NetBox faster with fetch_all set to False.
+                - If you are using various query_filters options to reduce the number of devices, querying NetBox may be faster with fetch_all set to False.
                 - For efficiency, when False, these requests will be batched, for example /api/dcim/interfaces?limit=0&device_id=1&device_id=2&device_id=3
-                - These GET request URIs can become quite large for a large number of devices. If you run into HTTP 414 errors, you can adjust the max_uri_length option to suit your web server.
+                - For large numbers of devices, GET URIs can become quite long. If you encounter HTTP 414 errors, adjust max_uri_length to suit your web server.
             default: True
             type: boolean
             version_added: "0.2.1"

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -20,7 +20,7 @@ DOCUMENTATION = """
     short_description: Queries and returns elements from NetBox
     description:
         - Queries NetBox via its API to return virtually any information
-          capable of being held in NetBox.        
+          capable of being held in NetBox.
     options:
         _terms:
             description:
@@ -60,12 +60,12 @@ DOCUMENTATION = """
             description:
                 - (DEPRECATED) - NetBox 2.11 and earlier only
                 - The private key as a string. Mutually exclusive with I(key_file).
-            required: False            
+            required: False
         key_file:
             description:
                 - (DEPRECATED) - NetBox 2.11 and earlier only
                 - The location of the private key tied to user account. Mutually exclusive with I(private_key).
-            required: False            
+            required: False
         raw_data:
             type: bool
             description:

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1105,7 +1105,8 @@ class NetboxModule(object):
                 user_query_params if user_query_params else query_params
             )
             self._handle_errors(
-                f"One or more of the kwargs provided are invalid for {parent}, provided kwargs: {', '.join(sorted(provided_kwargs))}. Acceptable kwargs: {', '.join(sorted(acceptable_query_params))}"
+                f"One or more of the kwargs provided are invalid for {parent}, provided kwargs: " +
+                "{', '.join(sorted(provided_kwargs))}. Acceptable kwargs: {', '.join(sorted(acceptable_query_params))}"
             )
 
         query_dict = self._convert_identical_keys(query_dict)
@@ -1119,7 +1120,8 @@ class NetboxModule(object):
             endpoint_choices = nb_endpoint.choices()
         except ValueError:
             self._handle_errors(
-                msg="Failed to fetch endpoint choices to validate against. This requires a write-enabled token. Make sure the token is write-enabled. If looking to fetch only information, use either the inventory or lookup plugin."
+                msg="Failed to fetch endpoint choices to validate against. This requires a write-enabled token. Make sure the token is write-enabled. " +
+                "If looking to fetch only information, use either the inventory or lookup plugin."
             )
 
         choices = list(chain.from_iterable(endpoint_choices.values()))

--- a/plugins/modules/netbox_circuit_termination.py
+++ b/plugins/modules/netbox_circuit_termination.py
@@ -44,7 +44,7 @@ options:
         required: true
         type: str
       mark_connected:
-        description: 
+        description:
           - Treat as if cable is connected
         required: false
         type: bool

--- a/plugins/modules/netbox_config_template.py
+++ b/plugins/modules/netbox_config_template.py
@@ -50,7 +50,7 @@ options:
           - Any additional parameters to pass when constructing the Jinja2 environment
         required: false
         type: dict
-      template_code: 
+      template_code:
         description:
           - The template code to be rendered.
         required: false
@@ -73,7 +73,7 @@ EXAMPLES = r"""
             - Cloud
           template_code: |
             #cloud-config
-            packages: 
+            packages:
               - ansible
 
     - name: Delete config template

--- a/plugins/modules/netbox_contact.py
+++ b/plugins/modules/netbox_contact.py
@@ -75,7 +75,7 @@ options:
           - URL associated with the contact
         required: false
         type: str
-        version_added: "3.7.0"    
+        version_added: "3.7.0"
       tags:
         description:
           - Any tags that the contact may need to be associated with
@@ -117,10 +117,10 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          name: contact ABC          
+          name: contact ABC
           title: Mr Contact
           phone: 123456789
-          email: contac@contact.com          
+          email: contac@contact.com
           tags:
             - tagA
             - tagB

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -13,7 +13,7 @@ module: netbox_custom_field
 short_description: Creates, updates or deletes custom fields within NetBox
 description:
   - Creates, updates or removes custom fields from NetBox
-notes:  
+notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Martin Rødvand (@rodvand)
@@ -41,11 +41,11 @@ options:
         type: list
         elements: raw
         version_added: "3.19.0"
-      type: 
-        description: 
+      type:
+        description:
           - The type of custom field
         required: false
-        choices: 
+        choices:
           - text
           - longtext
           - integer
@@ -60,8 +60,8 @@ options:
           - object
           - multiobject
         type: str
-      object_type: 
-        description: 
+      object_type:
+        description:
           - The object type of the custom field (if any)
         required: false
         type: str
@@ -111,18 +111,18 @@ options:
         description:
           - The group to associate the custom field with
         required: false
-        type: str      
+        type: str
         version_added: "3.10.0"
       ui_visibility:
          description:
            - The UI visibility of the custom field
          required: false
-         choices: 
+         choices:
            - read-write
            - read-only
            - hidden
            - hidden-ifunset
-         type: str      
+         type: str
          version_added: "3.10.0"
       validation_minimum:
         description:
@@ -138,10 +138,10 @@ options:
         description:
           - The regular expression to enforce on text fields
         required: false
-        type: str      
+        type: str
       choice_set:
         description:
-          - The name of the choice set to use (for selection fields) 
+          - The name of the choice set to use (for selection fields)
         required: false
         type: str
     required: true
@@ -150,7 +150,7 @@ options:
 EXAMPLES = r"""
 - name: "Test NetBox custom_fields module"
   connection: local
-  hosts: localhost  
+  hosts: localhost
   tasks:
     - name: Create a custom field on device and virtual machine
       netbox.netbox.netbox_custom_field:
@@ -181,7 +181,7 @@ EXAMPLES = r"""
         netbox_token: thisIsMyToken
         data:
           name: A Custom Field
-          required: yes    
+          required: yes
 
     - name: Update the custom field to make it read only
       netbox.netbox.netbox_custom_field:
@@ -189,7 +189,7 @@ EXAMPLES = r"""
         netbox_token: thisIsMyToken
         data:
           name: A Custom Field
-          ui_visibility: read-only      
+          ui_visibility: read-only
 
     - name: Delete the custom field
       netbox.netbox.netbox_custom_field:

--- a/plugins/modules/netbox_custom_field_choice_set.py
+++ b/plugins/modules/netbox_custom_field_choice_set.py
@@ -13,7 +13,7 @@ module: netbox_custom_field_choice_set
 short_description: Creates, updates or deletes custom field choice sets within Netbox
 description:
   - Creates, updates or removes custom fields choice sets from Netbox
-notes:  
+notes:
   - This should be run with connection C(local) and hosts C(localhost)
 author:
   - Philipp Rintz (@p-rintz)
@@ -40,11 +40,11 @@ options:
         type: str
       extra_choices:
         description:
-          - List of available choices in the choice set 
+          - List of available choices in the choice set
         required: false
         default: []
         type: list
-        elements: list                
+        elements: list
       base_choices:
         description:
          - Selection of base choice to use in the choice set
@@ -53,7 +53,7 @@ options:
         choices:
          - IATA
          - ISO_3166
-         - UN_LOCODE    
+         - UN_LOCODE
       order_alphabetically:
         description:
           - Order the choices alphabetically
@@ -65,7 +65,7 @@ options:
 EXAMPLES = r"""
 - name: "Test Netbox custom_field_choice_set module"
   connection: local
-  hosts: localhost  
+  hosts: localhost
   tasks:
     - name: Create a choice set with choices
       netbox.netbox.netbox_custom_field_choice_set:

--- a/plugins/modules/netbox_custom_link.py
+++ b/plugins/modules/netbox_custom_link.py
@@ -13,7 +13,7 @@ module: netbox_custom_link
 short_description: Creates, updates or deletes custom links within NetBox
 description:
   - Creates, updates or removes custom links from NetBox
-notes:  
+notes:
   - This should be ran with connection C(local) and hosts C(localhost)
   - Use the C(!unsafe) data type if you want jinja2 code in link_text or link_url
 author:
@@ -33,23 +33,23 @@ options:
         description:
           - The content type to apply this custom link to
         required: false
-        type: raw   
+        type: raw
       content_types:
         description:
           - The content type to apply this custom link to (NetBox 3.4+)
         required: false
         type: list
-        elements: raw 
+        elements: raw
         version_added: "3.10.0"
       object_types:
         description:
           - The object type(s) to apply this custom link to (NetBox 4.0+)
         required: false
         type: list
-        elements: raw 
+        elements: raw
         version_added: "3.19.0"
-      name: 
-        description: 
+      name:
+        description:
           - The name of the custom link
         required: true
         type: str
@@ -62,57 +62,57 @@ options:
         description:
           - Link URL of the custom link
         required: true
-        type: raw                
+        type: raw
       weight:
         description:
           - Fields with higher weights appear lower in a form
         required: false
-        type: int      
+        type: int
       group_name:
         description:
           - The group to associate the custom link with
         required: false
-        type: str      
+        type: str
       button_class:
         description:
-          - Button class for the custom link 
+          - Button class for the custom link
         required: false
         type: raw
       new_window:
         description:
-          - Open link in new window 
-        required: false
-        type: bool   
-      enabled:
-        description:
-          - Enable/disable custom link 
+          - Open link in new window
         required: false
         type: bool
-        version_added: "3.7.0"                      
+      enabled:
+        description:
+          - Enable/disable custom link
+        required: false
+        type: bool
+        version_added: "3.7.0"
     required: true
 """
 
 EXAMPLES = r"""
 - name: "Test NetBox custom_link module"
   connection: local
-  hosts: localhost  
+  hosts: localhost
   tasks:
     - name: Create a custom link on device
       netbox.netbox.netbox_custom_link:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          content_type: "dcim.device"            
+          content_type: "dcim.device"
           name: Custom Link
           link_text: "Open Web Management"
-          link_url: !unsafe https://{{ obj.name }}.domain.local                        
+          link_url: !unsafe https://{{ obj.name }}.domain.local
 
     - name: Delete the custom link
       netbox.netbox.netbox_custom_link:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          content_type: "dcim.device"            
+          content_type: "dcim.device"
           name: Custom Link
           link_text: "Open Web Management"
           link_url: !unsafe https://{{ obj.name }}.domain.local

--- a/plugins/modules/netbox_device.py
+++ b/plugins/modules/netbox_device.py
@@ -100,13 +100,13 @@ options:
         description:
           - Airflow of the device
         choices:
-          - front-to-rear 
-          - rear-to-front 
-          - left-to-right 
-          - right-to-left 
+          - front-to-rear
+          - rear-to-front
+          - left-to-right
+          - right-to-left
           - side-to-rear
           - passive
-          - mixed                    
+          - mixed
         required: false
         type: str
         version_added: "3.10.0"

--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -75,7 +75,7 @@ options:
           - Bridge the interface will connected to
         required: false
         type: raw
-        version_added: "3.6.0" 
+        version_added: "3.6.0"
       mtu:
         description:
           - The MTU of the interface

--- a/plugins/modules/netbox_device_type.py
+++ b/plugins/modules/netbox_device_type.py
@@ -81,13 +81,13 @@ options:
         description:
           - Airflow of the device
         choices:
-          - front-to-rear 
-          - rear-to-front 
-          - left-to-right 
-          - right-to-left 
+          - front-to-rear
+          - rear-to-front
+          - left-to-right
+          - right-to-left
           - side-to-rear
           - passive
-          - mixed                    
+          - mixed
         required: false
         type: str
         version_added: "3.10.0"
@@ -113,7 +113,7 @@ options:
         required: false
         type: str
       default_platform:
-        description: 
+        description:
           - Set the default platform used by the device
         required: false
         type: raw

--- a/plugins/modules/netbox_export_template.py
+++ b/plugins/modules/netbox_export_template.py
@@ -13,7 +13,7 @@ module: netbox_export_template
 short_description: Creates, updates or deletes export templates within NetBox
 description:
   - Creates, updates or removes export templates from NetBox
-notes:  
+notes:
   - This should be ran with connection C(local) and hosts C(localhost)
   - Use the C(!unsafe) data type if you want jinja2 code in template_code
 author:
@@ -39,17 +39,17 @@ options:
           - The content type to apply this export template to (NetBox 3.4+)
         required: false
         type: list
-        elements: raw 
+        elements: raw
         version_added: "3.10.0"
       object_types:
         description:
           - The object type to apply this export template to (NetBox 4.0+)
         required: false
         type: list
-        elements: raw 
+        elements: raw
         version_added: "3.10.0"
-      name: 
-        description: 
+      name:
+        description:
           - The name of the export template
         required: true
         type: str
@@ -62,7 +62,7 @@ options:
         description:
           - Template code of the export template
         required: true
-        type: raw                
+        type: raw
       mime_type:
         description:
           - MIME type of the export template
@@ -72,19 +72,19 @@ options:
         description:
           - The file extension of the export template
         required: false
-        type: str            
+        type: str
       as_attachment:
         description:
-          - Download file as attachment 
+          - Download file as attachment
         required: false
-        type: bool                                          
+        type: bool
     required: true
 """
 
 EXAMPLES = r"""
 - name: "Test NetBox export_templates module"
   connection: local
-  hosts: localhost  
+  hosts: localhost
   tasks:
     - name: "Ensure export template for /etc/hosts entries exists"
       netbox.netbox.netbox_export_template:

--- a/plugins/modules/netbox_inventory_item.py
+++ b/plugins/modules/netbox_inventory_item.py
@@ -43,8 +43,8 @@ options:
         description:
           - The parent inventory item the inventory item will be associated with
         required: false
-        type: raw     
-        version_added: "3.5.0"   
+        type: raw
+        version_added: "3.5.0"
       label:
         description:
           - The physical label of the inventory item
@@ -163,7 +163,7 @@ EXAMPLES = r"""
           description: "New SFP"
           inventory_item_role: NIC
         state: present
-        
+
     - name: Create inventory item with parent
       netbox.netbox.netbox_inventory_item:
         netbox_url: http://netbox.local

--- a/plugins/modules/netbox_inventory_item_role.py
+++ b/plugins/modules/netbox_inventory_item_role.py
@@ -48,18 +48,18 @@ options:
           - The slugified version of the name or custom slug.
           - This is auto-generated following NetBox rules if not provided
         required: false
-        type: str      
+        type: str
       tags:
         description:
           - The tags to add/update
         required: false
         type: list
-        elements: raw        
+        elements: raw
       custom_fields:
         description:
           - Must exist in NetBox
         required: false
-        type: dict        
+        type: dict
     required: true
     type: dict
 """

--- a/plugins/modules/netbox_journal_entry.py
+++ b/plugins/modules/netbox_journal_entry.py
@@ -70,7 +70,7 @@ options:
   state:
     description:
       - |
-        Use C(new) for adding a journal entry.        
+        Use C(new) for adding a journal entry.
     choices: [new]
     default: new
     type: str

--- a/plugins/modules/netbox_l2vpn.py
+++ b/plugins/modules/netbox_l2vpn.py
@@ -33,7 +33,7 @@ options:
         description:
           - The name of the L2VPN
         required: true
-        type: str              
+        type: str
       type:
         description:
           - The type of L2VPN
@@ -43,7 +43,7 @@ options:
         description:
           - The identifier of the L2VPN
         required: false
-        type: int     
+        type: int
       import_targets:
         description:
           - Route targets to import
@@ -55,7 +55,7 @@ options:
           - Route targets to export
         required: false
         type: list
-        elements: raw       
+        elements: raw
       description:
         description:
           - The description of the L2VPN
@@ -122,8 +122,8 @@ EXAMPLES = r"""
           import_targets:
             - "65000:1"
           export_targets:
-            - "65000:2"            
-          tenant: Test Tenant                    
+            - "65000:2"
+          tenant: Test Tenant
           description: Just a test
           tags:
             - Schnozzberry

--- a/plugins/modules/netbox_module.py
+++ b/plugins/modules/netbox_module.py
@@ -42,7 +42,7 @@ options:
         description:
           - The module type of the module
         required: true
-        type: raw 
+        type: raw
       status:
         description:
           - The status of the module
@@ -65,7 +65,7 @@ options:
         description:
           - The description of the module
         required: false
-        type: str  
+        type: str
       asset_tag:
         description:
           - The asset tag of the modyle
@@ -102,7 +102,7 @@ EXAMPLES = r"""
       netbox.netbox.netbox_module:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
-        data:          
+        data:
           device: C9300-DEMO
           module_bay: Network Module
           module_type: C9300-NM-8X
@@ -112,7 +112,7 @@ EXAMPLES = r"""
       netbox.netbox.netbox_module:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
-        data:          
+        data:
           device:
             name: C9300-DEMO
             site: EUPARIS

--- a/plugins/modules/netbox_module_type.py
+++ b/plugins/modules/netbox_module_type.py
@@ -37,17 +37,17 @@ options:
         description:
           - The model of the module type
         required: true
-        type: raw      
+        type: raw
       part_number:
         description:
           - The part number of the module type
         required: false
-        type: str      
+        type: str
       weight:
         description:
           - The weight of the device type
         required: false
-        type: float        
+        type: float
       weight_unit:
         description:
           - The weight unit
@@ -58,7 +58,7 @@ options:
           - oz
         required: false
         type: str
-        version_added: "3.10.0" 
+        version_added: "3.10.0"
       comments:
         description:
           - Comments that may include additional information in regards to the module type
@@ -90,7 +90,7 @@ EXAMPLES = r"""
       netbox.netbox.netbox_module_type:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
-        data:          
+        data:
           model: ws-test-3750
           manufacturer: Test Manufacturer
         state: present
@@ -99,10 +99,10 @@ EXAMPLES = r"""
       netbox.netbox.netbox_module_type:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
-        data:          
+        data:
           model: ws-test-3750
           manufacturer: Test Manufacturer
-          part_number: ws-3750g-v2          
+          part_number: ws-3750g-v2
         state: present
 
     - name: Delete module type within netbox

--- a/plugins/modules/netbox_platform.py
+++ b/plugins/modules/netbox_platform.py
@@ -96,7 +96,7 @@ EXAMPLES = r"""
         data:
           name: Test Platform
         state: present
-    
+
     - name: Create platform within NetBox with a config template
       netbox.netbox.netbox_platform:
         netbox_url: http://netbox.local

--- a/plugins/modules/netbox_service_template.py
+++ b/plugins/modules/netbox_service_template.py
@@ -47,19 +47,19 @@ options:
         choices:
           - tcp
           - udp
-          - sctp          
+          - sctp
         required: false
-        type: str      
+        type: str
       description:
         description:
           - Description of the service template
         required: false
-        type: str        
+        type: str
       comments:
         description:
           - Comments
         required: false
-        type: str        
+        type: str
       tags:
         description:
           - Any tags that the service template may need to be associated with
@@ -108,7 +108,7 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          name: SSH          
+          name: SSH
         state: absent
 """
 

--- a/plugins/modules/netbox_virtual_disk.py
+++ b/plugins/modules/netbox_virtual_disk.py
@@ -37,7 +37,7 @@ options:
         description:
           - Name of the disk to be created
         required: true
-        type: str            
+        type: str
       description:
         description:
           - The description of the disk
@@ -47,7 +47,7 @@ options:
         description:
           - The size (in GB) of the disk
         required: false
-        type: int      
+        type: int
       tags:
         description:
           - Any tags that the virtual disk may need to be associated with
@@ -58,7 +58,7 @@ options:
         description:
           - Must exist in NetBox
         required: false
-        type: dict        
+        type: dict
     required: true
     type: dict
 """
@@ -70,7 +70,7 @@ EXAMPLES = r"""
   gather_facts: False
   tasks:
     - name: Create virtual disk
-      netbox_virtual_disk:        
+      netbox_virtual_disk:
         data:
           virtual_machine: test100
           name: disk0

--- a/plugins/modules/netbox_vm_interface.py
+++ b/plugins/modules/netbox_vm_interface.py
@@ -150,7 +150,7 @@ EXAMPLES = r"""
           mtu: 1600
           mode: Tagged
         state: present
-        
+
     - name: Create bridge interface within NetBox
       netbox_vm_interface:
         netbox_url: http://netbox.local
@@ -159,7 +159,7 @@ EXAMPLES = r"""
           virtual_machine: test100
           name: br1000
         state: present
-        
+
     - name: Connect bridge interface within NetBox
       netbox_vm_interface:
         netbox_url: http://netbox.local
@@ -167,7 +167,7 @@ EXAMPLES = r"""
         data:
           virtual_machine: test100
           name: br1001
-          vm_bridge: br1000                        
+          vm_bridge: br1000
         state: present
 """
 

--- a/plugins/modules/netbox_webhook.py
+++ b/plugins/modules/netbox_webhook.py
@@ -13,7 +13,7 @@ module: netbox_webhook
 short_description: Creates, updates or deletes webhook configuration within NetBox
 description:
   - Creates, updates or removes webhook configuration within NetBox
-notes:  
+notes:
   - This should be ran with connection C(local) and hosts C(localhost)
   - Use C(!unsafe) when adding jinja2 code to C(additional_headers) or C(body_template)
 author:
@@ -35,12 +35,12 @@ options:
           - Required when I(state=present)
         required: false
         type: list
-        elements: raw      
+        elements: raw
       name:
         description:
           - Name of the webhook
         required: true
-        type: str      
+        type: str
       type_create:
         description:
           - Call this webhook when a matching object is created
@@ -91,29 +91,29 @@ options:
         description:
           - Secret key to generate X-Hook-Signature to include in the payload.
         required: false
-        type: str        
+        type: str
       conditions:
         description:
           - A set of conditions which determine whether the webhook will be generated.
         required: false
-        type: dict      
+        type: dict
       ssl_verification:
         description:
-          - Enable ssl verification. 
+          - Enable ssl verification.
         required: false
         type: bool
       ca_file_path:
         description:
           - CA certificate file to use for SSL verification
         required: false
-        type: str                                          
+        type: str
     required: true
 """
 
 EXAMPLES = r"""
 - name: "Test NetBox webhook module"
   connection: local
-  hosts: localhost  
+  hosts: localhost
   tasks:
     - name: Create a webhook
       netbox_webhook:
@@ -121,7 +121,7 @@ EXAMPLES = r"""
         netbox_token: thisIsMyToken
         data:
           content_types:
-            - dcim.device            
+            - dcim.device
           name: Example Webhook
           type_create: yes
           payload_url: https://payload.url/
@@ -138,7 +138,7 @@ EXAMPLES = r"""
           type_delete: yes
           payload_url: https://payload.url/
           body_template: !unsafe >-
-            {{ data }}         
+            {{ data }}
 
     - name: Delete the webhook
       netbox_webhook:
@@ -150,7 +150,7 @@ EXAMPLES = r"""
           type_delete: yes
           payload_url: https://payload.url/
           body_template: !unsafe >-
-            {{ data }}  
+            {{ data }}
         state: absent
 """
 

--- a/plugins/modules/netbox_wireless_lan.py
+++ b/plugins/modules/netbox_wireless_lan.py
@@ -13,7 +13,7 @@ module: netbox_wireless_lan
 short_description: Creates or removes Wireless LANs from NetBox
 description:
   - Creates or removes wireless LANs from NetBox
-notes:  
+notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Martin Rødvand (@rodvand)
@@ -76,7 +76,7 @@ options:
         description:
           - The PSK of the Wireless LAN
         required: false
-        type: str    
+        type: str
       tags:
         description:
           - Any tags that the Wireless LAN may need to be associated with
@@ -87,7 +87,7 @@ options:
         description:
           - must exist in NetBox
         required: false
-        type: dict    
+        type: dict
       comments:
         description:
           - Comments of the wireless LAN
@@ -124,11 +124,11 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          ssid: Wireless Network One          
+          ssid: Wireless Network One
           description: Cool Wireless Network
           auth_type: wpa-enterprise
           auth_cipher: aes
-          auth_psk: psk123456                    
+          auth_psk: psk123456
           tags:
             - tagA
             - tagB

--- a/plugins/modules/netbox_wireless_lan_group.py
+++ b/plugins/modules/netbox_wireless_lan_group.py
@@ -13,7 +13,7 @@ module: netbox_wireless_lan_group
 short_description: Creates or removes Wireless LAN Groups from NetBox
 description:
   - Creates or removes Wireless LAN Groups from NetBox
-notes:  
+notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Martin Rødvand (@rodvand)
@@ -47,7 +47,7 @@ options:
         description:
           - Description of the Wireless LAN Group
         required: false
-        type: str          
+        type: str
       tags:
         description:
           - Any tags that the Wireless LAN Group may need to be associated with
@@ -58,7 +58,7 @@ options:
         description:
           - must exist in NetBox
         required: false
-        type: dict    
+        type: dict
     required: true
 """
 
@@ -90,7 +90,7 @@ EXAMPLES = r"""
         netbox_token: thisIsMyToken
         data:
           name: Wireless LAN Group One
-          description: Wireless LAN Group description            
+          description: Wireless LAN Group description
           tags:
             - tagA
             - tagB

--- a/plugins/modules/netbox_wireless_link.py
+++ b/plugins/modules/netbox_wireless_link.py
@@ -13,7 +13,7 @@ module: netbox_wireless_link
 short_description: Creates or removes Wireless links from NetBox
 description:
   - Creates or removes wireless links from NetBox
-notes:  
+notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Martin Rødvand (@rodvand)
@@ -47,7 +47,7 @@ options:
         description:
           - Description of the wireless link
         required: false
-        type: str    
+        type: str
       status:
         description:
           - The status of the wireless link
@@ -56,7 +56,7 @@ options:
           - planned
           - decommissioning
         required: false
-        type: str          
+        type: str
       auth_type:
         description:
           - The authentication type of the wireless link
@@ -80,7 +80,7 @@ options:
         description:
           - The PSK of the wireless link
         required: false
-        type: str    
+        type: str
       comments:
         description:
           - Comments of the wireless link
@@ -97,7 +97,7 @@ options:
         description:
           - must exist in NetBox
         required: false
-        type: dict    
+        type: dict
     required: true
 """
 
@@ -144,11 +144,11 @@ EXAMPLES = r"""
           interface_b:
             device: Device Two
             name: wireless_link_0
-          ssid: Wireless Network One          
+          ssid: Wireless Network One
           description: Cool Wireless Network
           auth_type: wpa-enterprise
           auth_cipher: aes
-          auth_psk: psk123456                    
+          auth_psk: psk123456
           tags:
             - tagA
             - tagB

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,3 @@
+modules:
+  python_requires: '>=3.8'
+

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,2 @@
 modules:
   python_requires: '>=3.8'
-

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -59,49 +59,49 @@ create_tags = make_netbox_calls(
 
 # ORDER OF OPERATIONS FOR THE MOST PART
 
-## Create TENANTS
+# Create TENANTS
 tenants = [{"name": "Test Tenant", "slug": "test-tenant"}]
 created_tenants = make_netbox_calls(nb.tenancy.tenants, tenants)
-### Test Tenant to be used later on
+# Test Tenant to be used later on
 test_tenant = nb.tenancy.tenants.get(slug="test-tenant")
 
 
-## Create TENANT GROUPS
+# Create TENANT GROUPS
 tenant_groups = [{"name": "Test Tenant Group", "slug": "test-tenant-group"}]
 created_tenant_groups = make_netbox_calls(nb.tenancy.tenant_groups, tenant_groups)
 
 
-## Create Regions
+# Create Regions
 regions = [
     {"name": "Test Region", "slug": "test-region"},
     {"name": "Parent Region", "slug": "parent-region"},
     {"name": "Other Region", "slug": "other-region"},
 ]
 created_regions = make_netbox_calls(nb.dcim.regions, regions)
-### Region variables to be used later on
+# Region variables to be used later on
 parent_region = nb.dcim.regions.get(slug="parent-region")
 test_region = nb.dcim.regions.get(slug="test-region")
 
-### Create relationship between regions
+# Create relationship between regions
 test_region.parent = parent_region
 test_region.save()
 
-## Create site_groups
+# Create site_groups
 site_groups = [
     {"name": "Test site_group", "slug": "test-site_group"},
     {"name": "Parent site_group", "slug": "parent-site_group"},
     {"name": "Other site_group", "slug": "other-site_group"},
 ]
 created_site_groups = make_netbox_calls(nb.dcim.site_groups, site_groups)
-### site_group variables to be used later on
+# site_group variables to be used later on
 parent_site_group = nb.dcim.site_groups.get(slug="parent-site_group")
 test_site_group = nb.dcim.site_groups.get(slug="test-site_group")
 
-### Create relationship between site_groups
+# Create relationship between site_groups
 test_site_group.parent = parent_site_group
 test_site_group.save()
 
-## Create SITES and register variables
+# Create SITES and register variables
 sites = [
     {
         "name": "Test Site",
@@ -113,20 +113,20 @@ sites = [
     {"name": "Test Site2", "slug": "test-site2"},
 ]
 created_sites = make_netbox_calls(nb.dcim.sites, sites)
-### Site variables to be used later on
+# Site variables to be used later on
 test_site = nb.dcim.sites.get(slug="test-site")
 test_site2 = nb.dcim.sites.get(slug="test-site2")
 
-## Create Site Groups
+# Create Site Groups
 site_groups = [{"name": "Test Site Group", "slug": "test-site-group"}]
 created_site_groups = make_netbox_calls(nb.dcim.site_groups, site_groups)
 
-## Create VRFs
+# Create VRFs
 vrfs = [{"name": "Test VRF", "rd": "1:1"}]
 created_vrfs = make_netbox_calls(nb.ipam.vrfs, vrfs)
 
 
-## Create PREFIXES
+# Create PREFIXES
 prefixes = [
     {"prefix": "192.168.100.0/24", "site": test_site2.id},
     {"prefix": "10.10.0.0/16"},
@@ -134,7 +134,7 @@ prefixes = [
 created_prefixes = make_netbox_calls(nb.ipam.prefixes, prefixes)
 
 
-## Create VLAN GROUPS
+# Create VLAN GROUPS
 vlan_groups = [
     {
         "name": "Test Vlan Group",
@@ -155,11 +155,11 @@ if nb_version >= version.parse("2.11"):
             vg["scope_type"] = "dcim.site"
             vg["scope_id"] = vg.pop("site")
 created_vlan_groups = make_netbox_calls(nb.ipam.vlan_groups, vlan_groups)
-## VLAN Group variables to be used later on
+# VLAN Group variables to be used later on
 test_vlan_group = nb.ipam.vlan_groups.get(slug="test-vlan-group")
 
 
-## Create VLANS
+# Create VLANS
 vlans = [
     {"name": "Wireless", "vid": 100, "site": test_site.id},
     {"name": "Data", "vid": 200, "site": test_site.id},
@@ -174,7 +174,7 @@ vlans = [
 ]
 created_vlans = make_netbox_calls(nb.ipam.vlans, vlans)
 
-## Create FHRP GROUPS
+# Create FHRP GROUPS
 fhrp_groups = [
     {
         "protocol": "other",
@@ -189,24 +189,24 @@ fhrp_groups = [
 ]
 created_fhrp_groups = make_netbox_calls(nb.ipam.fhrp_groups, fhrp_groups)
 
-## Create IPAM Roles
+# Create IPAM Roles
 ipam_roles = [{"name": "Network of care", "slug": "network-of-care"}]
 create_ipam_roles = make_netbox_calls(nb.ipam.roles, ipam_roles)
 
 
-## Create Manufacturers
+# Create Manufacturers
 manufacturers = [
     {"name": "Cisco", "slug": "cisco"},
     {"name": "Arista", "slug": "arista"},
     {"name": "Test Manufactuer", "slug": "test-manufacturer"},
 ]
 created_manufacturers = make_netbox_calls(nb.dcim.manufacturers, manufacturers)
-### Manufacturer variables to be used later on
+# Manufacturer variables to be used later on
 cisco_manu = nb.dcim.manufacturers.get(slug="cisco")
 arista_manu = nb.dcim.manufacturers.get(slug="arista")
 
 
-## Create Device Types
+# Create Device Types
 device_types = [
     {"model": "Cisco Test", "slug": "cisco-test", "manufacturer": cisco_manu.id},
     {"model": "Arista Test", "slug": "arista-test", "manufacturer": arista_manu.id},
@@ -232,13 +232,13 @@ device_types = [
 ]
 
 created_device_types = make_netbox_calls(nb.dcim.device_types, device_types)
-### Device type variables to be used later on
+# Device type variables to be used later on
 cisco_test = nb.dcim.device_types.get(slug="cisco-test")
 arista_test = nb.dcim.device_types.get(slug="arista-test")
 nexus_parent = nb.dcim.device_types.get(slug="nexus-parent")
 nexus_child = nb.dcim.device_types.get(slug="nexus-child")
 
-## Create Device Roles
+# Create Device Roles
 device_roles = [
     {"name": "Core Switch", "slug": "core-switch", "color": "aa1409", "vm_role": False},
     {
@@ -255,11 +255,11 @@ device_roles = [
     },
 ]
 created_device_roles = make_netbox_calls(nb.dcim.device_roles, device_roles)
-### Device role variables to be used later on
+# Device role variables to be used later on
 core_switch = nb.dcim.device_roles.get(slug="core-switch")
 
 
-## Create Rack Groups
+# Create Rack Groups
 rack_groups = [
     {"name": "Test Rack Group", "slug": "test-rack-group", "site": test_site.id},
     {"name": "Parent Rack Group", "slug": "parent-rack-group", "site": test_site.id},
@@ -269,15 +269,15 @@ if nb_version >= version.parse("2.11"):
 else:
     created_rack_groups = make_netbox_calls(nb.dcim.rack_groups, rack_groups)
 
-### Create Rack Group Parent relationship
+# Create Rack Group Parent relationship
 created_rack_groups[0].parent = created_rack_groups[1]
 created_rack_groups[0].save()
 
-## Create Rack Roles
+# Create Rack Roles
 rack_roles = [{"name": "Test Rack Role", "slug": "test-rack-role", "color": "4287f5"}]
 created_rack_roles = make_netbox_calls(nb.dcim.rack_roles, rack_roles)
 
-## Create Racks
+# Create Racks
 racks = [
     {
         "name": "Test Rack Site 2",
@@ -287,7 +287,7 @@ racks = [
     {"name": "Test Rack", "site": test_site.id, "group": created_rack_groups[0].id},
 ]
 
-## Use location instead of group for 2.11+
+# Use location instead of group for 2.11+
 if nb_version >= version.parse("2.11"):
     racks[1]["location"] = created_rack_groups[0].id
     del racks[1]["group"]
@@ -297,7 +297,7 @@ test_rack = nb.dcim.racks.get(name="Test Rack")  # racks don't have slugs
 test_rack_site2 = nb.dcim.racks.get(name="Test Rack Site 2")
 
 
-## Create Devices
+# Create Devices
 devices = [
     {
         "name": "test100",
@@ -338,7 +338,7 @@ devices = [
     },
 ]
 
-## Add some locations for 2.11+
+# Add some locations for 2.11+
 if nb_version >= version.parse("2.11"):
     devices[0]["location"] = created_rack_groups[0].id
     devices[1]["location"] = created_rack_groups[0].id
@@ -350,7 +350,7 @@ if nb_version >= version.parse("3.6"):
             device["role"] = device.pop("device_role")
 
 created_devices = make_netbox_calls(nb.dcim.devices, devices)
-### Device variables to be used later on
+# Device variables to be used later on
 test100 = nb.dcim.devices.get(name="test100")
 
 # Create VC, assign member, create initial interface
@@ -365,14 +365,14 @@ nexus_interfaces = [
 ]
 created_nexus_interfaces = make_netbox_calls(nb.dcim.interfaces, nexus_interfaces)
 
-## Create Interfaces
+# Create Interfaces
 dev_interfaces = [
     {"name": "GigabitEthernet1", "device": test100.id, "type": "1000base-t"},
     {"name": "GigabitEthernet2", "device": test100.id, "type": "1000base-t"},
 ]
 created_interfaces = make_netbox_calls(nb.dcim.interfaces, dev_interfaces)
 
-## Wireless Interfaces
+# Wireless Interfaces
 if nb_version >= version.parse("3.1"):
     wlink_interfaces = [
         {"name": "wlink1", "device": test100.id, "type": "ieee802.11a"},
@@ -380,12 +380,12 @@ if nb_version >= version.parse("3.1"):
     ]
     wireless_interfaces = make_netbox_calls(nb.dcim.interfaces, wlink_interfaces)
 
-## Interface variables to be used later on
+# Interface variables to be used later on
 test100_gi1 = nb.dcim.interfaces.get(name="GigabitEthernet1", device_id=1)
 test100_gi2 = nb.dcim.interfaces.get(name="GigabitEthernet2", device_id=1)
 
 
-## Create IP Addresses
+# Create IP Addresses
 ip_addresses = [
     {
         "address": "172.16.180.1/24",
@@ -415,25 +415,25 @@ created_ip_addresses = make_netbox_calls(nb.ipam.ip_addresses, ip_addresses)
 # Assign Primary IP
 nexus.update({"primary_ip4": 4})
 
-## Create RIRs
+# Create RIRs
 rirs = [{"name": "Example RIR", "slug": "example-rir"}]
 created_rirs = make_netbox_calls(nb.ipam.rirs, rirs)
 
-## Create Cluster Group
+# Create Cluster Group
 cluster_groups = [{"name": "Test Cluster Group", "slug": "test-cluster-group"}]
 created_cluster_groups = make_netbox_calls(
     nb.virtualization.cluster_groups, cluster_groups
 )
 test_cluster_group = nb.virtualization.cluster_groups.get(slug="test-cluster-group")
 
-## Create Cluster Type
+# Create Cluster Type
 cluster_types = [{"name": "Test Cluster Type", "slug": "test-cluster-type"}]
 created_cluster_types = make_netbox_calls(
     nb.virtualization.cluster_types, cluster_types
 )
 test_cluster_type = nb.virtualization.cluster_types.get(slug="test-cluster-type")
 
-## Create Cluster
+# Create Cluster
 clusters = [
     {
         "name": "Test Cluster",
@@ -450,7 +450,7 @@ created_clusters = make_netbox_calls(nb.virtualization.clusters, clusters)
 test_cluster = nb.virtualization.clusters.get(name="Test Cluster")
 test_cluster2 = nb.virtualization.clusters.get(name="Test Cluster 2")
 
-## Create Virtual Machine
+# Create Virtual Machine
 virtual_machines = [
     {"name": "test100-vm", "cluster": test_cluster.id},
     {"name": "test101-vm", "cluster": test_cluster.id},
@@ -475,7 +475,7 @@ created_virtual_disks = make_netbox_calls(
     nb.virtualization.virtual_disks, virtual_disks
 )
 
-## Create Virtual Machine Interfaces
+# Create Virtual Machine Interfaces
 virtual_machines_intfs = [
     # Create test100-vm intfs
     {"name": "Eth0", "virtual_machine": test100_vm.id},
@@ -498,7 +498,7 @@ created_virtual_machines_intfs = make_netbox_calls(
 )
 
 
-## Create Services
+# Create Services
 services = [
     {"device": test100.id, "name": "ssh", "ports": [22], "protocol": "tcp"},
     {
@@ -519,17 +519,17 @@ services = [
 created_services = make_netbox_calls(nb.ipam.services, services)
 
 
-## Create Circuit Provider
+# Create Circuit Provider
 providers = [{"name": "Test Provider", "slug": "test-provider"}]
 created_providers = make_netbox_calls(nb.circuits.providers, providers)
 test_provider = nb.circuits.providers.get(slug="test-provider")
 
-## Create Circuit Type
+# Create Circuit Type
 circuit_types = [{"name": "Test Circuit Type", "slug": "test-circuit-type"}]
 created_circuit_types = make_netbox_calls(nb.circuits.circuit_types, circuit_types)
 test_circuit_type = nb.circuits.circuit_types.get(slug="test-circuit-type")
 
-## Create Circuit
+# Create Circuit
 circuits = [
     {"cid": "Test Circuit", "provider": test_provider.id, "type": test_circuit_type.id},
     {
@@ -541,7 +541,7 @@ circuits = [
 created_circuits = make_netbox_calls(nb.circuits.circuits, circuits)
 test_circuit_two = nb.circuits.circuits.get(cid="Test Circuit Two")
 
-## Create Circuit Termination
+# Create Circuit Termination
 circuit_terms = [
     {
         "circuit": test_circuit_two.id,
@@ -561,7 +561,7 @@ route_targets = [
 ]
 created_route_targets = make_netbox_calls(nb.ipam.route_targets, route_targets)
 
-## Create L2VPNs
+# Create L2VPNs
 l2vpns = [
     {
         "identifier": 111111,

--- a/tests/integration/render_config.sh
+++ b/tests/integration/render_config.sh
@@ -15,7 +15,8 @@ set -o pipefail # don't hide errors within pipes
 function main()
 {
     readonly template="$1"
-    readonly content="$(cat "${template}")"
+    content="$(cat "${template}")"
+    readonly content
 
     eval "echo \"$content\""
 }

--- a/tests/integration/targets/inventory-v3.5/compare_inventory_json.py
+++ b/tests/integration/targets/inventory-v3.5/compare_inventory_json.py
@@ -62,7 +62,7 @@ def sort_hostvar_arrays(obj):
     if not hostvars:
         return
 
-    for _, host in hostvars.items():
+    for _discard, host in hostvars.items():
         if interfaces := host.get("interfaces"):
             host["interfaces"] = sorted(interfaces, key=itemgetter("id"))
 

--- a/tests/integration/targets/inventory-v3.6/compare_inventory_json.py
+++ b/tests/integration/targets/inventory-v3.6/compare_inventory_json.py
@@ -62,7 +62,7 @@ def sort_hostvar_arrays(obj):
     if not hostvars:
         return
 
-    for _, host in hostvars.items():
+    for _discard, host in hostvars.items():
         if interfaces := host.get("interfaces"):
             host["interfaces"] = sorted(interfaces, key=itemgetter("id"))
 

--- a/tests/integration/targets/inventory-v3.7/compare_inventory_json.py
+++ b/tests/integration/targets/inventory-v3.7/compare_inventory_json.py
@@ -62,7 +62,7 @@ def sort_hostvar_arrays(obj):
     if not hostvars:
         return
 
-    for _, host in hostvars.items():
+    for _discard, host in hostvars.items():
         if interfaces := host.get("interfaces"):
             host["interfaces"] = sorted(interfaces, key=itemgetter("id"))
 

--- a/tests/integration/targets/inventory-v4.0/compare_inventory_json.py
+++ b/tests/integration/targets/inventory-v4.0/compare_inventory_json.py
@@ -62,7 +62,7 @@ def sort_hostvar_arrays(obj):
     if not hostvars:
         return
 
-    for _, host in hostvars.items():
+    for _discard, host in hostvars.items():
         if interfaces := host.get("interfaces"):
             host["interfaces"] = sorted(interfaces, key=itemgetter("id"))
 

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,1 +1,0 @@
-plugins/inventory/nb_inventory.py pylint!skip


### PR DESCRIPTION
## Related Issue
#1241 

## New Behavior
- Drop test coverage for Ansible versions before v2.15.0
- Drop test coverage for Python versions before v3.8.0
- Update test suite such that `ansible-test sanity` now passes

## Contrast to Current Behavior
Impact is strictly to test coverage. Current test behavior includes obsolete versions of both Ansible and Python; this change drops support for obsolete versions of both.

## Discussion: Benefits and Drawbacks
Benefits:
- Moves this collection toward alignment with current Ansible best practices
- Reduces the maintenance burden of keeping tests passing on those obsolete versions

Drawbacks:
- Some specialized use cases may depend on coverage with obsolete Ansible and Python versions

## Changes to the Documentation
None needed

## Proposed Release Note Entry
Dropped test coverage for Ansible versions older than v2.15.0 and Python versions older than 3.8.0, both of which are now obsolete.

## Double Check
* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
