### PR TITLE
Fix #1469 - the old api code path didnt get the variable defined that  is being used to locate the api endpoints

### DIFF
--- a/changelogs/fragments/1469-fix-old-apis.yml
+++ b/changelogs/fragments/1469-fix-old-apis.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Fix broken code path when using old api path on old netbox systems

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1648,10 +1648,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 pass
 
         self.api_version = version.parse(netbox_api_version)
+        parsed_endpoint_url = urlparse(self.api_endpoint)
+        base_path = parsed_endpoint_url.path
 
         if self.api_version >= version.parse("3.5.0"):
-            parsed_endpoint_url = urlparse(self.api_endpoint)
-            base_path = parsed_endpoint_url.path
             self.allowed_device_query_parameters = [
                 p["name"]
                 for p in openapi["paths"][base_path + "/api/dcim/devices/"]["get"][


### PR DESCRIPTION
…


## Related Issue

#1469  

## New Behavior

The variable that is being used to identify the api endpoint can now be used in the code path for older netbox servers so the inventory plugin shouldn't crash when attempting to communicate with old servers.
 
...

## Contrast to Current Behavior

When using old netbox servers we should be able to retrieve inventory information rather than crashing with errors about not being able to access variables.

...

## Discussion: Benefits and Drawbacks

This is only relevant to old old servers but we currently have a broken code path in the current version of the plugin.

One alternative in my mind would be to remove all of the checks for version lt 3.5.0, update the documentation to indicate that it's really not supported and probably create a new check for the old api version/path that just returns an error saying "upgrade to a newer version of netbox"

...

## Changes to the Documentation

None - stopping a bug from triggering.

## Proposed Release Note Entry

Fix of logic when interacting with old netbox servers.

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
