### PR TITLE
Add vid_ranges to netbox_vlan_group

### DIFF
--- a/changelogs/fragments/1307-feature-netbox_vlan_group-add-vid_ranges.yml
+++ b/changelogs/fragments/1307-feature-netbox_vlan_group-add-vid_ranges.yml
@@ -1,0 +1,2 @@
+minor_changes:
+      - Add `vid_ranges` to `netbox_vlan_group` module (https://github.com/netbox-community/ansible_modules/issues/1307)

--- a/plugins/modules/netbox_vlan_group.py
+++ b/plugins/modules/netbox_vlan_group.py
@@ -88,7 +88,8 @@ options:
         description:
           - Array of starting and ending VLAN ID pairs
         required: false
-        type: raw
+        type: list
+        elements: raw
         version_added: "3.20.0"
       tags:
         description:

--- a/plugins/modules/netbox_vlan_group.py
+++ b/plugins/modules/netbox_vlan_group.py
@@ -84,6 +84,12 @@ options:
         required: false
         type: int
         version_added: "3.7.0"
+      vid_ranges:
+        description:
+          - Array of starting and ending VLAN ID pairs
+        required: false
+        type: raw
+        version_added: "3.20.0"
       tags:
         description:
           - The tags to add/update
@@ -124,6 +130,18 @@ EXAMPLES = r"""
           name: Test vlan group
           scope_type: "dcim.site"
           scope: Test Site
+        state: present
+
+    - name: Create vlan group within NetBox with vid_ranges
+      netbox_vlan_group:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test vlan group
+          vid_ranges: [
+            [1300, 1329],
+            [1, 2]
+          ]
         state: present
 
     - name: Delete vlan group within netbox
@@ -192,6 +210,7 @@ def main():
                     scope=dict(required=False, type="raw"),
                     min_vid=dict(required=False, type="int"),
                     max_vid=dict(required=False, type="int"),
+                    vid_ranges=dict(required=False, type="list", elements="raw"),
                     description=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->
#1307

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Add possibility to add and update vid_ranges in VLAN Group

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Possibility to use the new field in NetBox v4.1.0

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The user can make changes to vid_ranges on VLAN groups in NetBox v4.1.0
The old fields are not removed 
The user need to know which field to use based on the version on NetBox

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

minor_changes:
      - Add `vid_ranges` to `netbox_vlan_group` module (https://github.com/netbox-community/ansible_modules/issues/1307)


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ X] I have explained my PR according to the information in the comments or in a linked issue.
* [ X] My PR targets the `devel` branch.
