### PR TITLE
add module_type  for front and rear port templates

### DIFF
--- a/changelogs/fragments/module_type_template.yml
+++ b/changelogs/fragments/module_type_template.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add `module_type` as supported to `netbox_rear_port_template`
+  - Add `module_type` as supported to `netbox_front_port_template`

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -408,7 +408,6 @@ from ansible.module_utils.six.moves.urllib import error as urllib_error
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 
-
 try:
     from packaging import specifiers, version
 except ImportError as imp_exc:

--- a/plugins/module_utils/netbox_circuits.py
+++ b/plugins/module_utils/netbox_circuits.py
@@ -11,7 +11,6 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
     SLUG_REQUIRED,
 )
 
-
 NB_PROVIDERS = "providers"
 NB_PROVIDER_NETWORKS = "provider_networks"
 NB_CIRCUIT_TYPES = "circuit_types"

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -12,7 +12,6 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
     SLUG_REQUIRED,
 )
 
-
 NB_CABLES = "cables"
 NB_CONSOLE_PORTS = "console_ports"
 NB_CONSOLE_PORT_TEMPLATES = "console_port_templates"

--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -15,7 +15,6 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
     SLUG_REQUIRED,
 )
 
-
 NB_AGGREGATES = "aggregates"
 NB_ASNS = "asns"
 NB_FHRP_GROUPS = "fhrp_groups"

--- a/plugins/module_utils/netbox_tenancy.py
+++ b/plugins/module_utils/netbox_tenancy.py
@@ -11,7 +11,6 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
     SLUG_REQUIRED,
 )
 
-
 NB_TENANTS = "tenants"
 NB_TENANT_GROUPS = "tenant_groups"
 NB_CONTACTS = "contacts"

--- a/plugins/module_utils/netbox_virtualization.py
+++ b/plugins/module_utils/netbox_virtualization.py
@@ -11,7 +11,6 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
     SLUG_REQUIRED,
 )
 
-
 NB_VIRTUAL_MACHINES = "virtual_machines"
 NB_CLUSTERS = "clusters"
 NB_CLUSTER_GROUP = "cluster_groups"

--- a/plugins/module_utils/netbox_vpn.py
+++ b/plugins/module_utils/netbox_vpn.py
@@ -14,7 +14,6 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
     SLUG_REQUIRED,
 )
 
-
 NB_L2VPNS = "l2vpns"
 NB_L2VPN_TERMINATIONS = "l2vpn_terminations"
 NB_TUNNELS = "tunnels"

--- a/plugins/module_utils/netbox_wireless.py
+++ b/plugins/module_utils/netbox_wireless.py
@@ -11,7 +11,6 @@ from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import 
     SLUG_REQUIRED,
 )
 
-
 NB_WIRELESS_LANS = "wireless_lans"
 NB_WIRELESS_LAN_GROUPS = "wireless_lan_groups"
 NB_WIRELESS_LINKS = "wireless_links"

--- a/plugins/modules/netbox_front_port_template.py
+++ b/plugins/modules/netbox_front_port_template.py
@@ -34,7 +34,12 @@ options:
       device_type:
         description:
           - The device type the front port template is attached to
-        required: true
+          - Either I(device_type) or I(module_type) are required
+        type: raw
+      module_type:
+        description:
+          - The module type the front port template is attached to
+          - Either I(device_type) or I(module_type) are required
         type: raw
       name:
         description:
@@ -103,6 +108,17 @@ EXAMPLES = r"""
           rear_port_template: Test Rear Port Template
         state: present
 
+    - name: Create front port template for a module type within NetBox
+      netbox.netbox.netbox_front_port_template:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test Front Port Template
+          module_type: Test Module Type
+          type: bnc
+          rear_port_template: Test Rear Port Template
+        state: present
+
     - name: Update front port template with other fields
       netbox.netbox.netbox_front_port_template:
         netbox_url: http://netbox.local
@@ -160,7 +176,8 @@ def main():
                 type="dict",
                 required=True,
                 options=dict(
-                    device_type=dict(required=True, type="raw"),
+                    device_type=dict(required=False, type="raw"),
+                    module_type=dict(required=False, type="raw"),
                     name=dict(required=True, type="str"),
                     type=dict(
                         required=False,
@@ -192,12 +209,19 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["device_type", "name", "type", "rear_port_template"]),
-        ("state", "absent", ["device_type", "name", "type", "rear_port_template"]),
+        ("state", "present", ["name", "type", "rear_port_template"]),
+        ("state", "absent", ["name", "type", "rear_port_template"]),
+    ]
+
+    required_one_of = [
+        ("device_type", "module_type"),
     ]
 
     module = NetboxAnsibleModule(
-        argument_spec=argument_spec, supports_check_mode=True, required_if=required_if
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=required_if,
+        required_one_of=required_one_of,
     )
 
     netbox_front_port_template = NetboxDcimModule(module, NB_FRONT_PORT_TEMPLATES)

--- a/plugins/modules/netbox_rear_port_template.py
+++ b/plugins/modules/netbox_rear_port_template.py
@@ -34,7 +34,12 @@ options:
       device_type:
         description:
           - The device type the rear port template is attached to
-        required: true
+          - Either I(device_type) or I(module_type) are required
+        type: raw
+      module_type:
+        description:
+          - The module type the rear port template is attached to
+          - Either I(device_type) or I(module_type) are required
         type: raw
       name:
         description:
@@ -97,6 +102,16 @@ EXAMPLES = r"""
           type: bnc
         state: present
 
+    - name: Create rear port template for a module type within NetBox
+      netbox.netbox.netbox_rear_port_template:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test Rear Port Template
+          module_type: Test Module Type
+          type: bnc
+        state: present
+
     - name: Update rear port template with other fields
       netbox.netbox.netbox_rear_port_template:
         netbox_url: http://netbox.local
@@ -152,7 +167,8 @@ def main():
                 type="dict",
                 required=True,
                 options=dict(
-                    device_type=dict(required=True, type="raw"),
+                    device_type=dict(required=False, type="raw"),
+                    module_type=dict(required=False, type="raw"),
                     name=dict(required=True, type="str"),
                     type=dict(
                         required=False,
@@ -183,12 +199,19 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["device_type", "name", "type"]),
-        ("state", "absent", ["device_type", "name", "type"]),
+        ("state", "present", ["name", "type"]),
+        ("state", "absent", ["name", "type"]),
+    ]
+
+    required_one_of = [
+        ("device_type", "module_type"),
     ]
 
     module = NetboxAnsibleModule(
-        argument_spec=argument_spec, supports_check_mode=True, required_if=required_if
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=required_if,
+        required_one_of=required_one_of,
     )
 
     netbox_rear_port_template = NetboxDcimModule(module, NB_REAR_PORT_TEMPLATES)

--- a/tests/integration/targets/v4.3/tasks/netbox_front_port_template.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_front_port_template.yml
@@ -7,6 +7,15 @@
 ### NETBOX_FRONT_PORT_TEMPLATE
 ##
 ##
+- name: "NETBOX_FRONT_PORT_TEMPLATE 0.1: Create module type for testing power ports on module types"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Module Type Front And Rear Port Tests
+      manufacturer: Test Manufacturer
+    state: present
+
 - name: "FRONT_PORT_TEMPLATE 1: Necessary info creation"
   netbox.netbox.netbox_front_port_template:
     netbox_url: http://localhost:32768
@@ -145,3 +154,142 @@
       - test_six['front_port_template']['type'] == "bnc"
       - test_six['front_port_template']['rear_port'] == 1
       - test_six['msg'] == "front_port_template Front Port Template already exists"
+
+- name: "FRONT_PORT_TEMPLATE 7: Necessary info creation"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      rear_port_template: Module Type Rear Port Template
+    state: present
+  register: test_seven
+
+- name: "FRONT_PORT_TEMPLATE 7: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_seven['front_port_template']['module_type'] == 1
+      - test_seven['front_port_template']['type'] == "bnc"
+      - test_seven['front_port_template']['rear_port'] == 4
+      - test_seven['msg'] == "front_port_template Module Type Front Port Template created"
+
+- name: "FRONT_PORT_TEMPLATE 8: Create duplicate"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      rear_port_template: Module Type Rear Port Template
+    state: present
+  register: test_eight
+
+- name: "FRONT_PORT_TEMPLATE 8: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_eight['changed']
+      - test_eight['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_eight['front_port_template']['module_type'] == 1
+      - test_eight['front_port_template']['type'] == "bnc"
+      - test_eight['front_port_template']['rear_port'] == 4
+      - test_eight['msg'] == "front_port_template Module Type Front Port Template already exists"
+
+- name: "FRONT_PORT_TEMPLATE 9: Update Front Port Template with other fields"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      rear_port_template: Module Type Rear Port Template
+      rear_port_template_position: 5
+    state: present
+  register: test_nine
+
+- name: "FRONT_PORT_TEMPLATE 9: ASSERT - Update Front Port Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['after']['rear_port_position'] == 5
+      - test_nine['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_nine['front_port_template']['module_type'] == 1
+      - test_nine['front_port_template']['type'] == "bnc"
+      - test_nine['front_port_template']['rear_port_position'] == 5
+      - test_nine['front_port_template']['rear_port'] == 4
+      - test_nine['msg'] == "front_port_template Module Type Front Port Template updated"
+
+- name: "FRONT_PORT_TEMPLATE 10: Create Front Port Template for Delete Test"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      rear_port_template: Module Type Rear Port Template
+    state: present
+  register: test_ten
+
+- name: "FRONT_PORT_TEMPLATE 10: ASSERT - Create Front Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['front_port_template']['name'] == "Module Type Front Port Template 2"
+      - test_ten['front_port_template']['module_type'] == 1
+      - test_ten['front_port_template']['type'] == "bnc"
+      - test_ten['front_port_template']['rear_port'] == 4
+      - test_ten['msg'] == "front_port_template Module Type Front Port Template 2 created"
+
+- name: "FRONT_PORT_TEMPLATE 11: Delete Front Port Template"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      rear_port_template: Module Type Rear Port Template
+    state: absent
+  register: test_eleven
+
+- name: "FRONT_PORT_TEMPLATE 11: ASSERT - Delete Front Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "present"
+      - test_eleven['diff']['after']['state'] == "absent"
+      - test_eleven['msg'] == "front_port_template Module Type Front Port Template 2 deleted"
+
+- name: "FRONT_PORT_TEMPLATE 12: Create duplicate with rear_port_template dictionary"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      rear_port_template:
+        module: Module Type Front And Rear Port Tests
+        name: Module Type Rear Port Template
+    state: present
+  register: test_twelve
+
+- name: "FRONT_PORT_TEMPLATE 12: ASSERT - Create duplicate with rear_port_template dictionary"
+  ansible.builtin.assert:
+    that:
+      - not test_twelve['changed']
+      - test_twelve['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_twelve['front_port_template']['module_type'] == 1
+      - test_twelve['front_port_template']['type'] == "bnc"
+      - test_twelve['front_port_template']['rear_port'] == 4
+      - test_twelve['msg'] == "front_port_template Module Type Front Port Template already exists"

--- a/tests/integration/targets/v4.3/tasks/netbox_power_port_template.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_power_port_template.yml
@@ -145,7 +145,7 @@
       - test_six['diff']['before']['state'] == "absent"
       - test_six['diff']['after']['state'] == "present"
       - test_six['power_port_template']['name'] == "Module Power Port Template"
-      - test_six['power_port_template']['module_type'] == 1
+      - test_six['power_port_template']['module_type'] == 2
       - test_six['msg'] == "power_port_template Module Power Port Template created"
 
 - name: "POWER_PORT_TEMPLATE 7: Create duplicate"
@@ -163,7 +163,7 @@
     that:
       - not test_seven['changed']
       - test_seven['power_port_template']['name'] == "Module Power Port Template"
-      - test_seven['power_port_template']['module_type'] == 1
+      - test_seven['power_port_template']['module_type'] == 2
       - test_seven['msg'] == "power_port_template Module Power Port Template already exists"
 
 - name: "POWER_PORT_TEMPLATE 8: Update power_port_template with other fields"
@@ -187,7 +187,7 @@
       - test_eight['diff']['after']['allocated_draw'] == 10
       - test_eight['diff']['after']['maximum_draw'] == 20
       - test_eight['power_port_template']['name'] == "Module Power Port Template"
-      - test_eight['power_port_template']['module_type'] == 1
+      - test_eight['power_port_template']['module_type'] == 2
       - test_eight['power_port_template']['type'] == "ita-e"
       - test_eight['power_port_template']['allocated_draw'] == 10
       - test_eight['power_port_template']['maximum_draw'] == 20

--- a/tests/integration/targets/v4.3/tasks/netbox_rear_port_template.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_rear_port_template.yml
@@ -7,6 +7,15 @@
 ### NETBOX_REAR_PORT_TEMPLATE
 ##
 ##
+- name: "NETBOX_REAR_PORT_TEMPLATE 0.1: Create module type for testing power ports on module types"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Module Type Front And Rear Port Tests
+      manufacturer: Test Manufacturer
+    state: present
+
 - name: "REAR_PORT_TEMPLATE 1: Necessary info creation"
   netbox.netbox.netbox_rear_port_template:
     netbox_url: http://localhost:32768
@@ -134,3 +143,109 @@
       - test_six['rear_port_template']['device_type'] == 2
       - test_six['rear_port_template']['type'] == "bnc"
       - test_six['msg'] == "rear_port_template Rear Port Template 2 created"
+
+- name: "REAR_PORT_TEMPLATE 7: Necessary info creation"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_seven
+
+- name: "REAR_PORT_TEMPLATE 7: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['rear_port_template']['name'] == "Module Type Rear Port Template"
+      - test_seven['rear_port_template']['module_type'] == 1
+      - test_seven['rear_port_template']['type'] == "bnc"
+      - test_seven['msg'] == "rear_port_template Module Type Rear Port Template created"
+
+- name: "REAR_PORT_TEMPLATE 8: Create duplicate"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_eight
+
+- name: "REAR_PORT_TEMPLATE 8: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_eight['changed']
+      - test_eight['rear_port_template']['name'] == "Module Type Rear Port Template"
+      - test_eight['rear_port_template']['module_type'] == 1
+      - test_eight['rear_port_template']['type'] == "bnc"
+      - test_eight['msg'] == "rear_port_template Module Type Rear Port Template already exists"
+
+- name: "REAR_PORT_TEMPLATE 9: Update Rear Port Template with other fields"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      positions: 5
+    state: present
+  register: test_nine
+
+- name: "REAR_PORT_TEMPLATE 9: ASSERT - Update Rear Port Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['after']['positions'] == 5
+      - test_nine['rear_port_template']['name'] == "Module Type Rear Port Template"
+      - test_nine['rear_port_template']['module_type'] == 1
+      - test_nine['rear_port_template']['type'] == "bnc"
+      - test_nine['rear_port_template']['positions'] == 5
+      - test_nine['msg'] == "rear_port_template Module Type Rear Port Template updated"
+
+- name: "REAR_PORT_TEMPLATE 10: Create Rear Port Template for Delete Test"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_ten
+
+- name: "REAR_PORT_TEMPLATE 10: ASSERT - Create Rear Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['rear_port_template']['name'] == "Module Type Rear Port Template 2"
+      - test_ten['rear_port_template']['module_type'] == 1
+      - test_ten['rear_port_template']['type'] == "bnc"
+      - test_ten['msg'] == "rear_port_template Module Type Rear Port Template 2 created"
+
+- name: "REAR_PORT_TEMPLATE 11: Delete Rear Port Template"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: absent
+  register: test_eleven
+
+- name: "REAR_PORT_TEMPLATE 11: ASSERT - Delete Rear Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "present"
+      - test_eleven['diff']['after']['state'] == "absent"
+      - test_eleven['msg'] == "rear_port_template Module Type Rear Port Template 2 deleted"


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1216 

## New Behavior

Modules can now be created as templates in netbox, aswell as having interfaces attached to the templates. Power ports are supported in the collection, but not front and rear ports.
This PR fixes that and adds support for both front and rear-ports

...

## Contrast to Current Behavior

The rear_port_template and front_port_template now takes either device_type or module_type as a required parameter

...

## Discussion: Benefits and Drawbacks

- this implementes features already present in the netbox ui
- olders versions of netbox not having module_templates is not supported by the module_type, but can still use the device_type

...

## Changes to the Documentation

docs are updated the pr files

...

## Proposed Release Note Entry

add support for module_type in netbox_front_port_template and netbox_rear_port_template

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
