### PR TITLE
Updated netbox_circuit_termination.py to support NetBox 4.2.x

### DIFF
--- a/changelogs/fragments/netbox_circuit_termination.yml
+++ b/changelogs/fragments/netbox_circuit_termination.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - netbox_circuit_termination - Add parameters termination_id and termination_type for NetBox 4.2+

--- a/plugins/modules/netbox_circuit_termination.py
+++ b/plugins/modules/netbox_circuit_termination.py
@@ -51,13 +51,15 @@ options:
         version_added: 3.5.0
       termination_id:
         description:
-          - The ProviderNetwork, Location, Site, Region, or SiteGroup ID of the circuit termination will be assigned to.  This is used with NetBox versions >= 4.2.0.
+          - The ProviderNetwork, Location, Site, Region, or SiteGroup ID of the circuit termination will be assigned to.
+          - This parameter is used with NetBox versions >= 4.2.0.
         required: false
         type: int
         version_added: 4.2.0
       termination_type:
         description:
-          - The type the circuit termination will be assigned to.  This is used with NetBox versions >= 4.2.0.
+          - The type the circuit termination will be assigned to.
+          - This parameter is used with NetBox versions >= 4.2.0.
         choices:
           - dcim.site
           - dcim.location
@@ -69,12 +71,14 @@ options:
         version_added: 4.2.0
       site:
         description:
-          - The site the circuit termination will be assigned to.  This is used with NetBox versions before 4.2.0.
+          - The site the circuit termination will be assigned to.
+          - This parameter is used with NetBox versions before 4.2.0.
         required: false
         type: raw
       provider_network:
         description:
-          - The provider_network the circuit termination will be assigned to.  This is used with NetBox versions before 4.2.0.
+          - The provider_network the circuit termination will be assigned to.
+          - This parameter is used with NetBox versions before 4.2.0.
         required: false
         type: raw
       port_speed:

--- a/plugins/modules/netbox_circuit_termination.py
+++ b/plugins/modules/netbox_circuit_termination.py
@@ -49,16 +49,22 @@ options:
         required: false
         type: bool
         version_added: 3.5.0
-      site:
+      termination_id:
         description:
-          - The site the circuit termination will be assigned to
+          - The ProviderNewtork, Location, Site, Region, or SiteGroup ID of the circuit termination will be assigned to
         required: false
-        type: raw
-      provider_network:
+        type: int
+      termination_type:
         description:
-          - The provider_network the circuit termination will be assigned to
+          - The type the circuit termination will be assigned to
+        choices:
+          - dcim.site
+          - dcim.location
+          - dcim.region
+          - dcim.sitegroup
+          - circuits.providernetwork
         required: false
-        type: raw
+        type: str
       port_speed:
         description:
           - The speed of the port (Kbps)
@@ -100,7 +106,8 @@ EXAMPLES = r"""
         data:
           circuit: Test Circuit
           term_side: A
-          site: Test Site
+          termination_id: 1
+          termination_type: dcim.site
           port_speed: 10000
         state: present
 
@@ -163,8 +170,8 @@ def main():
                     circuit=dict(required=True, type="raw"),
                     term_side=dict(required=True, choices=["A", "Z"]),
                     mark_connected=dict(required=False, type="bool"),
-                    site=dict(required=False, type="raw"),
-                    provider_network=dict(required=False, type="raw"),
+                    termination_id=dict(required=False, type="int"),
+                    termination_type=dict(required=False, type="str"),
                     port_speed=dict(required=False, type="int"),
                     upstream_speed=dict(required=False, type="int"),
                     xconnect_id=dict(required=False, type="str"),

--- a/plugins/modules/netbox_circuit_termination.py
+++ b/plugins/modules/netbox_circuit_termination.py
@@ -194,7 +194,17 @@ def main():
                     term_side=dict(required=True, choices=["A", "Z"]),
                     mark_connected=dict(required=False, type="bool"),
                     termination_id=dict(required=False, type="int"),
-                    termination_type=dict(required=False, type="str"),
+                    termination_type=dict(
+                        required=False,
+                        type="str",
+                        choices=[
+                            "dcim.site",
+                            "dcim.location",
+                            "dcim.region",
+                            "dcim.sitegroup",
+                            "circuits.providernetwork",
+                        ],
+                    ),
                     site=dict(required=False, type="raw"),
                     provider_network=dict(required=False, type="raw"),
                     port_speed=dict(required=False, type="int"),

--- a/plugins/modules/netbox_circuit_termination.py
+++ b/plugins/modules/netbox_circuit_termination.py
@@ -54,6 +54,7 @@ options:
           - The ProviderNetwork, Location, Site, Region, or SiteGroup ID of the circuit termination will be assigned to.  This is used with NetBox versions >= 4.2.0.
         required: false
         type: int
+        version_added: 4.2.0
       termination_type:
         description:
           - The type the circuit termination will be assigned to.  This is used with NetBox versions >= 4.2.0.
@@ -65,6 +66,7 @@ options:
           - circuits.providernetwork
         required: false
         type: str
+        version_added: 4.2.0
       site:
         description:
           - The site the circuit termination will be assigned to.  This is used with NetBox versions before 4.2.0.
@@ -214,14 +216,14 @@ def main():
         ("termination_id", "site"),
         ("termination_type", "site"),
         ("termination_id", "provider_network"),
-        ("termination_type", "provider_network")
+        ("termination_type", "provider_network"),
     ]
 
     module = NetboxAnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if,
-        mutually_exclusive=mutually_exclusive
+        mutually_exclusive=mutually_exclusive,
     )
 
     netbox_circuit_termination = NetboxCircuitsModule(module, NB_CIRCUIT_TERMINATIONS)

--- a/plugins/modules/netbox_circuit_termination.py
+++ b/plugins/modules/netbox_circuit_termination.py
@@ -51,7 +51,7 @@ options:
         version_added: 3.5.0
       termination_id:
         description:
-          - The ProviderNewtork, Location, Site, Region, or SiteGroup ID of the circuit termination will be assigned to
+          - The ProviderNetwork, Location, Site, Region, or SiteGroup ID of the circuit termination will be assigned to
         required: false
         type: int
       termination_type:


### PR DESCRIPTION
## Related Issue

#1401 

## New Behavior

This fix is to resolve the changes created by the [NetBox 4.2.0 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0) relating to:

`The site and provider_network foreign key fields on circuits.CircuitTermination have been replaced by the termination generic foreign key.`

## Contrast to Current Behavior

Current behavior results in module failure with the error:

`A circuit termination must attach to a terminating object.`

## Discussion: Benefits and Drawbacks

This fix resolves the issue with NetBox 4.2.x.  It is backward compatible with prior versions.

## Changes to the Documentation

Documentation in the module has been updated.

## Proposed Release Note Entry

Updated netbox_circuit_termination.py to support NetBox 4.2.x breaking changes.

## Double Check

* [ x ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ x ] I have explained my PR according to the information in the comments or in a linked issue.
* [ x ] My PR targets the `devel` branch.
