### PR TITLE
feat: Add `status` option to `netbox_cluster` module

### DIFF
--- a/changelogs/fragments/1275-feature-netbox_cluster-adds-status-field.yml
+++ b/changelogs/fragments/1275-feature-netbox_cluster-adds-status-field.yml
@@ -1,0 +1,2 @@
+minor_changes:
+      - Add `status` to `netbox_cluster` (https://github.com/netbox-community/ansible_modules/issues/1275)

--- a/plugins/modules/netbox_cluster.py
+++ b/plugins/modules/netbox_cluster.py
@@ -35,6 +35,12 @@ options:
           - The name of the cluster
         required: true
         type: str
+      status:
+        description:
+          - Status of the cluster
+        required: false
+        type: raw
+        version_added: "3.20.0"
       cluster_type:
         description:
           - type of the cluster
@@ -114,7 +120,7 @@ EXAMPLES = r"""
             - Schnozzberry
         state: present
 
-    - name: Update the group and site of an existing cluster
+    - name: Update the group, site and status of an existing cluster
       netbox.netbox.netbox_cluster:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
@@ -123,6 +129,7 @@ EXAMPLES = r"""
           cluster_type: qemu
           cluster_group: GROUP
           site: SITE
+          status: planned
         state: present
 """
 
@@ -160,6 +167,7 @@ def main():
                 required=True,
                 options=dict(
                     name=dict(required=True, type="str"),
+                    status=dict(required=False, type="raw"),
                     cluster_type=dict(required=False, type="raw"),
                     cluster_group=dict(required=False, type="raw"),
                     site=dict(required=False, type="raw"),


### PR DESCRIPTION
Add the `status` option to the `netbox_cluster` module, allowing users to specify the status of the cluster. This enhancement provides more flexibility in managing clusters within NetBox.

Fixes #1275

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1275 

## New Behavior

The `netbox_cluster` module now supports the `status` option, allowing users to specify the status of the cluster.

...

## Contrast to Current Behavior

The `netbox_cluster` module was missing support for the `status` option.

...

## Discussion: Benefits and Drawbacks

This allows users to specify the status of the cluster. This enhancement provides more flexibility in managing clusters within NetBox.

...

## Changes to the Documentation

The new option is added in the documentation part of the file.

...

## Proposed Release Note Entry

Add support for the `status` option for the `netbox_cluster` module

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
