### PR TITLE
Support of object types for netbox_tag module

### DIFF
--- a/changelogs/fragments/netbox_tag.yml
+++ b/changelogs/fragments/netbox_tag.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - netbox_tag - Add support for object_types on tags

--- a/plugins/modules/netbox_tag.py
+++ b/plugins/modules/netbox_tag.py
@@ -95,7 +95,6 @@ EXAMPLES = r"""
           name: "MyTag"
           object_types:
             - dcim.prefix
-
 """
 
 RETURN = r"""

--- a/plugins/modules/netbox_tag.py
+++ b/plugins/modules/netbox_tag.py
@@ -50,6 +50,12 @@ options:
           - Tag description
         required: false
         type: str
+      object_types:
+        description:
+          - Objects types using the tag
+        required: false
+        type: list
+        elements: raw
     required: true
 """
 
@@ -119,6 +125,7 @@ def main():
                     color=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     slug=dict(required=False, type="str"),
+                    object_types=dict(required=False, type="list", elements="raw"),
                 ),
             ),
         )

--- a/plugins/modules/netbox_tag.py
+++ b/plugins/modules/netbox_tag.py
@@ -86,6 +86,16 @@ EXAMPLES = r"""
       loop:
         - mgmt
         - tun
+
+    - name: Restrict object types
+      netbox.netbox.netbox_tag:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: "MyTag"
+          object_types:
+            - dcim.prefix
+
 """
 
 RETURN = r"""

--- a/tests/integration/targets/v4.2/tasks/netbox_tag.yml
+++ b/tests/integration/targets/v4.2/tasks/netbox_tag.yml
@@ -12,6 +12,8 @@
       name: Test Tag 1
       description: Tag 1 test
       color: "0000ff"
+      object_types:
+        - ipem.prefix
     state: present
   register: test_one
 
@@ -25,6 +27,7 @@
       - test_one['tags']['description'] == "Tag 1 test"
       - test_one['tags']['name'] == "Test Tag 1"
       - test_one['tags']['slug'] == "test-tag-1"
+      - test_one['tags']['object_types'][0] = "ipam.prefix"
       - test_one['msg'] == "tags Test Tag 1 created"
 
 - name: "TAG 2: Create duplicate"
@@ -53,6 +56,8 @@
       name: Test Tag 1
       description: Tag 1 update test
       color: "00ff00"
+      object_types:
+        - ipam.asn
     state: present
   register: test_three
 
@@ -65,6 +70,7 @@
       - test_three['tags']['name'] == "Test Tag 1"
       - test_three['tags']['description'] == "Tag 1 update test"
       - test_three['tags']['color'] == "00ff00"
+       -test_three['tags']['object_types'][0] == "ipam.asn"
       - test_three['msg'] == "tags Test Tag 1 updated"
 
 - name: "TAG 4: ASSERT - Delete"


### PR DESCRIPTION

## Related Issue

Not tracked yet: Setting object type for tags is not supported.

## New Behavior

Add extra parameters to the module so object_types is supported.

## Contrast to Current Behavior
N/A

## Discussion: Benefits and Drawbacks

Support for this field


## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

- Suport for "object_types" in netbox_tag

## Double Check

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
