### PR TITLE
Convert more keys/attribute values from list to set

### DIFF
--- a/changelogs/fragments/1486-fix-list-as-set.yml
+++ b/changelogs/fragments/1486-fix-list-as-set.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Take a more generic approach for set comparison. Other models have object_types too

--- a/plugins/module_utils/netbox_users.py
+++ b/plugins/module_utils/netbox_users.py
@@ -15,9 +15,6 @@ NB_PERMISSIONS = "permissions"
 NB_TOKENS = "tokens"
 NB_USERS = "users"
 
-# These suboptions are lists, but need to be modeled as sets for comparison purposes.
-LIST_AS_SET_KEYS = set(["permissions", "groups", "actions", "object_types"])
-
 
 class NetboxUsersModule(NetboxModule):
     def __init__(self, module, endpoint):
@@ -73,26 +70,17 @@ class NetboxUsersModule(NetboxModule):
         self.module.exit_json(**self.result)
 
     def _update_netbox_object(self, data):
-        if self.endpoint == NB_TOKENS:
-            return self._update_netbox_token(data)
+        if self.endpoint == "users":
+            return self._update_netbox_user(data)
         else:
-            return self.__update_netbox_object__(data)
+            if self.endpoint == "tokens" and "key" in data:
+                del data["key"]
+            return super()._update_netbox_object(data)
 
-    def _update_netbox_token(self, data):
-        if "key" in data:
-            del data["key"]
-        return self.__update_netbox_object__(data)
-
-    def __update_netbox_object__(self, data):
+    def _update_netbox_user(self, data):
         serialized_nb_obj = self.nb_object.serialize()
         updated_obj = serialized_nb_obj.copy()
         updated_obj.update(data)
-
-        if serialized_nb_obj:
-            for key in LIST_AS_SET_KEYS:
-                if serialized_nb_obj.get(key) and data.get(key):
-                    serialized_nb_obj[key] = set(serialized_nb_obj[key])
-                    updated_obj[key] = set(data[key])
 
         if serialized_nb_obj == updated_obj:
             return serialized_nb_obj, None


### PR DESCRIPTION
## Related Issue

Fixes #1486 

## New Behavior

In addition to `tags`, the fields `tagged_vlans` and `object_types` should be considered a set, not an ordered list. This should be in sync with `pynetbox` as well. (https://github.com/netbox-community/pynetbox/blob/master/pynetbox/core/response.py#L25-L26) I'll propose that object_types will be added there as well.

This is a follow up on #1456 to take a more generic approach when lists should be converted to/compared as set

...

## Contrast to Current Behavior

The field `object_types` is currently handled as a sorted list, but the response is unsorted resuting in constand changed tasks, even nothing has changed.

...

## Discussion: Benefits and Drawbacks

I don't see any drawbacks as object_types is not considered to be ordered.

...

## Changes to the Documentation

Nothing, as it doesn't affect the outcome, it just fixes a display issue (changed vs ok)


## Proposed Release Note Entry

Take a more generic approach for set comparison. Other models have object_types too
...

## Double Check


* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
