### PR TITLE
Fix bad-return-value-key issue in sanity checks

### DIFF
--- a/changelogs/fragments/1488-bad-return-value-key-fix.yml
+++ b/changelogs/fragments/1488-bad-return-value-key-fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Fix RETURNS documentation string for netbox_virtual_machines module

--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -196,7 +196,7 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
-virtual machine:
+virtual_machine:
   description: Serialized object as created or already existent within NetBox
   returned: success (when I(state=present))
   type: dict


### PR DESCRIPTION
This changes "virtual machine" to "virtual_machine" in order to satisfy ansible-test's sanity checks, which has flagged this key as unusable with Jinja templating.