### PR TITLE
fix issue 1479 - netbox_service - More than one result returned for

### DIFF
--- a/changelogs/fragments/1479-fix-services_parent_object.yml
+++ b/changelogs/fragments/1479-fix-services_parent_object.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - add parent_object_type and parent_object_id to services ALLOWED_QUERY_PARAMS
+minor_changes:
+  - add workaround to _build_query_params for services and Netbox 4.3.0 - 4.4.3 (wrong parent_object_type data type)

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -567,7 +567,17 @@ ALLOWED_QUERY_PARAMS = {
     "rir": set(["slug"]),
     "role": set(["slug"]),
     "route_target": set(["name"]),
-    "services": set(["device", "virtual_machine", "name", "port", "protocol"]),
+    "services": set(
+        [
+            "device",
+            "virtual_machine",
+            "name",
+            "port",
+            "protocol",
+            "parent_object_type",
+            "parent_object_id",
+        ]
+    ),
     "service_template": set(["name"]),
     "site": set(["slug", "name"]),
     "site_group": set(["slug"]),
@@ -1187,6 +1197,15 @@ class NetboxModule(object):
                     query_dict["device_type_id"] = query_dict.pop("device_type")
                 else:
                     query_dict["devicetype_id"] = query_dict.pop("device_type")
+        # TODO workaround for Netbox 4.3.0 - 4.4.3 - #20554
+        # Remove 'elif parent == "services":' block after support for
+        # Netbox 4.3.0 - 4.4.3 is removed
+        elif parent == "services":
+            if self._version_check_greater(
+                self.version, "4.3", greater_or_equal=True
+            ) and self._version_check_greater("4.4.4", self.full_version):
+                query_dict.pop("parent_object_id", None)
+                query_dict.pop("parent_object_type", None)
 
         if not query_dict:
             provided_kwargs = child.keys() if child else module_data.keys()


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
Issue https://github.com/netbox-community/ansible_modules/issues/1479

(and PR https://github.com/netbox-community/ansible_modules/pull/1427 seems missing ALLOWED_QUERY_PARAMS part)


<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## Modified Behavior
- add `parent_object_type` and `parent_object_id` to `services`  `ALLOWED_QUERY_PARAMS` 
- add workaround to `_build_query_params` for services and Netbox 4.3.0 - 4.4.3
  https://github.com/netbox-community/netbox/issues/20554

## New Behavior
None
<!--
Please describe in a few words the intentions of your PR.
-->

...

## Contrast to Current Behavior
You'll be able to create more services with the same name but different parent. For netbox 4.4.4 and never
Parent param introduced in Netbox 4.3.0

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

...

## Discussion: Benefits and Drawbacks
Services will work correctly again for Netbox 4.4.4 (4.3.0) and never
 - `parent_object_type` and `parent_object_id` should be added to  `services`  `ALLOWED_QUERY_PARAMS` 
 - be able to query services correctly. Only name of service is not globally unique for Netbox 4.3.0 and never. So parent parameters should be involved.

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Documentation
None
<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry
- add parent_object_type and parent_object_id to services ALLOWED_QUERY_PARAMS
<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
