### PR TITLE
Add tenant field support to netbox_vlan_group

### DIFF
--- a/changelogs/fragments/add-tenant-to-vlan-group.yml
+++ b/changelogs/fragments/add-tenant-to-vlan-group.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "netbox_vlan_group - Add tenant field support"
+  - "netbox_vlan_group - Add tenant field support (https://github.com/netbox-community/ansible_modules/issues/1446)"

--- a/changelogs/fragments/add-tenant-to-vlan-group.yml
+++ b/changelogs/fragments/add-tenant-to-vlan-group.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "netbox_vlan_group - Add tenant field support"

--- a/plugins/modules/netbox_vlan_group.py
+++ b/plugins/modules/netbox_vlan_group.py
@@ -91,6 +91,12 @@ options:
         type: list
         elements: raw
         version_added: "3.20.0"
+      tenant:
+        description:
+          - The tenant that the VLAN group will be assigned to
+        required: false
+        type: raw
+        version_added: "3.23.0"
       tags:
         description:
           - The tags to add/update
@@ -143,6 +149,17 @@ EXAMPLES = r"""
             [1300, 1329],
             [1, 2]
           ]
+        state: present
+
+    - name: Create vlan group with tenant assignment
+      netbox_vlan_group:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          name: Test vlan group
+          scope_type: "dcim.site"
+          scope: Test Site
+          tenant: Test Tenant
         state: present
 
     - name: Delete vlan group within netbox
@@ -212,6 +229,7 @@ def main():
                     min_vid=dict(required=False, type="int"),
                     max_vid=dict(required=False, type="int"),
                     vid_ranges=dict(required=False, type="list", elements="raw"),
+                    tenant=dict(required=False, type="raw"),
                     description=dict(required=False, type="str"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),

--- a/tests/integration/netbox-deploy.py
+++ b/tests/integration/netbox-deploy.py
@@ -60,7 +60,10 @@ create_tags = make_netbox_calls(
 # ORDER OF OPERATIONS FOR THE MOST PART
 
 # Create TENANTS
-tenants = [{"name": "Test Tenant", "slug": "test-tenant"}]
+tenants = [
+    {"name": "Test Tenant", "slug": "test-tenant"},
+    {"name": "Test Tenant 2", "slug": "test-tenant-2"},
+]
 created_tenants = make_netbox_calls(nb.tenancy.tenants, tenants)
 # Test Tenant to be used later on
 test_tenant = nb.tenancy.tenants.get(slug="test-tenant")

--- a/tests/integration/targets/v4.3/tasks/netbox_vlan_group.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_vlan_group.yml
@@ -335,8 +335,7 @@
       - results['vlan_group']['slug'] == "vlan-group-tenant-test"
       - results['vlan_group']['scope_type'] == "dcim.site"
       - results['vlan_group']['scope_id'] == 1
-      - results['vlan_group']['tenant'] is defined
-      - results['vlan_group']['tenant']['name'] == "Test Tenant"
+      - results['vlan_group']['tenant'] == 1
       - results['msg'] == "vlan_group VLAN Group Tenant Test created"
 
 - name: "VLAN_GROUP 14: Create duplicate VLAN group with tenant (idempotency)"
@@ -356,7 +355,7 @@
     that:
       - results is not changed
       - results['vlan_group']['name'] == "VLAN Group Tenant Test"
-      - results['vlan_group']['tenant']['name'] == "Test Tenant"
+      - results['vlan_group']['tenant'] == 1
       - results['msg'] == "vlan_group VLAN Group Tenant Test already exists"
 
 - name: "VLAN_GROUP 15: Update VLAN group tenant"
@@ -378,7 +377,7 @@
       - results['diff']['before']['tenant'] == 1
       - results['diff']['after']['tenant'] == 2
       - results['vlan_group']['name'] == "VLAN Group Tenant Test"
-      - results['vlan_group']['tenant']['name'] == "Test Tenant 2"
+      - results['vlan_group']['tenant'] == 2
       - results['msg'] == "vlan_group VLAN Group Tenant Test updated"
 
 - name: "VLAN_GROUP 16: Delete VLAN group with tenant"

--- a/tests/integration/targets/v4.3/tasks/netbox_vlan_group.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_vlan_group.yml
@@ -312,3 +312,90 @@
       - results['vlan_group']['scope_id'] == 1
       - results['vlan_group']['description'] == "Ansible updated description"
       - results['msg'] == "vlan_group VLAN Group Location already exists"
+
+- name: "VLAN_GROUP 13: Create VLAN group with tenant"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+      tenant: Test Tenant
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 13: ASSERT - Create VLAN group with tenant"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "absent"
+      - results['diff']['after']['state'] == "present"
+      - results['vlan_group']['name'] == "VLAN Group Tenant Test"
+      - results['vlan_group']['slug'] == "vlan-group-tenant-test"
+      - results['vlan_group']['scope_type'] == "dcim.site"
+      - results['vlan_group']['scope_id'] == 1
+      - results['vlan_group']['tenant'] is defined
+      - results['vlan_group']['tenant']['name'] == "Test Tenant"
+      - results['msg'] == "vlan_group VLAN Group Tenant Test created"
+
+- name: "VLAN_GROUP 14: Create duplicate VLAN group with tenant (idempotency)"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+      tenant: Test Tenant
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 14: ASSERT - Create duplicate VLAN group with tenant (idempotency)"
+  ansible.builtin.assert:
+    that:
+      - results is not changed
+      - results['vlan_group']['name'] == "VLAN Group Tenant Test"
+      - results['vlan_group']['tenant']['name'] == "Test Tenant"
+      - results['msg'] == "vlan_group VLAN Group Tenant Test already exists"
+
+- name: "VLAN_GROUP 15: Update VLAN group tenant"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+      tenant: Test Tenant 2
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 15: ASSERT - Update VLAN group tenant"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['tenant'] == 1
+      - results['diff']['after']['tenant'] == 2
+      - results['vlan_group']['name'] == "VLAN Group Tenant Test"
+      - results['vlan_group']['tenant']['name'] == "Test Tenant 2"
+      - results['msg'] == "vlan_group VLAN Group Tenant Test updated"
+
+- name: "VLAN_GROUP 16: Delete VLAN group with tenant"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+    state: absent
+  register: results
+
+- name: "VLAN_GROUP 16: ASSERT - Delete VLAN group with tenant"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "present"
+      - results['diff']['after']['state'] == "absent"
+      - results['msg'] == "vlan_group VLAN Group Tenant Test deleted"


### PR DESCRIPTION
## Related Issue

#1446

## New Behavior

The `netbox_vlan_group` module now supports the `tenant` field, allowing users to assign VLAN groups to specific tenants in NetBox.

Users can now specify a tenant when creating or updating VLAN groups:
```yaml
- name: Create vlan group with tenant assignment
  netbox_vlan_group:
    netbox_url: http://netbox.local
    netbox_token: thisIsMyToken
    data:
      name: Test vlan group
      scope_type: "dcim.site"
      scope: Test Site
      tenant: Test Tenant
    state: present
```

## Contrast to Current Behavior

Previously, the `netbox_vlan_group` module did not support the `tenant` field, making it impossible to assign VLAN groups to tenants through Ansible automation. Users had to manually set tenants in the NetBox UI or use the API directly.

## Discussion: Benefits and Drawbacks

**Benefits:**
- Enables full automation of VLAN group tenant assignments via Ansible
- Brings the module to feature parity with NetBox's VLAN group API capabilities
- Maintains consistency with other modules in the collection that support tenant fields
- Allows for better multi-tenant network automation workflows

**Drawbacks:**
- None identified

**Backwards Compatibility:**
- Fully backwards compatible - the tenant field is optional and existing playbooks will continue to work without modification

## Changes to the Documentation

- Added `tenant` field documentation to the module's argument spec
- Added example demonstrating tenant assignment usage
- Added changelog fragment for release notes (will appear in next release)

## Proposed Release Note Entry

`netbox_vlan_group` - Add tenant field support (https://github.com/netbox-community/ansible_modules/issues/1446)

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.