### PR TITLE
fixes #1426 : broken netbox_service module

### DIFF
--- a/changelogs/fragments/netbox_service.yml
+++ b/changelogs/fragments/netbox_service.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix issue #1426 : broken netbox_service module

--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -162,6 +162,8 @@ class NetboxIpamModule(NetboxModule):
         - vlans
         - vlan_groups
         - vrfs
+        - services
+        - service_template
         """
         # Used to dynamically set key when returning results
         endpoint_name = ENDPOINT_NAME_MAPPING[self.endpoint]
@@ -213,6 +215,16 @@ class NetboxIpamModule(NetboxModule):
         if self.endpoint in SLUG_REQUIRED:
             if not data.get("slug"):
                 data["slug"] = self._to_slug(name)
+
+        if self.endpoint == "services":
+            if "device" in data:
+                data["parent_object_type"] = "dcim.device"
+                data["parent_object_id"] = data["device"]
+                del data["device"]
+            elif "virtual_machine" in data:
+                data["parent_object_type"] = "virtualization.virtualmachine"
+                data["parent_object_id"] = data["virtual_machine"]
+                del data["virtual_machine"]
 
         if self.module.params.get("first_available"):
             first_available = True


### PR DESCRIPTION

## Related Issue

https://github.com/netbox-community/ansible_modules/issues/1426

## New Behavior

netbox_service module is working again, with either ***device*** or ***virtual_machine*** parameter, corretly mapped to API parameters

## Discussion: Benefits and Drawbacks

Not sure if the extra params should be cleaned in netbox_ipam.py after being moved to API parameters., but it's working.

## Changes to the Documentation

None

## Proposed Release Note Entry

Changelog fragment pushed
## Double Check

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
