### PR TITLE
Add missing elements to netbox_fhrp_group

### DIFF
--- a/plugins/modules/netbox_fhrp_group.py
+++ b/plugins/modules/netbox_fhrp_group.py
@@ -78,6 +78,22 @@ options:
         required: false
         type: list
         elements: raw
+      ip_address:
+        description:
+          - Virtual IP address for the FHRP group
+        type: str
+        required: false
+      ip_status:
+        description:
+          - IP address status
+        choices:
+          - dhcp
+          - reserved
+          - deprecated
+          - slaac
+          - active
+        type: str
+        required: false
       custom_fields:
         description:
           - Must exist in NetBox
@@ -104,6 +120,8 @@ EXAMPLES = r"""
           auth_type: md5
           auth_key: 11111
           description: test FHRP group
+          ip_address: 192.168.10.3/24
+          ip_status: active
         state: present
 
     - name: Delete FHRP group within netbox
@@ -165,6 +183,16 @@ def main():
                     auth_key=dict(type="str", no_log=True),
                     description=dict(type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
+                    ip_address=dict(required=False, type="str"),
+                    ip_status=dict(type="str",
+                                   choices=[
+                                       "dhcp",
+                                       "reserved",
+                                       "deprecated",
+                                       "slaac",
+                                       "active"
+                                   ]
+                               ),
                     custom_fields=dict(required=False, type="dict"),
                 ),
             ),


### PR DESCRIPTION
## New Behavior

I can't specify a virtual IP when creating an FHRP group via Ansible, so I added this functionality

## Contrast to Current Behavior

Two new keys `ip_address` and `ip_status` have been added to netbox_fhrp_group.py

## Discussion: Benefits and Drawbacks

My solution is backwards compatible because I use `required=False` and user tasks will not stop working.
Next. This functionality is needed to conveniently manage FHRP groups.


## Changes to the Documentation

As far as I know, the documentation in the wiki is automatically generated from the `DOCUMENTATION` variable in the module, so I added a description there of what I did and how to work with it

## Proposed Release Note Entry

Add missing elements to netbox_fhrp_group


* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
