### PR TITLE
feat: Add `status` and `facility` options to `netbox_location` module

### DIFF
--- a/changelogs/fragments/fix_issues_1279_1280.yml
+++ b/changelogs/fragments/fix_issues_1279_1280.yml
@@ -1,0 +1,3 @@
+minor_changes:
+      - Add ``status`` to ``location`` (https://github.com/netbox-community/ansible_modules/issues/1279)
+      - Add ``facility`` to ``location`` (https://github.com/netbox-community/ansible_modules/issues/1280)

--- a/plugins/modules/netbox_location.py
+++ b/plugins/modules/netbox_location.py
@@ -34,6 +34,12 @@ options:
           - The name of the location
         required: true
         type: str
+      status:
+        description:
+          - Status of the location
+        required: false
+        type: raw
+        version_added: "3.20.0"
       slug:
         description:
           - The slugified version of the name or custom slug.
@@ -56,6 +62,12 @@ options:
         required: false
         type: raw
         version_added: "3.8.0"
+      facility:
+        description:
+          - Data center provider or facility, ex. Equinix NY7
+        required: false
+        type: str
+        version_added: "3.20.0"
       description:
         description:
           - The description of the location
@@ -93,7 +105,7 @@ EXAMPLES = r"""
           site: Test Site
         state: present
 
-    - name: Create location within NetBox with a parent location
+    - name: Create location within NetBox with a parent location, status and facility
       netbox.netbox.netbox_location:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
@@ -101,6 +113,8 @@ EXAMPLES = r"""
           name: Child location
           site: Test Site
           parent_location: Test location
+          status: planned
+          facility : Test Facility
         state: present
 
     - name: Delete location within NetBox
@@ -146,10 +160,12 @@ def main():
                 required=True,
                 options=dict(
                     name=dict(required=True, type="str"),
+                    status=dict(required=False, type="raw"),
                     slug=dict(required=False, type="str"),
                     site=dict(required=False, type="raw"),
                     parent_location=dict(required=False, type="raw"),
                     tenant=dict(required=False, type="raw"),
+                    facility=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),

--- a/plugins/modules/netbox_location.py
+++ b/plugins/modules/netbox_location.py
@@ -114,7 +114,7 @@ EXAMPLES = r"""
           site: Test Site
           parent_location: Test location
           status: planned
-          facility : Test Facility
+          facility: Test Facility
         state: present
 
     - name: Delete location within NetBox


### PR DESCRIPTION
This commit adds the `status` and `facility` options to the `netbox_location` module. The `status` option allows specifying the status of the location, while the `facility` option allows specifying the data center provider or facility. These options were added to enhance the functionality of the module and provide more flexibility in managing locations within NetBox.

Fixes #1279, #1280

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

 #1279, #1280

## New Behavior

Adds the `status` and `facility` options to the `netbox_location` module. The `status` option allows specifying the status of the location, while the `facility` (added in NetBox v4.0.0) option allows specifying the data center provider or facility. These options were added to enhance the functionality of the module and provide more flexibility in managing locations within NetBox. 

...

## Contrast to Current Behavior

Currently you cannot add the `status` and `facility` options to the `netbox_location` module.

...

## Discussion: Benefits and Drawbacks

The `status` of the location was missing from the module, and `facility` was added in NetBox 4.0.0 so it is useful to be able to set this also. 

...

## Changes to the Documentation

The new option is added in the documentation part of the file.

...

## Proposed Release Note Entry

Add support for `status` and `facility` (added in NetBox 4.0.0)  for the `netbox_location` module.

...

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
