### PR TITLE
Update netbox_utils.py

### DIFF
--- a/changelogs/fragments/fix_default_platform_dict.yml
+++ b/changelogs/fragments/fix_default_platform_dict.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - netbox_device_type - Resolve AttributeError when passing a dictionary to default_platform.

--- a/changelogs/fragments/fix_default_platform_dict.yml
+++ b/changelogs/fragments/fix_default_platform_dict.yml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - netbox_device_type - Resolve AttributeError when passing a dictionary to default_platform.

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -491,6 +491,7 @@ ALLOWED_QUERY_PARAMS = {
     "choice_set": set(["name"]),
     "custom_link": set(["name"]),
     "data_source": set(["name"]),
+    "default_platform": set(["slug"]),
     "dcim.consoleport": set(["name", "device"]),
     "dcim.consoleserverport": set(["name", "device"]),
     "dcim.frontport": set(["name", "device", "rear_port"]),


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

<!--
Add the related issue in the form of #issue-number (Example #100)
Haven't opened an issue..
-->

### Fixes: AttributeError for `default_platform` dictionary lookup

#### Description of the issue
When creating or updating a `netbox_device_type` and passing a dictionary to `default_platform` (e.g., to explicitly search by slug: `{'slug': 'cisco-ios'}`), the module crashes with the following error:

```python
AttributeError: 'NoneType' object has no attribute 'intersection'

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Added "default_platform": set(["slug"]) to ALLOWED_QUERY_PARAMS in plugins/module_utils/netbox_utils.py

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Contrast to Current Behavior
Currently, passing a dictionary to default_platform causes a hard Python crash because the field is entirely missing from ALLOWED_QUERY_PARAMS. Additionally, relying solely on simple strings for default_platform often leads to ambiguous match errors from the NetBox API (e.g., passing "cisco-ios" matches both cisco-ios and cisco-ios-xe). The new behavior prevents the crash and enables explicit, exact matching via dictionaries.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Benefits: Fixes a bug for a feature that was intended to work since v3.15.0 (type: raw). Allows users to avoid ambiguous API matches by explicitly defining the search parameter (like slug).

Drawbacks: None identified.

Backwards-compatible: Yes. Passing a simple string continues to work exactly as before.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

None required. default_platform is already documented as type: raw, which implies it should accept dictionaries.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Fix AttributeError in netbox_device_type when passing a dictionary to default_platform

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
