### PR TITLE
Update meta/runtime.yml With Missing Modules

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -20,6 +20,7 @@ action_groups:
     - netbox_cluster_group
     - netbox_cluster_type
     - netbox_config_context
+    - netbox_config_template
     - netbox_console_port
     - netbox_console_port_template
     - netbox_console_server_port
@@ -28,6 +29,7 @@ action_groups:
     - netbox_contact_group
     - netbox_contact_role
     - netbox_custom_field
+    - netbox_custom_field_choice_set
     - netbox_custom_link
     - netbox_device
     - netbox_device_bay
@@ -53,6 +55,7 @@ action_groups:
     - netbox_module
     - netbox_module_bay
     - netbox_module_type
+    - netbox_permission
     - netbox_platform
     - netbox_power_feed
     - netbox_power_outlet
@@ -78,14 +81,17 @@ action_groups:
     - netbox_tag
     - netbox_tenant
     - netbox_tenant_group
+    - netbox_token
     - netbox_tunnel
     - netbox_tunnel_group
+    - netbox_user
+    - netbox_user_group
     - netbox_virtual_chassis
+    - netbox_virtual_disk
     - netbox_virtual_machine
     - netbox_vlan
     - netbox_vlan_group
     - netbox_vm_interface
-    - netbox_virtual_disk
     - netbox_vrf
     - netbox_webhook
     - netbox_wireless_lan


### PR DESCRIPTION
Some modules like `netbox_user_group` cannot take advantage of module_defaults for arguments like `netbox_url` and `netbox_token`. 

This appear to be due to the netbox action group not containing those modules. This PR is to add missing modules to the netbox action group.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
Initial implementation of action group to support module_defaults.

https://github.com/netbox-community/ansible_modules/issues/411

## New Behavior

Modules defaults work with all current netbox ansible modules.

## Contrast to Current Behavior

Module defaults like `netbox_url` and `netbox_token` do not get inherited by modules not listed in the netbox action_group. With the modules like `netbox_user_group` added, they now inherit the module_defaults.

## Discussion: Benefits and Drawbacks

Consistent module_default parameter inheritance across all modules.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Added modules `netbox_config_template`, `netbox_custom_field_choice_set`, `netbox_permission`, `netbox_token`, `netbox_user`, and `netbox_user_group` to the netbox action group to support module_default parameter inheritance in those modules.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
