### PR TITLE
Set type of permission constraint to raw

### DIFF
--- a/plugins/modules/netbox_permission.py
+++ b/plugins/modules/netbox_permission.py
@@ -58,7 +58,7 @@ options:
         description:
           - The constraints of the permission to be created
         required: false
-        type: dict
+        type: raw
     required: true
 """
 

--- a/plugins/modules/netbox_permission.py
+++ b/plugins/modules/netbox_permission.py
@@ -169,7 +169,7 @@ def main():
                     enabled=dict(required=False, type="bool"),
                     actions=dict(required=False, type="list", elements="raw"),
                     object_types=dict(required=False, type="list", elements="raw"),
-                    constraints=dict(required=False, type="dict"),
+                    constraints=dict(required=False, type="raw"),
                 ),
             ),
         )


### PR DESCRIPTION
According to https://netboxlabs.com/docs/netbox/en/stable/administration/permissions/, constraints can be either a dictionary or a list of dictionaries. The only way to represent this in Ansible is with the `raw` type.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
#1373 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->
Update the constraint field type from `list` to `raw`.


## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
There is no way to specify multiple constraints without this change. There is also no way to specify the type more precisely, at least according to https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

I believe the generated docs will need to be regenerated, but no manual changes are required.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
Update type of permission constraint from `list` to `raw`

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
