### PR TITLE
fix issue 1335

### DIFF
--- a/changelogs/fragments/1335-api-status-page-not-found.yml
+++ b/changelogs/fragments/1335-api-status-page-not-found.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix call /api/status/ instead /api/status in nb_inventory plugin. (https://github.com/netbox-community/ansible_modules/issues/1335).

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1607,7 +1607,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             cached_api_version = None
             cache = None
 
-        status = self._fetch_information(self.api_endpoint + "/api/status")
+        status = self._fetch_information(self.api_endpoint + "/api/status/")
         netbox_api_version = ".".join(status["netbox-version"].split(".")[:2])
 
         if version.parse(netbox_api_version) >= version.parse("3.5.0"):


### PR DESCRIPTION
## Related Issue

#1335 

## New Behavior

Fix call /api/status/ instead /api/status. Path without trailing slash produce django warning.

...

## Contrast to Current Behavior


...

## Discussion: Benefits and Drawbacks
Yes. Is it backwards-compatible.

...

## Changes to the Documentation

...

## Proposed Release Note Entry
Fix call /api/status/ instead /api/status in nb_inventory plugin. (https://github.com/netbox-community/ansible_modules/issues/1335).

...

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
