### PR TITLE
Fix duplicate task name in documentation

### DIFF
--- a/changelogs/fragments/1435-fix-duplicate-task-name.yml
+++ b/changelogs/fragments/1435-fix-duplicate-task-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix task duplicate task name in documentation that cause ansible-lint error

--- a/changelogs/fragments/1435-fix-duplicate-task-name.yml
+++ b/changelogs/fragments/1435-fix-duplicate-task-name.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - Fix task duplicate task name in documentation that cause ansible-lint error
-  

--- a/changelogs/fragments/1435-fix-duplicate-task-name.yml
+++ b/changelogs/fragments/1435-fix-duplicate-task-name.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - Fix task duplicate task name in documentation that cause ansible-lint error
+  

--- a/docs/plugins/netbox_device_type_module.rst
+++ b/docs/plugins/netbox_device_type_module.rst
@@ -1076,7 +1076,7 @@ Examples
               manufacturer: Test Manufacturer
             state: present
 
-        - name: Create device type within NetBox with only required information
+        - name: Create device type within NetBox with more information
           netbox.netbox.netbox_device_type:
             netbox_url: http://netbox.local
             netbox_token: thisIsMyToken

--- a/docs/plugins/netbox_platform_module.rst
+++ b/docs/plugins/netbox_platform_module.rst
@@ -782,7 +782,7 @@ Examples
               config_template: "my_config_template_slug"
             state: present
 
-        - name: Create platform within NetBox with only required information
+        - name: Create platform within NetBox with more information
           netbox.netbox.netbox_platform:
             netbox_url: http://netbox.local
             netbox_token: thisIsMyToken

--- a/docs/plugins/netbox_prefix_module.rst
+++ b/docs/plugins/netbox_prefix_module.rst
@@ -1216,7 +1216,7 @@ Examples
       gather_facts: false
 
       tasks:
-        - name: Create prefix within NetBox with only required information
+        - name: Create prefix within NetBox with only required information before deleting it 
           netbox.netbox.netbox_prefix:
             netbox_url: http://netbox.local
             netbox_token: thisIsMyToken

--- a/plugins/modules/netbox_device_type.py
+++ b/plugins/modules/netbox_device_type.py
@@ -150,7 +150,7 @@ EXAMPLES = r"""
           manufacturer: Test Manufacturer
         state: present
 
-    - name: Create device type within NetBox with only required information
+    - name: Create device type within NetBox with more information
       netbox.netbox.netbox_device_type:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken

--- a/plugins/modules/netbox_platform.py
+++ b/plugins/modules/netbox_platform.py
@@ -106,7 +106,7 @@ EXAMPLES = r"""
           config_template: "my_config_template_slug"
         state: present
 
-    - name: Create platform within NetBox with only required information
+    - name: Create platform within NetBox with more information
       netbox.netbox.netbox_platform:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken

--- a/plugins/modules/netbox_prefix.py
+++ b/plugins/modules/netbox_prefix.py
@@ -153,7 +153,7 @@ EXAMPLES = r"""
   gather_facts: false
 
   tasks:
-    - name: Create prefix within NetBox with only required information
+    - name: Create prefix within NetBox with only required information before deleting it
       netbox.netbox.netbox_prefix:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken


### PR DESCRIPTION
## Related Issue
As mentionned in https://github.com/netbox-community/ansible_modules/pull/1433#issuecomment-3024601330 I fix lint issue

## New Behavior
N/A

## Contrast to Current Behavior
N/A

## Discussion: Benefits and Drawbacks
Lint check will pass

## Changes to the Documentation
Name of tasks

## Proposed Release Note Entry
Fix Lint error caused by duplicate task name

## Double Check


* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
