### PR TITLE
netbox_ip_address: support for FHRP group assignment

### DIFF
--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1076,6 +1076,11 @@ class NetboxModule(object):
                 query_dict.update(
                     {"interface_id": module_data.get("assigned_object_id")}
                 )
+            elif module_data["assigned_object_type"] == "ipam.fhrpgroup":
+                query_dict.update(
+                    {"???": module_data.get("assigned_object_id")}
+                )
+
 
         elif parent == "virtual_chassis":
             query_dict.update({"master": self.module.params["data"].get("master")})

--- a/plugins/modules/netbox_ip_address.py
+++ b/plugins/modules/netbox_ip_address.py
@@ -340,6 +340,7 @@ def main():
                             name=dict(required=False, type="str"),
                             device=dict(required=False, type="str"),
                             virtual_machine=dict(required=False, type="str"),
+                            fhrp_group=dict(required=False, type="str"),
                         ),
                     ),
                     comments=dict(required=False, type="str"),


### PR DESCRIPTION

## Related Issue

#1428 

## New Behavior

Add support for FHRP group assignment

...

## Contrast to Current Behavior

doesnt support it rn

...

## Discussion: Benefits and Drawbacks

just a draft PR right now, 
I'm trying to read into the codebase to understand how exactly the query_dict is relevant and how it does the assignment to assigned_object

...

## Changes to the Documentation

n/a \ in code
...

## Proposed Release Note Entry

netbox_ip_address: add support for FHRP group assignment

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [ X] I have explained my PR according to the information in the comments or in a linked issue.
* [ X] My PR targets the `devel` branch.
