### PR TITLE
Update netbox_service.py

### DIFF
--- a/plugins/modules/netbox_service.py
+++ b/plugins/modules/netbox_service.py
@@ -85,6 +85,18 @@ options:
           - Must exist in NetBox and in key/value format
         required: false
         type: dict
+      parent_object_type:
+        description:
+          - Specifies which object type to associate with service.
+        required: true
+        type: str
+        version_added: "3.22.0"
+      parent_object_id:
+        description:
+          - Specifies which object to associate with service.
+        required: true
+        type: int
+        version_added: "3.22.0"
     required: true
 """
 
@@ -108,6 +120,8 @@ EXAMPLES = r"""
             - address: 127.0.0.1
           tags:
             - prometheus
+          parent_object_type: "dcim.device"
+          parent_object_id: 1
         state: present
 
     - name: Delete service
@@ -155,6 +169,8 @@ def main():
                     comments=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
+                    parent_object_type=dict(required=True, type="str"),
+                    parent_object_id=dict(required=True, type="int"),
                 ),
             ),
         )


### PR DESCRIPTION
# Add support for `parent_object_type` and `parent_object_id` in `netbox_service.py`

## Related Issue

## New Behavior

* Extends the **NetBox Service** module with two new required parameters introduced in NetBox 4.3:

| Parameter            | Type | Required | Since |
|----------------------|------|----------|-------|
| `parent_object_type` | str  | yes      | 3.22  |
| `parent_object_id`   | int  | yes      | 3.22  |

* Allows users to bind a service directly to **any** NetBox object type (device, VM interface, IP address, etc.) by specifying its type and primary‑key ID.

## Contrast to Current Behavior

* Prior to NetBox 4.3 the API accepted `device`, `virtual_machine`, or similar fixed keys.  
* Without these new fields, the module now fails with **“A parent object (type & id) must be specified”** errors when talking to NetBox ≥ 4.3.

## Discussion: Benefits and Drawbacks

### Benefits
* Restores full compatibility with the current NetBox API.
* Change is additive, so it remains harmless for NetBox ≤ 4.2 (fields are ignored by the API).

### Drawbacks
* Slightly expands the module interface; playbooks **must** supply the new params when upgrading to NetBox 4.3+.

## Changes to the Documentation

## Proposed Release Note Entry

```text
* **netbox_service** – add required NetBox 4.3 fields
  * new parameters: `parent_object_type` (str), `parent_object_id` (int)
```

## Double Check

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the **devel** branch.