### PR TITLE
Issue #1300 - nb_inventory injecting a variable as api_endpoint

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1594,7 +1594,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         except Exception:
             cached_api_version = None
             cache = None
-
+        self.api_endpoint = self.templar.template( self.get_option("api_endpoint"), fail_on_undefined=False)
         status = self._fetch_information(self.api_endpoint + "/api/status")
         netbox_api_version = ".".join(status["netbox-version"].split(".")[:2])
 


### PR DESCRIPTION
Fixes issue-#1300
allows api_endpoint to be a variable and string

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
#1300 
<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

<!--
-->

calls the templar.template module to transform the api_endpoint if referenced as a variable e.g: "{{ fake_var }}"

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

_fake_var: "https://netbox.test.domain.com"_
Current behavior for a inventory file is referencing `api_endpoint: "{{ fake_var }}"` 
for the above example you would receive an error to the affect of 

`[WARNING]:  * Failed to parse
<location of your netbox plugin> with auto plugin:
unknown url type: "{{ fake_var }}/api/status"`

this solves that issue and the result is no error and we can see 
`Fetching: https://netbox.test.domain.com/api/status`

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

- This could be beneficial to the plugin as a whole, not everyone has one netbox environment. As well nor do they share domain names. This change allows for dynamically calling the api_endpoint. While also not changing anyones current setup
- I believe there are no real drawbacks for this change. It does not take away functionality. Truly it only increases the way you can call the api_endpoint
- Yes it is backwards-compatible

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

N/A
## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

netbox.nb_inventory: api_endpoint option can now take variable calls E.G: `api_endpoint: "{{ netbox_url }}" `

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
