### PR TITLE
fix: move prefix lookup to lookup secondary

### DIFF
--- a/changelogs/fragments/1281_move_prefix_lookup_to_secondary.yml
+++ b/changelogs/fragments/1281_move_prefix_lookup_to_secondary.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - If `fetch_all` is `false`, prefix lookup depends on site lookup, so move it to secondary lookup (https://github.com/netbox-community/ansible_modules/issues/733)

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1510,9 +1510,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if self.interfaces:
             lookups.append(self.refresh_interfaces)
 
-        if self.prefixes:
-            lookups.append(self.refresh_prefixes)
-
         if self.services:
             lookups.append(self.refresh_services)
 
@@ -1533,6 +1530,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # IP addresses are needed for either interfaces or dns_name options
         if self.interfaces or self.dns_name or self.ansible_host_dns_name:
             lookups.append(self.refresh_ipaddresses)
+
+        if self.prefixes:
+            lookups.append(self.refresh_prefixes)
 
         return lookups
 


### PR DESCRIPTION
If fetch_all is false, prefix lookup depends on site lookup, so move it
to secondary lookup.
Solves #733
