### PR TITLE
feat: Add `description` option to `netbox_cluster_group` module

### DIFF
--- a/changelogs/fragments/1276-feature-netbox_cluster_group-adds-description-field.yml
+++ b/changelogs/fragments/1276-feature-netbox_cluster_group-adds-description-field.yml
@@ -1,0 +1,2 @@
+minor_changes:
+      - Add `description` to `netbox_cluster_group` module (https://github.com/netbox-community/ansible_modules/issues/1276)

--- a/plugins/modules/netbox_cluster_group.py
+++ b/plugins/modules/netbox_cluster_group.py
@@ -41,6 +41,12 @@ options:
           - This is auto-generated following NetBox rules if not provided
         required: false
         type: str
+      description:
+        description:
+          - The description of the cluster group
+        required: false
+        type: str
+        version_added: "3.20.0"
       tags:
         description:
           - The tags to add/update
@@ -115,6 +121,7 @@ def main():
                 options=dict(
                     name=dict(required=True, type="str"),
                     slug=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
                 ),


### PR DESCRIPTION
Add `description` option to `netbox_cluster_group` module, allowing users to specify the description of the cluster group. 

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1276 

## New Behavior

The `netbox_cluster_group` module now supports the `description` option, allowing users to specify the description of the cluster group.

...

## Contrast to Current Behavior

The `netbox_cluster_group` module was missing the `description` option.

...

## Discussion: Benefits and Drawbacks

This allows users to specify the description of the cluster group. This enhancement provides more flexibility in managing cluster groups within NetBox.

...

## Changes to the Documentation

The new option is added in the documentation part of the file.

...

## Proposed Release Note Entry

Add support for the `description` option for the `netbox_cluster_group` module.

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
