### PR TITLE
Fix faulty IP address DNS check

### DIFF
--- a/changelogs/fragments/fix-ip-address-dns-check.yml
+++ b/changelogs/fragments/fix-ip-address-dns-check.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nb_inventory - Fix AttributeError when `ip_address` is None during DNS name lookup

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1037,7 +1037,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 )
 
         # Don"t assign a host_var for empty dns_name
-        if ip_address.get("dns_name") == "":
+        if ip_address is None or ip_address.get("dns_name") == "":
             return None
 
         return ip_address.get("dns_name")


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

#1444 

## New Behavior

Check for no IP address being available

## Contrast to Current Behavior

Current behavior breaks inventory sync if the primary IP is not on one of the interfaces when checking for DNS. If you're not using the DNS feature, then this is the same as having None.

## Discussion: Benefits and Drawbacks

This breaks our inventory sync periodically when there is dirty data left behind in our Netbox. Since we're not using the DNS feature and we don't need to check.

However, this will hide the issue where the primary IP is not on any interface.

## Changes to the Documentation

None

## Proposed Release Note Entry

Fix sync error when primary IP address not on interfaces

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `devel` branch.
