### PR TITLE
Add ability to rename host inventory variables using patterns

### DIFF
--- a/changelogs/fragments/1273-ability-to-rename-host-inventory-vars.yml
+++ b/changelogs/fragments/1273-ability-to-rename-host-inventory-vars.yml
@@ -1,0 +1,2 @@
+minor_changes:
+      - Add ability to rename variables set on the host by ``netbox.netbox.nb_inventory`` through configuration.

--- a/tests/unit/inventory/test_nb_inventory.py
+++ b/tests/unit/inventory/test_nb_inventory.py
@@ -34,6 +34,18 @@ load_relative_test_data = partial(
 )
 
 
+class MockInventory:
+
+    def __init__(self):
+        self.variables = {}
+
+    def set_variable(self, hostname, key, value):
+        if hostname not in self.variables:
+            self.variables[hostname] = {}
+
+        self.variables[hostname][key] = value
+
+
 @pytest.fixture
 def inventory_fixture(
     allowed_device_query_parameters_fixture, allowed_vm_query_parameters_fixture
@@ -45,6 +57,9 @@ def inventory_fixture(
     inventory.api_version = version.Version("2.0")
     inventory.allowed_device_query_parameters = allowed_device_query_parameters_fixture
     inventory.allowed_vm_query_parameters = allowed_vm_query_parameters_fixture
+
+    # Inventory mock, to validate what has been set via inventory.inventory.set_variable
+    inventory.inventory = MockInventory()
 
     return inventory
 
@@ -260,3 +275,24 @@ def test_extract_custom_fields(inventory_fixture, custom_fields, expected):
     )
 
     assert extracted_custom_fields == expected
+
+
+def test_rename_variables(inventory_fixture):
+    inventory_fixture.rename_variables = inventory_fixture.parse_rename_variables(
+        (
+            {"pattern": r"cluster(.*)", "repl": r"netbox_cluster\1"},
+            {"pattern": r"ansible_host", "repl": r"host"},
+        )
+    )
+
+    inventory_fixture._set_variable("host", "ansible_fqdn", "host.example.org")
+    inventory_fixture._set_variable("host", "ansible_host", "host")
+    inventory_fixture._set_variable("host", "cluster", "staging")
+    inventory_fixture._set_variable("host", "cluster_id", "0xdeadbeef")
+
+    assert inventory_fixture.inventory.variables["host"] == {
+        "ansible_fqdn": "host.example.org",
+        "host": "host",
+        "netbox_cluster": "staging",
+        "netbox_cluster_id": "0xdeadbeef",
+    }


### PR DESCRIPTION
## Related Issue

None.

## New Behavior

Certain environments may have conflicts with the variables given by Netbox, and the variables used in the existing Ansible codebase.

With this change, such cases can be worked around by renaming individual variables, or whole groups of them.

For example, this will rename all `cluster*` variables to have a `netbox__` prefix instead (e.g., `cluster_group` -> `netbox__cluster_group`):

```yaml
rename_variables:
  - pattern: 'cluster(.*)'
    repl: 'netbox__cluster\1'
```

Uses a list, instead of a dict, to ensure that the order of evaluation is strictly defined across all Python versions, and to add the ability to exclude certain variables from being rewritten. For example:

```yaml
rename_variables:
  # Keep cluster_type the same
  - pattern: 'cluster_type'
    repl: 'cluster_type'

  # Rename all other cluster* variables
  - pattern: 'cluster(.*)'
    repl: 'netbox__cluster\1'
```

## Contrast to Current Behavior

Currently, the variable names are hard-coded and cannot be modified.

## Discussion: Benefits and Drawbacks

With this change, it becomes easier to adapt Netbox to code-bases where some of the variables found in Netbox already have a meaning.

The change is purely optional, so anyone that does not need it, can just ignore it.

## Changes to the Documentation

The documentation is updated in the module. I assume this will be published once merged.

## Proposed Release Note Entry

Add ability to rename host inventory variables using patterns, to avoid conflicts with existing variables.

...

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
