### PR TITLE
Fix missing netbox_config_template module in module_defaults

### DIFF
--- a/changelogs/fragments/action_groups_config_template.yml
+++ b/changelogs/fragments/action_groups_config_template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix missing netbox_config_template module in module_defaults

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -10,6 +10,7 @@ plugin_routing:
 
 action_groups:
   netbox:
+    - netbox_config_template
     - netbox_aggregate
     - netbox_asn
     - netbox_cable


### PR DESCRIPTION

## New Behavior

netbox_config_template is now working


## Proposed Release Note Entry

Fix missing netbox_config_template module in module_defaults

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
