### PR TITLE
nb_inventory - fix cache key uniqueness across sources

### DIFF
--- a/changelogs/fragments/fix-inventory-cache.yml
+++ b/changelogs/fragments/fix-inventory-cache.yml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - Set the cache once per inventory plugin source instead of once per HTTP request.

--- a/changelogs/fragments/fix-inventory-cache.yml
+++ b/changelogs/fragments/fix-inventory-cache.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Set the cache once per inventory plugin source instead of once per HTTP request.

--- a/changelogs/fragments/fix-inventory-cache.yml
+++ b/changelogs/fragments/fix-inventory-cache.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Set the cache once per inventory plugin source instead of once per HTTP request.
+  - Fix inventory cache key uniqueness across sources.

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -2169,9 +2169,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         cache_key = self.get_cache_key(path)
 
         global UPDATE_CACHE
-        UPDATE_CACHE = not self.use_cache and self.get_option('cache')
+        UPDATE_CACHE = not self.use_cache and self.get_option("cache")
 
-        if self.use_cache and self.get_option('cache'):
+        if self.use_cache and self.get_option("cache"):
             try:
                 HTTP_RESPONSE.update(self._cache[cache_key])
             except KeyError:

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -422,13 +422,18 @@ except ImportError as imp_exc:
 else:
     PYTZ_IMPORT_ERROR = None
 
+# Temporary cache
+HTTP_RESPONSE = {}
+
+# A global indicating whether the backing cache should be updated
+UPDATE_CACHE = False
+
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = "netbox.netbox.nb_inventory"
 
     def _fetch_information(self, url):
         results = None
-        cache_key = self.get_cache_key(url)
 
         # get the user's cache option to see if we should save the cache if it is changing
         user_cache_setting = self.get_option("cache")
@@ -439,12 +444,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # attempt to read the cache if inventory isn't being refreshed and the user has caching enabled
         if attempt_to_read_cache:
             try:
-                results = self._cache[cache_key]
+                results = HTTP_RESPONSE[url]
                 need_to_fetch = False
             except KeyError:
-                # occurs if the cache_key is not in the cache or if the cache_key expired
+                # occurs if the URL is not in the local cache
                 # we need to fetch the URL now
                 need_to_fetch = True
+                global UPDATE_CACHE
+                UPDATE_CACHE = self.get_option("cache")
         else:
             # not reading from cache so do fetch
             need_to_fetch = True
@@ -491,9 +498,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             except ValueError:
                 raise AnsibleError("Incorrect JSON payload: %s" % raw_data)
 
-            # put result in cache if enabled
-            if user_cache_setting:
-                self._cache[cache_key] = results
+            # put result in local cache if enabled
+            if UPDATE_CACHE:
+                HTTP_RESPONSE[url] = results
 
         return results
 
@@ -2159,6 +2166,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self._read_config_data(path=path)
         self.use_cache = cache
 
+        cache_key = self.get_cache_key(path)
+
+        global UPDATE_CACHE
+        UPDATE_CACHE = not self.use_cache and self.get_option('cache')
+
+        if self.use_cache and self.get_option('cache'):
+            try:
+                HTTP_RESPONSE.update(self._cache[cache_key])
+            except KeyError:
+                # The cache key does not exist or it expired
+                UPDATE_CACHE = True
+
         # Handle extra "/" from api_endpoint configuration and trim if necessary, see PR#49943
         self.api_endpoint = self.get_option("api_endpoint").strip("/")
         self.timeout = self.get_option("timeout")
@@ -2215,6 +2234,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         )
 
         self.main()
+
+        if UPDATE_CACHE:
+            self._cache[cache_key] = HTTP_RESPONSE
 
     def parse_rename_variables(self, rename_variables):
         return [

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -422,18 +422,13 @@ except ImportError as imp_exc:
 else:
     PYTZ_IMPORT_ERROR = None
 
-# Temporary cache
-HTTP_RESPONSE = {}
-
-# A global indicating whether the backing cache should be updated
-UPDATE_CACHE = False
-
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = "netbox.netbox.nb_inventory"
 
     def _fetch_information(self, url):
         results = None
+        cache_key = self.cache_key_base + self.get_cache_key(url)
 
         # get the user's cache option to see if we should save the cache if it is changing
         user_cache_setting = self.get_option("cache")
@@ -444,14 +439,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # attempt to read the cache if inventory isn't being refreshed and the user has caching enabled
         if attempt_to_read_cache:
             try:
-                results = HTTP_RESPONSE[url]
+                results = self._cache[cache_key]
                 need_to_fetch = False
             except KeyError:
-                # occurs if the URL is not in the local cache
+                # occurs if the cache_key is not in the cache or if the cache_key expired
                 # we need to fetch the URL now
                 need_to_fetch = True
-                global UPDATE_CACHE
-                UPDATE_CACHE = self.get_option("cache")
         else:
             # not reading from cache so do fetch
             need_to_fetch = True
@@ -498,9 +491,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             except ValueError:
                 raise AnsibleError("Incorrect JSON payload: %s" % raw_data)
 
-            # put result in local cache if enabled
-            if UPDATE_CACHE:
-                HTTP_RESPONSE[url] = results
+            # put result in cache if enabled
+            if user_cache_setting:
+                self._cache[cache_key] = results
 
         return results
 
@@ -2164,19 +2157,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)
         self._read_config_data(path=path)
+        self.cache_key_base = self.get_cache_key(path)
         self.use_cache = cache
-
-        cache_key = self.get_cache_key(path)
-
-        global UPDATE_CACHE
-        UPDATE_CACHE = not self.use_cache and self.get_option("cache")
-
-        if self.use_cache and self.get_option("cache"):
-            try:
-                HTTP_RESPONSE.update(self._cache[cache_key])
-            except KeyError:
-                # The cache key does not exist or it expired
-                UPDATE_CACHE = True
 
         # Handle extra "/" from api_endpoint configuration and trim if necessary, see PR#49943
         self.api_endpoint = self.get_option("api_endpoint").strip("/")
@@ -2234,9 +2216,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         )
 
         self.main()
-
-        if UPDATE_CACHE:
-            self._cache[cache_key] = HTTP_RESPONSE
 
     def parse_rename_variables(self, rename_variables):
         return [


### PR DESCRIPTION
## Related Issue

~Possibly fixes https://github.com/netbox-community/ansible_modules/issues/1411#issuecomment-3834941933 / https://github.com/ansible/ansible/issues/86292.~

~I suspect a large inventory is needed to reproduce the performance issue. I was not able to reproduce by using a small inventory provided by the netbox free trial. The issue reported against ansible/ansible outputs \~30x as many lines as my attempt to reproduce.~

No related issues.

## New Behavior

Pass `get_cache_key` the inventory source, and read/set the backing cache once per source. This aligns with the developer guide and intended use of the method: https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_inventory.html#inventory-cache.

This ~reduces the number of times the raw data is converted to/from the internal cache format, and~ fixes cache key uniqueness across sources.

## Contrast to Current Behavior

~Every HTTP request is converted to/from the internal cache format.~

Multiple `netbox.netbox.nb_inventory` sources can read from/write to the same cache keys, which is precisely what the `get_cache_key` method is intended to prevent.

## Discussion: Benefits and Drawbacks

The change is backwards compatible.

## Changes to the Documentation

N/A

## Proposed Release Note Entry

N/A

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.