### PR TITLE
use `ansible.module_utils.common.text.converters`

### DIFF
--- a/changelogs/fragments/deprecated-to-text.yml
+++ b/changelogs/fragments/deprecated-to-text.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Use `ansible.module_utils.common.text.converters` instead of the deprecated `ansible.module_utils._text`

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -402,7 +402,7 @@ from ansible.constants import DEFAULT_LOCAL_TMP
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.common.text.converters import to_text, to_native
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib import error as urllib_error
 from ansible.module_utils.six.moves.urllib.parse import urlencode

--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 # Import necessary packages
 from ipaddress import ip_interface
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import (
     NetboxModule,

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -14,8 +14,7 @@ import re
 import json
 from itertools import chain
 
-from ansible.module_utils.common.text.converters import to_text
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.common.collections import is_iterable
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib, _load_params
 from ansible.module_utils.urls import open_url


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
Hello maintainers,

I have been using your module; it's of great help. I came across some deprecation warnings in 3.16 and 3.22

Your feedback is much appreciated.

Related to no issue.

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior
None.

<!--
Please describe in a few words the intentions of your PR.
-->

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

No difference.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

`ansible.module_utils._text` shall be deprecated in `ansible-core 2.24`; see https://github.com/ansible-collections/vmware.vmware/issues/268.

Use `ansible.module_utils.common.text.converters`. This clears out deprecating warnings.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->
No change.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Use `ansible.module_utils.common.text.converters` instead of the deprecated `ansible.module_utils._text`

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
