### PR TITLE
Prevent 'site' key error when using inventory caching

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1150,8 +1150,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for prefix in prefixes:
             if prefix.get("site"):
                 self.prefixes_sites_lookup[prefix["site"]["id"]].append(prefix)
-            # Remove "site" attribute, as it's redundant when prefixes are assigned to site
-            del prefix["site"]
+                # Remove "site" attribute, as it's redundant when prefixes are assigned to site
+                del prefix["site"]
 
     def refresh_regions_lookup(self):
         url = self.api_endpoint + "/api/dcim/regions/?limit=0"


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

#833

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Regards the Netbox Inventory plugin.   
Resolves `KeyError: 'site'` when a caching plugin is used and `prefixes: true`

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently, any time the cache is read, and there are prefixes in the cache, Ansible crashes on a missing 'site' key. This is because the site key is removed from the prefix before storing it in cache. After the fix, the site key is only deleted when it actually exists.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Without this change it seems impossible to use an Ansible inventory caching plugin ánd enable `prefixes` in the Netbox inventory plugin.

Two years ago @endreszabo [stated that](https://github.com/netbox-community/ansible_modules/issues/833#issue-1377946354) making this change resulted in an empty `prefixes: []` array for any given site for him. When I try to reproduce this I don't get that problem, and all my prefixes are listed under my sites as expected. I suspect that other changes in this project, or Ansible-core have fixed his issue. 

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

Not necessary as far as I know

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Prevent inventory caching error when using prefixes

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
