### PR TITLE
Feature/tenant data

### DIFF
--- a/changelogs/fragments/add-tenant-data-option.yml
+++ b/changelogs/fragments/add-tenant-data-option.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
   - nb_inventory - Add ``tenant_data`` option to include full tenant data structures in host vars, mirroring ``site_data`` behavior.
-  

--- a/changelogs/fragments/add-tenant-data-option.yml
+++ b/changelogs/fragments/add-tenant-data-option.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - nb_inventory - Add ``tenant_data`` option to include full tenant data structures in host vars, mirroring ``site_data`` behavior.
+  

--- a/changelogs/fragments/add-tenant-data-option.yml
+++ b/changelogs/fragments/add-tenant-data-option.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
   - nb_inventory - Add ``tenant_data`` option to include full tenant data structures in host vars, mirroring ``site_data`` behavior.

--- a/changelogs/fragments/add-tenant-data-option.yml
+++ b/changelogs/fragments/add-tenant-data-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nb_inventory - Add ``tenant_data`` option to include full tenant data structures in host vars, mirroring ``site_data`` behavior.

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1242,7 +1242,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def refresh_tenants_lookup(self):
         url = self.api_endpoint + "/api/tenancy/tenants/?limit=0"
         tenants = self.get_resource_list(api_url=url)
-        self.tenants_lookup_slug = dict((tenant["id"], tenant["slug"]) for tenant in tenants)
+        self.tenants_lookup_slug = dict(
+            (tenant["id"], tenant["slug"]) for tenant in tenants
+        )
         if self.tenant_data:
             self.tenants_lookup = dict((tenant["id"], tenant) for tenant in tenants)
         else:
@@ -1847,7 +1849,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for grouping in self.group_by:
             # Don't handle regions here since no hosts are ever added to region groups
             # Sites and locations are also specially handled in the main()
-            if grouping in ["region", site_group_by, "location", site_group_group_by, tenant_group_by]:
+            if grouping in [
+                "region",
+                site_group_by,
+                "location",
+                site_group_group_by,
+                tenant_group_by,
+            ]:
                 continue
 
             if grouping not in self.group_extractors:
@@ -1893,7 +1901,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 group=site_group_name
             )
             self.site_group_names[site_id] = site_transformed_group_name
-        
+
     def _add_tenant_groups(self):
         self.tenant_group_names = dict()
 
@@ -2159,7 +2167,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     group=self.site_group_names[host["site"]["id"]],
                     host=hostname,
                 )
-            
+
             if getattr(self, "tenant_group_names", None) and host.get("tenant"):
                 self.inventory.add_host(
                     group=self.tenant_group_names[host["tenant"]["id"]],

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -118,6 +118,12 @@ DOCUMENTATION = """
             default: false
             type: boolean
             version_added: "3.5.0"
+        tenant_data:
+            description:
+                - If True, tenants' full data structures returned from Netbox API are included in host vars.
+            default: false
+            type: boolean
+            version_added: "3.23.0"
         prefixes:
             description:
                 - If True, it adds the device or virtual machine prefixes to hostvars nested under "site".
@@ -1236,7 +1242,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def refresh_tenants_lookup(self):
         url = self.api_endpoint + "/api/tenancy/tenants/?limit=0"
         tenants = self.get_resource_list(api_url=url)
-        self.tenants_lookup = dict((tenant["id"], tenant["slug"]) for tenant in tenants)
+        self.tenants_lookup_slug = dict((tenant["id"], tenant["slug"]) for tenant in tenants)
+        if self.tenant_data:
+            self.tenants_lookup = dict((tenant["id"], tenant) for tenant in tenants)
+        else:
+            self.tenants_lookup = self.tenants_lookup_slug
 
     def refresh_racks_lookup(self):
         url = self.api_endpoint + "/api/dcim/racks/?limit=0"
@@ -1831,12 +1841,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def add_host_to_groups(self, host, hostname):
         site_group_by = self._pluralize_group_by("site")
+        tenant_group_by = self._pluralize_group_by("tenant")
         site_group_group_by = self._pluralize_group_by("site_group")
 
         for grouping in self.group_by:
             # Don't handle regions here since no hosts are ever added to region groups
             # Sites and locations are also specially handled in the main()
-            if grouping in ["region", site_group_by, "location", site_group_group_by]:
+            if grouping in ["region", site_group_by, "location", site_group_group_by, tenant_group_by]:
                 continue
 
             if grouping not in self.group_extractors:
@@ -1882,6 +1893,21 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 group=site_group_name
             )
             self.site_group_names[site_id] = site_transformed_group_name
+        
+    def _add_tenant_groups(self):
+        self.tenant_group_names = dict()
+
+        for (
+            tenant_id,
+            tenant_name,
+        ) in self.tenants_lookup_slug.items():
+            tenant_group_name = self.generate_group_name(
+                self._pluralize_group_by("tenant"), tenant_name
+            )
+            tenant_transformed_group_name = self.inventory.add_group(
+                group=tenant_group_name
+            )
+            self.tenant_group_names[tenant_id] = tenant_transformed_group_name
 
     def _add_region_groups(self):
         # Mapping of region id to group name
@@ -2073,6 +2099,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         ):
             self._add_site_groups()
 
+        tenant_group_by = self._pluralize_group_by("tenant")
+        if tenant_group_by in self.group_by:
+            self._add_tenant_groups()
+
         # Create groups for locations. Will be a part of site groups.
         if "location" in self.group_by and self.api_version >= version.parse("2.11"):
             self._add_location_groups()
@@ -2129,6 +2159,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     group=self.site_group_names[host["site"]["id"]],
                     host=hostname,
                 )
+            
+            if getattr(self, "tenant_group_names", None) and host.get("tenant"):
+                self.inventory.add_host(
+                    group=self.tenant_group_names[host["tenant"]["id"]],
+                    host=hostname,
+                )
 
     def _set_authorization(self):
         # NetBox access
@@ -2174,6 +2210,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.interfaces = self.get_option("interfaces")
         self.services = self.get_option("services")
         self.site_data = self.get_option("site_data")
+        self.tenant_data = self.get_option("tenant_data")
         self.prefixes = self.get_option("prefixes")
         self.fetch_all = self.get_option("fetch_all")
         self.headers = {


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->
When `tenant_data: true` is set in the inventory configuration, the full tenant data structure from the NetBox API is included in host vars (id, name, slug, description, group, custom_fields, tags, etc.).

When `tenant_data: false` (default), only the tenant slug string is included — preserving current behavior.

## Contrast to Current Behavior
Currently, tenant host vars always contain only the slug string (e.g. `"acme-corp"`), regardless of configuration. There is no way to get the full tenant object in host vars.

The `site_data` option already provides this toggle for sites. This PR adds the equivalent for tenants.
<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->


## Discussion: Benefits and Drawbacks
- **Benefit**: Users managing multi-tenant environments can access full tenant details (group, description, custom fields) directly in playbooks without additional API lookups.
- **Benefit**: Follows the established pattern of `site_data`, so the implementation is consistent and predictable.
- **Backwards-compatible**: Yes. Default is `false`, so existing behavior is unchanged.
- **Drawback**: None significant. Slightly larger host vars when enabled.
<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
## Changes to the Documentation
Plugin DOCUMENTATION string updated with the new `tenant_data` option definition.
<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

## Proposed Release Note Entry
nb_inventory - Add `tenant_data` option to include full tenant data structures in host vars, mirroring `site_data` behavior.
<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
