### PR TITLE
fix(nb_inventory.py): services grouping no longer working

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1348,16 +1348,24 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         for service in services:
             service_id = service["id"]
-
-            if service.get("device"):
-                self.device_services_lookup[service["device"]["id"]][
-                    service_id
-                ] = service
-
-            if service.get("virtual_machine"):
-                self.vm_services_lookup[service["virtual_machine"]["id"]][
-                    service_id
-                ] = service
+            parent_type = service.get("parent_object_type")
+            parent_id = service.get("parent_object_id")
+        
+            if parent_type == "virtualization.virtualmachine":
+                self.vm_services_lookup[parent_id][service_id] = service
+        
+            elif parent_type == "dcim.device":
+                self.device_services_lookup[parent_id][service_id] = service
+        
+            else:
+                vm = service.get("virtual_machine")
+                device = service.get("device")
+        
+                if vm:
+                    self.vm_services_lookup[vm["id"]][service_id] = service
+        
+                if device:
+                    self.device_services_lookup[device["id"]][service_id] = service
 
     def refresh_virtual_disks(self):
         url_vm_virtual_disks = (


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

I did not make an issue for this behavior and instead fixed.

## New Behavior

If the Netbox used for the inventory is greater than v4.3.0, the grouping of services still works in addition to lower versions.

## Contrast to Current Behavior

If the Netbox used for the inventory is greater than v4.3.0, the grouping by services no longer works

## Discussion: Benefits and Drawbacks

Since [v4.3.0 of Netbox](https://github.com/netbox-community/netbox/releases/tag/v4.3.0), grouping by service was no longer working as it dropped the specific `device` and `virtual_machine` foreign keys for a generic `parent` relationship. This fixes a feature that was once working, but continues to keep the "old" style of checking for Netbox versions pre-4.3.0

## Changes to the Documentation

No changes required

## Proposed Release Note Entry

Fixed grouping by service no longer working if Netbox version is greater than v4.3.0

## Double Check

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
