### PR TITLE
inventory plugin: support netbox endpoints running in a non-root context path (subpath)

### DIFF
--- a/changelogs/fragments/nb_inventory.yml
+++ b/changelogs/fragments/nb_inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nb_inventory - Fixed empty inventory results when netbox server URL is a non-root path

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -406,6 +406,8 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib import error as urllib_error
 from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.six.moves.urllib.parse import urlparse
+
 from ansible.module_utils.six import raise_from
 
 try:
@@ -1629,26 +1631,32 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.api_version = version.parse(netbox_api_version)
 
         if self.api_version >= version.parse("3.5.0"):
+            parsed_endpoint_url = urlparse(self.api_endpoint)
+            base_path = parsed_endpoint_url.path
             self.allowed_device_query_parameters = [
                 p["name"]
-                for p in openapi["paths"]["/api/dcim/devices/"]["get"]["parameters"]
+                for p in openapi["paths"][base_path + "/api/dcim/devices/"]["get"][
+                    "parameters"
+                ]
             ]
             self.allowed_vm_query_parameters = [
                 p["name"]
-                for p in openapi["paths"]["/api/virtualization/virtual-machines/"][
-                    "get"
-                ]["parameters"]
+                for p in openapi["paths"][
+                    base_path + "/api/virtualization/virtual-machines/"
+                ]["get"]["parameters"]
             ]
         else:
             self.allowed_device_query_parameters = [
                 p["name"]
-                for p in openapi["paths"]["/dcim/devices/"]["get"]["parameters"]
+                for p in openapi["paths"][base_path + "/dcim/devices/"]["get"][
+                    "parameters"
+                ]
             ]
             self.allowed_vm_query_parameters = [
                 p["name"]
-                for p in openapi["paths"]["/virtualization/virtual-machines/"]["get"][
-                    "parameters"
-                ]
+                for p in openapi["paths"][
+                    base_path + "/virtualization/virtual-machines/"
+                ]["get"]["parameters"]
             ]
 
     def validate_query_parameter(self, parameter, allowed_query_parameters):


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1408 

## New Behavior

Updated Plugin to parse the full path of the netbox server and compose API endpoints accordingly.
...

## allow inventory to support netbox endpoints on host.example.com/netboxpath/

This is a patch I originally made for v3.13 which had updated parsing of the openapi endpoint and assumes that netbox is always running in the root context rather than a path.     This performs the additional url parsing to derive the correct inventory API endpoints if netbox is running on a path rather than a root context.

I've tested this rebased patch on latest netbox running on in the root context path, as well as my legacy deployment running on host.com/netbox/
...

## Discussion: Benefits and Drawbacks

- allows users to run in additional supported configurations ex: somehost.example.com/netbox/ rather than only netbox.example.com
-

...

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

update inventory plugin to support netbox API running on non-root context paths.
...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
