### PR TITLE
Netbox custom field related object filter

### DIFF
--- a/changelogs/fragments/netbox_custom_field.yml
+++ b/changelogs/fragments/netbox_custom_field.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Support for related_object_filter when related_object_type is "object"

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -152,7 +152,7 @@ options:
         type: str
       related_object_filter:
         description:
-          - Filter definition for related object selection
+          - Filter definition for related object selection. To reset the value, set it to an empty dict (null value is ignored by the API)
         required: false
         type: dict
     required: true

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -150,6 +150,11 @@ options:
           - The name of the choice set to use (for selection fields)
         required: false
         type: str
+      related_object_filter:
+        description:
+          - Filter definition for related object selection
+        required: false
+        type: dict
     required: true
 """
 
@@ -288,6 +293,7 @@ def main():
                         required=False,
                         type="str",
                     ),
+                    related_object_filter=dict(required=False, type="dict"),
                 ),
             )
         )


### PR DESCRIPTION
## Related Issue

Not tracked

## New Behavior

Support for extra parameter "related_objet_filter" allowing to set a filter for related object, allowed when type=object

Filter is passed as a dict in the task:
```yaml
    - name: create custom fields
      netbox.netbox.netbox_custom_field:
        netbox_url: "{{ netbox_url }}"
        netbox_token: "{{ netbox_token }}"
        data:
          name: "TEST_CF"
          object_types: ipam.prefix
          type: object
          related_object_type: ipam.prefix
          related_object_filter:
            tags: xx
        state: present
      delegate_to: localhost
```

## Contrast to Current Behavior

This parameter wasn't supported

## Discussion: Benefits and Drawbacks

I've noticed the reset of this param on the target objet must be done by passing an empty dict like "{{ {} }}". Setting it to null seems to be ignored by the API.

Like other data-dependent parameters, we rely on the remote API for asserting we can or connot use this paramater (this param is only allowed for type=object for instance)

## Changes to the Documentation

Should be transparent

## Proposed Release Note Entry
See fragment

## Double Check

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
