### PR TITLE
Add NetBox v4.5 CI support (INT-238)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,8 @@ jobs:
             NETBOX_DOCKER_VERSION: 3.3.0
           - VERSION: "v4.4"
             NETBOX_DOCKER_VERSION: 3.4.2
+          - VERSION: "v4.5"
+            NETBOX_DOCKER_VERSION: 4.0.2
 
     steps:
 
@@ -94,7 +96,7 @@ jobs:
           git clone https://github.com/netbox-community/netbox-docker.git
           cd netbox-docker
           git checkout ${{ matrix.NETBOX_DOCKER_VERSION }}
-          cp $GITHUB_WORKSPACE/tests/netbox-docker/${{ matrix.VERSION }}/docker-compose.override.yml docker-compose.override.yml
+          cp $GITHUB_WORKSPACE/tests/netbox-docker/${{ matrix.VERSION }}/* .
           docker compose up -d --quiet-pull netbox netbox-worker postgres redis redis-cache
           docker container ls
           cd ..

--- a/changelogs/fragments/1543-add-netbox-v45-ci.yml
+++ b/changelogs/fragments/1543-add-netbox-v45-ci.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Add NetBox v4.5 support to CI matrix (netbox-docker 4.0.2)
+  - Update netbox_front_port and netbox_front_port_template modules to handle v4.5 removal of rear_port/rear_port_position fields (replaced by PortMapping model)
+  - Update netbox_user module to strip is_staff field on v4.5+ (removed from User model)
+  - Update netbox_token module to support v4.5 v2 tokens with description-based lookup

--- a/hacking/integration-test.sh
+++ b/hacking/integration-test.sh
@@ -7,7 +7,7 @@
 # Usage: ./hacking/integration-test.sh [TARGET] [OPTIONS]
 #
 # Targets:
-#   v4.3, v4.4             - Main module tests (default: v4.4)
+#   v4.3, v4.4, v4.5       - Main module tests (default: v4.5)
 #   inventory-v4.3         - Inventory plugin tests
 #   regression-v4.3        - Regression tests
 #   all-v4.3               - Run all tests for a version (modules + inventory + regression)
@@ -22,7 +22,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 COLLECTION_TMP_DIR="${COLLECTION_TMP_DIR:-/tmp/test-collections}"
-DEFAULT_TARGET="v4.4"
+DEFAULT_TARGET="v4.5"
 
 show_help() {
     cat << 'EOF'
@@ -32,19 +32,20 @@ Usage: ./hacking/integration-test.sh [TARGET] [OPTIONS]
 
 TARGETS:
   Module Tests:
-    v4.0, v4.1, v4.2, v4.3, v4.4  - Main module tests (91 modules)
+    v4.0, v4.1, v4.2, v4.3, v4.4, v4.5  - Main module tests (91 modules)
 
   Inventory Tests:
-    inventory-v4.0, inventory-v4.1, inventory-v4.2, inventory-v4.3, inventory-v4.4
+    inventory-v4.0, inventory-v4.1, inventory-v4.2, inventory-v4.3, inventory-v4.4, inventory-v4.5
     Tests the NetBox inventory plugin against expected JSON output
 
   Regression Tests:
-    regression-v4.0, regression-v4.1, regression-v4.2, regression-v4.3, regression-v4.4
+    regression-v4.0, regression-v4.1, regression-v4.2, regression-v4.3, regression-v4.4, regression-v4.5
     Tests for specific bug fixes (referenced by GitHub issues)
 
   Combined:
     all-v4.3               - Run modules + inventory + regression for v4.3
     all-v4.4               - Run modules + inventory + regression for v4.4
+    all-v4.5               - Run modules + inventory + regression for v4.5
 
 OPTIONS:
   --list                 - List available test targets

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -120,7 +120,10 @@ class NetboxDcimModule(NetboxModule):
                     data["form_factor"] = self._to_slug(data["type"])
                     del data["type"]
 
-        # NetBox v4.5 replaced rear_port/rear_port_position with PortMapping model
+        # NetBox v4.5 replaced rear_port/rear_port_position with PortMapping model.
+        # Note: CONVERT_KEYS already maps rear_port_template -> rear_port and
+        # rear_port_template_position -> rear_port_position before run() executes,
+        # so both front_ports and front_port_templates use "rear_port" here.
         if self.endpoint in ("front_ports", "front_port_templates"):
             if self._version_check_greater(
                 self.api_version, "4.5", greater_or_equal=True
@@ -129,8 +132,14 @@ class NetboxDcimModule(NetboxModule):
                 data.pop("rear_port_position", None)
             else:
                 if self.state == "present" and "rear_port" not in data:
+                    field = (
+                        "rear_port_template"
+                        if self.endpoint == "front_port_templates"
+                        else "rear_port"
+                    )
                     self.module.fail_json(
-                        msg="rear_port is required for front_ports when using NetBox < v4.5"
+                        msg="%s is required for %s when using NetBox < v4.5"
+                        % (field, self.endpoint)
                     )
 
         # Used for msg output

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -120,6 +120,19 @@ class NetboxDcimModule(NetboxModule):
                     data["form_factor"] = self._to_slug(data["type"])
                     del data["type"]
 
+        # NetBox v4.5 replaced rear_port/rear_port_position with PortMapping model
+        if self.endpoint in ("front_ports", "front_port_templates"):
+            if self._version_check_greater(
+                self.api_version, "4.5", greater_or_equal=True
+            ):
+                data.pop("rear_port", None)
+                data.pop("rear_port_position", None)
+            else:
+                if self.state == "present" and "rear_port" not in data:
+                    self.module.fail_json(
+                        msg="rear_port is required for front_ports when using NetBox < v4.5"
+                    )
+
         # Used for msg output
         if data.get("name"):
             name = data["name"]

--- a/plugins/module_utils/netbox_users.py
+++ b/plugins/module_utils/netbox_users.py
@@ -73,10 +73,6 @@ class NetboxUsersModule(NetboxModule):
                     self.module.fail_json(
                         msg="'key' is required for tokens on NetBox < v4.5"
                     )
-                if self.state == "absent" and not data.get("key"):
-                    self.module.fail_json(
-                        msg="'key' is required for state=absent on NetBox < v4.5"
-                    )
 
         # Used for msg output
         if data.get("username"):
@@ -97,6 +93,9 @@ class NetboxUsersModule(NetboxModule):
                 query_params["id"] = data["id"]
             elif data.get("description"):
                 query_params["description"] = data["description"]
+                # Scope by user so tokens with same description across users don't collide
+                if data.get("user"):
+                    query_params["user_id"] = data["user"]
             self.nb_object = self._nb_endpoint_get(nb_endpoint, query_params, name)
         else:
             object_query_params = self._build_query_params(

--- a/plugins/module_utils/netbox_users.py
+++ b/plugins/module_utils/netbox_users.py
@@ -90,10 +90,21 @@ class NetboxUsersModule(NetboxModule):
         else:
             name = "token"
 
-        object_query_params = self._build_query_params(
-            endpoint_name, data, user_query_params
-        )
-        self.nb_object = self._nb_endpoint_get(nb_endpoint, object_query_params, name)
+        # v4.5+ tokens: look up by description (not key) since v2 keys are auto-generated
+        if self.endpoint == NB_TOKENS and is_v45:
+            query_params = {}
+            if data.get("id"):
+                query_params["id"] = data["id"]
+            elif data.get("description"):
+                query_params["description"] = data["description"]
+            self.nb_object = self._nb_endpoint_get(nb_endpoint, query_params, name)
+        else:
+            object_query_params = self._build_query_params(
+                endpoint_name, data, user_query_params
+            )
+            self.nb_object = self._nb_endpoint_get(
+                nb_endpoint, object_query_params, name
+            )
 
         if self.state == "present":
             self._ensure_object_exists(nb_endpoint, endpoint_name, name, data)

--- a/plugins/module_utils/netbox_users.py
+++ b/plugins/module_utils/netbox_users.py
@@ -45,6 +45,27 @@ class NetboxUsersModule(NetboxModule):
 
         data = self.data
 
+        # NetBox v4.5 removed is_staff from User model
+        if self.endpoint == NB_USERS:
+            if self._version_check_greater(
+                self.api_version, "4.5", greater_or_equal=True
+            ):
+                data.pop("is_staff", None)
+
+        # NetBox v4.5 v2 tokens: key is auto-generated, not user-provided
+        is_v45 = False
+        if self.endpoint == NB_TOKENS:
+            is_v45 = self._version_check_greater(
+                self.api_version, "4.5", greater_or_equal=True
+            )
+            if is_v45:
+                data.pop("key", None)
+            else:
+                if not data.get("key"):
+                    self.module.fail_json(
+                        msg="'key' is required for tokens on NetBox < v4.5"
+                    )
+
         # Used for msg output
         if data.get("username"):
             name = data["username"]
@@ -52,11 +73,26 @@ class NetboxUsersModule(NetboxModule):
             name = data["name"]
         elif data.get("key"):
             name = data["key"]
+        elif data.get("description"):
+            name = data["description"]
+        else:
+            name = "token"
 
-        object_query_params = self._build_query_params(
-            endpoint_name, data, user_query_params
-        )
-        self.nb_object = self._nb_endpoint_get(nb_endpoint, object_query_params, name)
+        # v4.5+ tokens without description/id cannot be looked up; always create
+        if (
+            self.endpoint == NB_TOKENS
+            and is_v45
+            and not data.get("id")
+            and not data.get("description")
+        ):
+            self.nb_object = None
+        else:
+            object_query_params = self._build_query_params(
+                endpoint_name, data, user_query_params
+            )
+            self.nb_object = self._nb_endpoint_get(
+                nb_endpoint, object_query_params, name
+            )
 
         if self.state == "present":
             self._ensure_object_exists(nb_endpoint, endpoint_name, name, data)
@@ -79,8 +115,8 @@ class NetboxUsersModule(NetboxModule):
             return self.__update_netbox_object__(data)
 
     def _update_netbox_token(self, data):
-        if "key" in data:
-            del data["key"]
+        data.pop("key", None)
+        data.pop("id", None)
         return self.__update_netbox_object__(data)
 
     def __update_netbox_object__(self, data):

--- a/plugins/module_utils/netbox_users.py
+++ b/plugins/module_utils/netbox_users.py
@@ -60,10 +60,22 @@ class NetboxUsersModule(NetboxModule):
             )
             if is_v45:
                 data.pop("key", None)
+                if not data.get("id") and not data.get("description"):
+                    self.module.fail_json(
+                        msg=(
+                            "For tokens on NetBox >= v4.5, 'description' or 'id' "
+                            "is required for idempotent operations (v2 tokens "
+                            "do not support key-based lookup)."
+                        )
+                    )
             else:
                 if not data.get("key"):
                     self.module.fail_json(
                         msg="'key' is required for tokens on NetBox < v4.5"
+                    )
+                if self.state == "absent" and not data.get("key"):
+                    self.module.fail_json(
+                        msg="'key' is required for state=absent on NetBox < v4.5"
                     )
 
         # Used for msg output
@@ -78,21 +90,10 @@ class NetboxUsersModule(NetboxModule):
         else:
             name = "token"
 
-        # v4.5+ tokens without description/id cannot be looked up; always create
-        if (
-            self.endpoint == NB_TOKENS
-            and is_v45
-            and not data.get("id")
-            and not data.get("description")
-        ):
-            self.nb_object = None
-        else:
-            object_query_params = self._build_query_params(
-                endpoint_name, data, user_query_params
-            )
-            self.nb_object = self._nb_endpoint_get(
-                nb_endpoint, object_query_params, name
-            )
+        object_query_params = self._build_query_params(
+            endpoint_name, data, user_query_params
+        )
+        self.nb_object = self._nb_endpoint_get(nb_endpoint, object_query_params, name)
 
         if self.state == "present":
             self._ensure_object_exists(nb_endpoint, endpoint_name, name, data)

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -587,7 +587,7 @@ ALLOWED_QUERY_PARAMS = {
     "tenant_group": set(["slug"]),
     "termination_a": set(["name", "device", "virtual_machine"]),
     "termination_b": set(["name", "device", "virtual_machine"]),
-    "token": set(["key", "description", "id"]),
+    "token": set(["key"]),
     "tunnel": set(["name"]),
     "tunnel_group": set(["slug"]),
     "user": set(["username", "password"]),

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -587,7 +587,7 @@ ALLOWED_QUERY_PARAMS = {
     "tenant_group": set(["slug"]),
     "termination_a": set(["name", "device", "virtual_machine"]),
     "termination_b": set(["name", "device", "virtual_machine"]),
-    "token": set(["key"]),
+    "token": set(["key", "description", "id"]),
     "tunnel": set(["name"]),
     "tunnel_group": set(["slug"]),
     "user": set(["username", "password"]),

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -587,7 +587,7 @@ ALLOWED_QUERY_PARAMS = {
     "tenant_group": set(["slug"]),
     "termination_a": set(["name", "device", "virtual_machine"]),
     "termination_b": set(["name", "device", "virtual_machine"]),
-    "token": set(["key", "description", "id", "user"]),
+    "token": set(["key", "description", "id"]),
     "tunnel": set(["name"]),
     "tunnel_group": set(["slug"]),
     "user": set(["username", "password"]),

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -587,7 +587,7 @@ ALLOWED_QUERY_PARAMS = {
     "tenant_group": set(["slug"]),
     "termination_a": set(["name", "device", "virtual_machine"]),
     "termination_b": set(["name", "device", "virtual_machine"]),
-    "token": set(["key", "description", "id"]),
+    "token": set(["key", "description", "id", "user"]),
     "tunnel": set(["name"]),
     "tunnel_group": set(["slug"]),
     "user": set(["username", "password"]),

--- a/plugins/modules/netbox_front_port.py
+++ b/plugins/modules/netbox_front_port.py
@@ -64,7 +64,8 @@ options:
       rear_port:
         description:
           - The rear_port the front port is attached to
-        required: true
+          - Required for NetBox < v4.5. Ignored on v4.5+ (replaced by PortMapping model).
+        required: false
         type: raw
       rear_port_position:
         description:
@@ -188,7 +189,7 @@ def main():
                         ],
                         type="str",
                     ),
-                    rear_port=dict(required=True, type="raw"),
+                    rear_port=dict(required=False, type="raw"),
                     rear_port_position=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
                     label=dict(required=False, type="str"),
@@ -199,8 +200,8 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["device", "name", "type", "rear_port"]),
-        ("state", "absent", ["device", "name", "type", "rear_port"]),
+        ("state", "present", ["device", "name", "type"]),
+        ("state", "absent", ["device", "name", "type"]),
     ]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_front_port_template.py
+++ b/plugins/modules/netbox_front_port_template.py
@@ -69,7 +69,8 @@ options:
       rear_port_template:
         description:
           - The rear_port_template the front port template is attached to
-        required: true
+          - Required for NetBox < v4.5. Ignored on v4.5+ (replaced by PortMapping model).
+        required: false
         type: raw
       rear_port_template_position:
         description:
@@ -199,7 +200,7 @@ def main():
                         ],
                         type="str",
                     ),
-                    rear_port_template=dict(required=True, type="raw"),
+                    rear_port_template=dict(required=False, type="raw"),
                     rear_port_template_position=dict(required=False, type="int"),
                     description=dict(required=False, type="str"),
                     label=dict(required=False, type="str"),
@@ -209,8 +210,8 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "type", "rear_port_template"]),
-        ("state", "absent", ["name", "type", "rear_port_template"]),
+        ("state", "present", ["name", "type"]),
+        ("state", "absent", ["name", "type"]),
     ]
 
     required_one_of = [

--- a/plugins/modules/netbox_token.py
+++ b/plugins/modules/netbox_token.py
@@ -29,8 +29,9 @@ options:
     suboptions:
       key:
         description:
-          - Key of the token to be created. Must be exactly 40 characters
-        required: true
+          - Key of the token to be created. Must be exactly 40 characters.
+          - Required for NetBox < v4.5 (v1 tokens). Optional on v4.5+ (v2 tokens auto-generate keys).
+        required: false
         type: str
       user:
         description:
@@ -40,6 +41,7 @@ options:
       description:
         description:
           - The description of the token to be created
+          - On v4.5+, used together with user for idempotent token lookup (since key-based lookup is not available for v2 tokens).
         required: false
         type: str
       write_enabled:
@@ -134,7 +136,7 @@ def main():
                 type="dict",
                 required=True,
                 options=dict(
-                    key=dict(required=True, type="str", no_log=True),
+                    key=dict(required=False, type="str", no_log=True),
                     user=dict(required=False, type="str"),
                     description=dict(required=False, type="str"),
                     write_enabled=dict(required=False, type="bool"),
@@ -145,8 +147,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["key", "user"]),
-        ("state", "absent", ["key"]),
+        ("state", "present", ["user"]),
     ]
 
     module = NetboxAnsibleModule(

--- a/plugins/modules/netbox_user.py
+++ b/plugins/modules/netbox_user.py
@@ -55,6 +55,7 @@ options:
       is_staff:
         description:
           - Staff status of the user to be created
+          - Only supported on NetBox < v4.5. Ignored on v4.5+ (field removed).
         required: false
         type: bool
       is_active:

--- a/tests/integration/targets/inventory-v4.5/.gitignore
+++ b/tests/integration/targets/inventory-v4.5/.gitignore
@@ -1,0 +1,1 @@
+runme_config

--- a/tests/integration/targets/inventory-v4.5/aliases
+++ b/tests/integration/targets/inventory-v4.5/aliases
@@ -1,0 +1,1 @@
+# https://docs.ansible.com/ansible/devel/dev_guide/testing/sanity/integration-aliases.html

--- a/tests/integration/targets/inventory-v4.5/compare_inventory_json.py
+++ b/tests/integration/targets/inventory-v4.5/compare_inventory_json.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+# Inspired by community.aws collection script_inventory_ec2 test
+# https://github.com/ansible-collections/community.aws/blob/master/tests/integration/targets/script_inventory_ec2/inventory_diff.py
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import argparse
+import json
+import sys
+from operator import itemgetter
+
+from deepdiff import DeepDiff
+
+# NetBox includes "created" and "last_updated" times on objects. These end up in the interfaces objects that are included verbatim from the NetBox API.
+# "url" may be different if local tests use a different host/port
+# Remove these from files saved in git as test data
+KEYS_REMOVE = frozenset(["created", "last_updated", "url"])
+
+# Ignore these when performing diffs as they will be different for each test run
+# (Was previously keys specific to NetBox 2.6)
+KEYS_IGNORE = frozenset()
+
+# Rack Groups became hierarchical in NetBox 2.8. Don't bother comparing against test data in NetBox 2.7
+KEYS_IGNORE_27 = frozenset(
+    [
+        "rack_groups",  # host var
+        "rack_group_parent_rack_group",  # group, group_names_raw = False
+        "parent_rack_group",  # group, group_names_raw = True
+    ]
+)
+
+
+# Assume the object will not be recursive, as it originally came from JSON
+def remove_keys(obj, keys):
+    if isinstance(obj, dict):
+        keys_to_remove = keys.intersection(obj.keys())
+        for key in keys_to_remove:
+            del obj[key]
+
+        for key, value in obj.items():
+            remove_keys(value, keys)
+
+    elif isinstance(obj, list):
+        # Iterate over temporary copy, as we may remove items
+        for item in obj[:]:
+            if isinstance(item, str) and item in keys:
+                # List contains a string that we want to remove
+                # eg. a group name in list of groups
+                obj.remove(item)
+            remove_keys(item, keys)
+
+
+def sort_hostvar_arrays(obj):
+    meta = obj.get("_meta")
+    if not meta:
+        return
+
+    hostvars = meta.get("hostvars")
+    if not hostvars:
+        return
+
+    for _, host in hostvars.items():  # pylint: disable=disallowed-name
+        if interfaces := host.get("interfaces"):
+            host["interfaces"] = sorted(interfaces, key=itemgetter("id"))
+
+        if services := host.get("services"):
+            host["services"] = sorted(services, key=itemgetter("id"))
+
+
+def read_json(filename):
+    with open(filename, "r", encoding="utf-8") as file:
+        return json.loads(file.read())
+
+
+def write_json(filename, data):
+    with open(filename, "w", encoding="utf-8") as file:
+        json.dump(data, file, indent=4)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Diff Ansible inventory JSON output")
+    parser.add_argument(
+        "filename_a",
+        metavar="ORIGINAL.json",
+        type=str,
+        help="Original json to test against",
+    )
+    parser.add_argument(
+        "filename_b",
+        metavar="NEW.json",
+        type=str,
+        help="Newly generated json to compare against original",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "When comparing files, various keys are removed. "
+            "This option will not compare the files, and instead writes ORIGINAL.json to NEW.json after removing these keys. "
+            "This is used to clean the test json files before saving to the git repo. "
+            "For example, this removes dates. "
+        ),
+    )
+    parser.add_argument(
+        "--netbox-version",
+        metavar="VERSION",
+        type=str,
+        help=(
+            "Apply comparison specific to NetBox version. "
+            "For example, rack_groups arrays will only contain a single item in v2.7, so are ignored in the comparison."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    data_a = read_json(args.filename_a)
+
+    if args.write:
+        # When writing test data, only remove "remove_keys" that will change on every git commit.
+        # This makes diffs more easily readable to ensure changes to test data look correct.
+        remove_keys(data_a, KEYS_REMOVE)
+        sort_hostvar_arrays(data_a)
+        write_json(args.filename_b, data_a)
+
+    else:
+        data_b = read_json(args.filename_b)
+
+        # Ignore keys that we don't want to diff, in addition to the ones removed that change on every commit
+        keys = KEYS_REMOVE.union(KEYS_IGNORE)
+        remove_keys(data_a, keys)
+        remove_keys(data_b, keys)
+
+        sort_hostvar_arrays(data_a)
+        sort_hostvar_arrays(data_b)
+
+        # Perform the diff
+        result = DeepDiff(data_a, data_b, ignore_order=True)
+
+        if result:
+            # Dictionary is not empty - print differences
+            print(result.to_json(indent=4))
+            sys.exit(1)
+        else:
+            # Success, no differences
+            sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-bearer-token.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-bearer-token.json
@@ -1,0 +1,1347 @@
+{
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "rack": "Test Rack Site 2",
+                "rack_role": "test-rack-role",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "Ethernet1/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/1/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.11/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.11/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/3/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 3,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet1/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/2/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/4/",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/6/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "telnet (TCP/23)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
+                        "ipaddresses": [],
+                        "name": "telnet",
+                        "ports": [
+                            23
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/11/",
+                        "enabled": true,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/12/",
+                        "enabled": true,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": null,
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        }
+                    }
+                ],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "rack": "Test Rack",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB12345678",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "config_context": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/3/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/1/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/4/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [
+                            {
+                                "address": "2001::1:1/64",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/2/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet2",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/5/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB01234567",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    },
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "http (TCP/80)",
+                        "display_url": "http://localhost:32768/ipam/services/2/",
+                        "id": 2,
+                        "ipaddresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1
+                            },
+                            {
+                                "address": "2001::1:1/64",
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2
+                            }
+                        ],
+                        "name": "http",
+                        "ports": [
+                            80
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "disk": 170,
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/1/",
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/2/",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/3/",
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/4/",
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/5/",
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/6/",
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/7/",
+                        "enabled": true,
+                        "id": 7,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/8/",
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/9/",
+                        "enabled": true,
+                        "id": 9,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/10/",
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "site_test_site2",
+            "region_other_region",
+            "region_parent_region",
+            "site_group_other_site_group",
+            "site_group_parent_site_group",
+            "rack_Test_Rack_Site_2",
+            "rack_role_test_rack_role",
+            "role_core_switch",
+            "device_type_cisco_test",
+            "manufacturer_cisco",
+            "status_active",
+            "device_type_nexus_parent",
+            "service_telnet",
+            "rack_Test_Rack",
+            "service_ssh",
+            "service_http",
+            "cluster_Test_Cluster_2",
+            "cluster_type_test_cluster_type",
+            "is_virtual",
+            "cluster_Test_Cluster",
+            "cluster_group_test_cluster_group"
+        ]
+    },
+    "cluster_Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "cluster_group_test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_type_test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "device_type_cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "device_type_nexus_parent": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "location_parent_rack_group": {
+        "children": [
+            "location_test_rack_group"
+        ]
+    },
+    "location_test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "manufacturer_cisco": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "rack_Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "rack_Test_Rack_Site_2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "rack_role_test_rack_role": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "region_parent_region": {
+        "children": [
+            "region_test_region"
+        ]
+    },
+    "region_test_region": {
+        "children": [
+            "site_test_site"
+        ]
+    },
+    "role_core_switch": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "service_http": {
+        "hosts": [
+            "test100"
+        ]
+    },
+    "service_ssh": {
+        "hosts": [
+            "test100",
+            "Test VM With Spaces"
+        ]
+    },
+    "service_telnet": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "site_group_parent_site_group": {
+        "children": [
+            "site_group_test_site_group"
+        ]
+    },
+    "site_test_site": {
+        "children": [
+            "location_parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "site_test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "status_active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-bearer-token.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-bearer-token.json
@@ -1,12 +1,732 @@
 {
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Power Tests",
+                            "id": 11,
+                            "name": "Device Power Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/18/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 18,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests",
+                            "id": 12,
+                            "name": "Device Virtual Chassis Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/19/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 19,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests 2",
+                            "id": 13,
+                            "name": "Device Virtual Chassis Tests 2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/20/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 20,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device With Contact",
+                            "id": 10,
+                            "name": "Device With Contact"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/17/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 17,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/21/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 21,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter (TCP/9100, 9200)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "parent_object_id": 14,
+                        "parent_object_type": "dcim.device",
+                        "ports": [
+                            9100,
+                            9200
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [
+                            {
+                                "color": "9e9e9e",
+                                "display": "Schnozzberry",
+                                "display_url": "http://localhost:32768/extras/tags/4/",
+                                "id": 4,
+                                "name": "Schnozzberry",
+                                "slug": "schnozzberry"
+                            }
+                        ]
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "L1": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L1",
+                            "id": 15,
+                            "name": "L1"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/22/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 22,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L2",
+                            "id": 16,
+                            "name": "L2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/23/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 23,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "config_context": {},
                 "custom_fields": {},
                 "device_type": "cisco-test",
-                "interfaces": [],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "R1-Device (345678901)",
+                            "id": 3,
+                            "name": "R1-Device"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/13/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 13,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
                 "is_virtual": false,
                 "locations": [],
                 "manufacturer": "cisco",
@@ -34,13 +754,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -56,6 +777,62 @@
                         "id": 1,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/9/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 9,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/7/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 7,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.11/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -70,6 +847,7 @@
                                 "id": 3,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -86,15 +864,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "Test MAC address",
+                                "display": "AA:BB:CC:DD:EE:F0",
+                                "id": 8,
+                                "mac_address": "AA:BB:CC:DD:EE:F0"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet1/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -109,6 +898,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -117,13 +907,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -139,6 +930,62 @@
                         "id": 2,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/10/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 10,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/8/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 8,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.12/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -153,6 +1000,7 @@
                                 "id": 4,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -169,15 +1017,19 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet2/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -192,19 +1044,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -224,18 +1093,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -250,6 +1138,76 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "Updated child interface from parent device",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/15/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 15,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/2",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -269,33 +1227,7 @@
                 ],
                 "role": "core-switch",
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "Test Nexus One",
-                            "id": 4,
-                            "name": "Test Nexus One"
-                        },
-                        "display": "telnet (TCP/23)",
-                        "display_url": "http://localhost:32768/ipam/services/3/",
-                        "id": 3,
-                        "ipaddresses": [],
-                        "name": "telnet",
-                        "ports": [
-                            23
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    }
-                ],
+                "services": [],
                 "site": "test-site",
                 "site_groups": [],
                 "status": {
@@ -323,10 +1255,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -336,6 +1272,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -351,10 +1288,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -364,6 +1305,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -371,33 +1313,7 @@
                 "locations": [],
                 "regions": [],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": null,
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/4/",
-                        "id": 4,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "Test VM With Spaces",
-                            "id": 6,
-                            "name": "Test VM With Spaces"
-                        }
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -432,7 +1348,143 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+                            "id": 9,
+                            "name": "b6b98683-14a0-4991-b4ac-b88e5fe81573"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/8/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "config_context": {
                     "ntp_servers": [
@@ -445,13 +1497,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 2,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -467,6 +1520,31 @@
                         "id": 3,
                         "ip_addresses": [
                             {
+                                "address": "10.255.255.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.255.255.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/6/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 6,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.1/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -481,6 +1559,7 @@
                                 "id": 1,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -497,15 +1576,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 1,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -520,6 +1610,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -528,13 +1619,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 6,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -550,6 +1642,131 @@
                         "id": 4,
                         "ip_addresses": [
                             {
+                                "address": "10.10.0.1/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.1/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/17/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 17,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.0.2/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.2/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/22/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 22,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.30/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.30/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/16/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 16,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.31/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.31/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/21/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 21,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "192.168.100.2/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "192.168.100.2/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/18/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 18,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "2001::1:1/64",
                                 "comments": "",
                                 "custom_fields": {},
@@ -564,6 +1781,7 @@
                                 "id": 2,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -579,16 +1797,38 @@
                         "lag": null,
                         "link_peers": [],
                         "link_peers_type": null,
-                        "mac_address": null,
+                        "mac_address": "AA:AB:CC:DD:EE:FF",
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:AB:CC:DD:EE:FF",
+                                "id": 2,
+                                "mac_address": "AA:AB:CC:DD:EE:FF"
+                            },
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 3,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet2",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": {
+                            "description": "",
+                            "display": "AA:AB:CC:DD:EE:FF",
+                            "id": 2,
+                            "mac_address": "AA:AB:CC:DD:EE:FF"
+                        },
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -603,19 +1843,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -635,18 +1892,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -661,6 +1937,391 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet3",
+                        "display_url": "http://localhost:32768/dcim/interfaces/11/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet3",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet21",
+                        "display_url": "http://localhost:32768/dcim/interfaces/12/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": true,
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet21",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [
+                            {
+                                "description": "",
+                                "display": "Data (200)",
+                                "id": 2,
+                                "name": "Data",
+                                "vid": 200
+                            },
+                            {
+                                "description": "",
+                                "display": "VoIP (300)",
+                                "id": 3,
+                                "name": "VoIP",
+                                "vid": 300
+                            }
+                        ],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": {
+                            "description": "",
+                            "display": "Wireless (100)",
+                            "id": 1,
+                            "name": "Wireless",
+                            "vid": 100
+                        },
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet4",
+                        "display_url": "http://localhost:32768/dcim/interfaces/14/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 14,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet4",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": true,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet5",
+                        "display_url": "http://localhost:32768/dcim/interfaces/16/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 16,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": true,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet5",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -678,6 +2339,8 @@
                     "parent-rack-group"
                 ],
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -689,40 +2352,9 @@
                         "comments": "",
                         "custom_fields": {},
                         "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/1/",
-                        "id": 1,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    },
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "http (TCP/80)",
-                        "display_url": "http://localhost:32768/ipam/services/2/",
-                        "id": 2,
+                        "display": "node-exporter (UDP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
                         "ipaddresses": [
                             {
                                 "address": "172.16.180.1/24",
@@ -733,28 +2365,26 @@
                                     "value": 4
                                 },
                                 "id": 1
-                            },
-                            {
-                                "address": "2001::1:1/64",
-                                "description": "",
-                                "display": "2001::1:1/64",
-                                "family": {
-                                    "label": "IPv6",
-                                    "value": 6
-                                },
-                                "id": 2
                             }
                         ],
-                        "name": "http",
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "dcim.device",
                         "ports": [
-                            80
+                            9100
                         ],
                         "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
+                            "label": "UDP",
+                            "value": "udp"
                         },
-                        "tags": [],
-                        "virtual_machine": null
+                        "tags": []
                     }
                 ],
                 "site": "test-site",
@@ -776,22 +2406,64 @@
                     {
                         "bridge": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
+                        "count_ipaddresses": 1,
                         "custom_fields": {},
-                        "description": "",
+                        "description": "Updated test100-vm Eth0 intf",
                         "display": "Eth0",
                         "display_url": "http://localhost:32768/virtualization/interfaces/1/",
-                        "enabled": true,
+                        "enabled": false,
                         "id": 1,
-                        "ip_addresses": [],
+                        "ip_addresses": [
+                            {
+                                "address": "10.188.1.100/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.188.1.100/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/19/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 19,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
                         "l2vpn_termination": null,
                         "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 4,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "mtu": 9000,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
-                        "tags": [],
+                        "tags": [
+                            "schnozzberry"
+                        ],
                         "untagged_vlan": null,
                         "virtual_machine": {
                             "description": "",
@@ -799,6 +2471,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -814,10 +2487,27 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:BC:DD:EE:FF:AA",
+                                "id": 5,
+                                "mac_address": "BB:BC:DD:EE:FF:AA"
+                            },
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 6,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -827,6 +2517,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -842,10 +2533,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -855,6 +2550,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -870,10 +2566,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -883,6 +2583,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -898,10 +2599,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -911,18 +2616,43 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "services": [],
-                "site": "test-site",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter-vm (TCP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "node-exporter-vm",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "virtualization.virtualmachine",
+                        "ports": [
+                            9100
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": []
+                    }
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -950,10 +2680,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -963,6 +2697,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -978,10 +2713,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -991,6 +2730,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1006,10 +2746,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1019,6 +2763,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1034,10 +2779,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1047,6 +2796,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1062,10 +2812,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1075,18 +2829,15 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1103,13 +2854,9 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1126,13 +2873,9 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1163,27 +2906,35 @@
     "all": {
         "children": [
             "ungrouped",
+            "site_site_with_contact",
             "site_test_site2",
             "region_other_region",
             "region_parent_region",
+            "region_region_with_contact",
             "site_group_other_site_group",
             "site_group_parent_site_group",
-            "rack_Test_Rack_Site_2",
-            "rack_role_test_rack_role",
+            "site_group_site_group_with_contact",
             "role_core_switch",
             "device_type_cisco_test",
             "manufacturer_cisco",
+            "status_staged",
             "status_active",
+            "service_node_exporter",
+            "tag_first",
+            "tag_second",
+            "tag_third",
+            "tag_nolookup",
+            "tag_lookup",
+            "rack_Test_Rack_Site_2",
+            "rack_role_test_rack_role",
             "device_type_nexus_parent",
-            "service_telnet",
             "rack_Test_Rack",
-            "service_ssh",
-            "service_http",
             "cluster_Test_Cluster_2",
             "cluster_type_test_cluster_type",
             "is_virtual",
             "cluster_Test_Cluster",
-            "cluster_group_test_cluster_group"
+            "cluster_group_test_cluster_group",
+            "service_node_exporter_vm"
         ]
     },
     "cluster_Test_Cluster": {
@@ -1191,7 +2942,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_Test_Cluster_2": {
@@ -1205,7 +2957,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_type_test_cluster_type": {
@@ -1215,14 +2968,24 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "device_type_cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "device_type_nexus_parent": {
@@ -1237,7 +3000,8 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "location_parent_rack_group": {
@@ -1248,16 +3012,25 @@
     "location_test_rack_group": {
         "hosts": [
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "manufacturer_cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "rack_Test_Rack": {
@@ -1282,31 +3055,36 @@
     },
     "region_test_region": {
         "children": [
+            "site_test_california",
             "site_test_site"
         ]
     },
     "role_core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
-        ]
-    },
-    "service_http": {
-        "hosts": [
-            "test100"
-        ]
-    },
-    "service_ssh": {
-        "hosts": [
             "test100",
-            "Test VM With Spaces"
+            "TestDeviceR1"
         ]
     },
-    "service_telnet": {
+    "service_node_exporter": {
         "hosts": [
-            "Test Nexus One"
+            "FOR_SERVICE",
+            "test100"
+        ]
+    },
+    "service_node_exporter_vm": {
+        "hosts": [
+            "test100-vm"
         ]
     },
     "site_group_parent_site_group": {
@@ -1314,34 +3092,88 @@
             "site_group_test_site_group"
         ]
     },
+    "site_group_test_site_group": {
+        "children": [
+            "site_test_california"
+        ]
+    },
     "site_test_site": {
         "children": [
+            "location_location_with_contact",
+            "location_office_building",
             "location_parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "site_test_site2": {
+        "children": [
+            "location_office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
         ]
     },
     "status_active": {
         "hosts": [
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
+        ]
+    },
+    "status_staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
+    "tag_first": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tag_lookup": {
+        "hosts": [
+            "L2"
+        ]
+    },
+    "tag_nolookup": {
+        "hosts": [
+            "L1"
+        ]
+    },
+    "tag_second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tag_third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-bearer-token.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-bearer-token.yml
@@ -1,0 +1,32 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token:
+  type: Token
+  value: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+config_context: true
+plurals: false
+interfaces: true
+services: true
+
+group_by:
+  - site
+  - tenant
+  - rack
+  - location
+  - rack_role
+  - tag
+  - role
+  - device_type
+  - manufacturer
+  - platform
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - services
+  - status

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2-filter.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2-filter.json
@@ -1,0 +1,1170 @@
+{
+    "_meta": {
+        "hostvars": {
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "Ethernet1/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/1/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.11/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.11/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/3/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 3,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet1/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/2/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/4/",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/6/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "telnet (TCP/23)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
+                        "ipaddresses": [],
+                        "name": "telnet",
+                        "ports": [
+                            23
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "rack": "Test Rack",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB12345678",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "config_context": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/3/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/1/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/4/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [
+                            {
+                                "address": "2001::1:1/64",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/2/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet2",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/5/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB01234567",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    },
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "http (TCP/80)",
+                        "display_url": "http://localhost:32768/ipam/services/2/",
+                        "id": 2,
+                        "ipaddresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1
+                            },
+                            {
+                                "address": "2001::1:1/64",
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2
+                            }
+                        ],
+                        "name": "http",
+                        "ports": [
+                            80
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "disk": 170,
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/1/",
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/2/",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/3/",
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/4/",
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/5/",
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/6/",
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/7/",
+                        "enabled": true,
+                        "id": 7,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/8/",
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/9/",
+                        "enabled": true,
+                        "id": 9,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/10/",
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "site_test_site2",
+            "region_other_region",
+            "region_parent_region",
+            "site_group_other_site_group",
+            "site_group_parent_site_group",
+            "role_core_switch",
+            "device_type_nexus_parent",
+            "manufacturer_cisco",
+            "service_telnet",
+            "status_active",
+            "rack_Test_Rack",
+            "device_type_cisco_test",
+            "service_ssh",
+            "service_http",
+            "cluster_Test_Cluster",
+            "cluster_group_test_cluster_group",
+            "cluster_type_test_cluster_type",
+            "is_virtual"
+        ]
+    },
+    "cluster_Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_group_test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_type_test_cluster_type": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "device_type_cisco_test": {
+        "hosts": [
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "device_type_nexus_parent": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "location_parent_rack_group": {
+        "children": [
+            "location_test_rack_group"
+        ]
+    },
+    "location_test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "manufacturer_cisco": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "rack_Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "region_parent_region": {
+        "children": [
+            "region_test_region"
+        ]
+    },
+    "region_test_region": {
+        "children": [
+            "site_test_site"
+        ]
+    },
+    "role_core_switch": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "service_http": {
+        "hosts": [
+            "test100"
+        ]
+    },
+    "service_ssh": {
+        "hosts": [
+            "test100"
+        ]
+    },
+    "service_telnet": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "site_group_parent_site_group": {
+        "children": [
+            "site_group_test_site_group"
+        ]
+    },
+    "site_test_site": {
+        "children": [
+            "location_parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "status_active": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2-filter.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2-filter.json
@@ -1,6 +1,574 @@
 {
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Power Tests",
+                            "id": 11,
+                            "name": "Device Power Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/18/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 18,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests",
+                            "id": 12,
+                            "name": "Device Virtual Chassis Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/19/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 19,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests 2",
+                            "id": 13,
+                            "name": "Device Virtual Chassis Tests 2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/20/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 20,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device With Contact",
+                            "id": 10,
+                            "name": "Device With Contact"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/17/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 17,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/21/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 21,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter (TCP/9100, 9200)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "parent_object_id": 14,
+                        "parent_object_type": "dcim.device",
+                        "ports": [
+                            9100,
+                            9200
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [
+                            {
+                                "color": "9e9e9e",
+                                "display": "Schnozzberry",
+                                "display_url": "http://localhost:32768/extras/tags/4/",
+                                "id": 4,
+                                "name": "Schnozzberry",
+                                "slug": "schnozzberry"
+                            }
+                        ]
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "L1": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L1",
+                            "id": 15,
+                            "name": "L1"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/22/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 22,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
             "Test Nexus One": {
                 "ansible_host": "172.16.180.12",
                 "config_context": {},
@@ -11,13 +579,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -33,6 +602,62 @@
                         "id": 1,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/9/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 9,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/7/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 7,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.11/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -47,6 +672,7 @@
                                 "id": 3,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -63,15 +689,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "Test MAC address",
+                                "display": "AA:BB:CC:DD:EE:F0",
+                                "id": 8,
+                                "mac_address": "AA:BB:CC:DD:EE:F0"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet1/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -86,6 +723,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -94,13 +732,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -116,6 +755,62 @@
                         "id": 2,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/10/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 10,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/8/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 8,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.12/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -130,6 +825,7 @@
                                 "id": 4,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -146,15 +842,19 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet2/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -169,19 +869,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -201,18 +918,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -227,6 +963,76 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "Updated child interface from parent device",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/15/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 15,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/2",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -246,33 +1052,7 @@
                 ],
                 "role": "core-switch",
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "Test Nexus One",
-                            "id": 4,
-                            "name": "Test Nexus One"
-                        },
-                        "display": "telnet (TCP/23)",
-                        "display_url": "http://localhost:32768/ipam/services/3/",
-                        "id": 3,
-                        "ipaddresses": [],
-                        "name": "telnet",
-                        "ports": [
-                            23
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    }
-                ],
+                "services": [],
                 "site": "test-site",
                 "site_groups": [],
                 "status": {
@@ -308,7 +1088,124 @@
                 },
                 "tags": []
             },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+                            "id": 9,
+                            "name": "b6b98683-14a0-4991-b4ac-b88e5fe81573"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/8/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "config_context": {
                     "ntp_servers": [
@@ -321,13 +1218,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 2,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -343,6 +1241,31 @@
                         "id": 3,
                         "ip_addresses": [
                             {
+                                "address": "10.255.255.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.255.255.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/6/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 6,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.1/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -357,6 +1280,7 @@
                                 "id": 1,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -373,15 +1297,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 1,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -396,6 +1331,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -404,13 +1340,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 6,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -426,6 +1363,131 @@
                         "id": 4,
                         "ip_addresses": [
                             {
+                                "address": "10.10.0.1/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.1/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/17/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 17,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.0.2/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.2/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/22/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 22,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.30/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.30/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/16/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 16,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.31/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.31/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/21/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 21,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "192.168.100.2/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "192.168.100.2/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/18/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 18,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "2001::1:1/64",
                                 "comments": "",
                                 "custom_fields": {},
@@ -440,6 +1502,7 @@
                                 "id": 2,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -455,16 +1518,38 @@
                         "lag": null,
                         "link_peers": [],
                         "link_peers_type": null,
-                        "mac_address": null,
+                        "mac_address": "AA:AB:CC:DD:EE:FF",
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:AB:CC:DD:EE:FF",
+                                "id": 2,
+                                "mac_address": "AA:AB:CC:DD:EE:FF"
+                            },
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 3,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet2",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": {
+                            "description": "",
+                            "display": "AA:AB:CC:DD:EE:FF",
+                            "id": 2,
+                            "mac_address": "AA:AB:CC:DD:EE:FF"
+                        },
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -479,19 +1564,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -511,18 +1613,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -537,6 +1658,391 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet3",
+                        "display_url": "http://localhost:32768/dcim/interfaces/11/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet3",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet21",
+                        "display_url": "http://localhost:32768/dcim/interfaces/12/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": true,
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet21",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [
+                            {
+                                "description": "",
+                                "display": "Data (200)",
+                                "id": 2,
+                                "name": "Data",
+                                "vid": 200
+                            },
+                            {
+                                "description": "",
+                                "display": "VoIP (300)",
+                                "id": 3,
+                                "name": "VoIP",
+                                "vid": 300
+                            }
+                        ],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": {
+                            "description": "",
+                            "display": "Wireless (100)",
+                            "id": 1,
+                            "name": "Wireless",
+                            "vid": 100
+                        },
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet4",
+                        "display_url": "http://localhost:32768/dcim/interfaces/14/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 14,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet4",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": true,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet5",
+                        "display_url": "http://localhost:32768/dcim/interfaces/16/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 16,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": true,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet5",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -554,6 +2060,8 @@
                     "parent-rack-group"
                 ],
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -565,40 +2073,9 @@
                         "comments": "",
                         "custom_fields": {},
                         "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/1/",
-                        "id": 1,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    },
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "http (TCP/80)",
-                        "display_url": "http://localhost:32768/ipam/services/2/",
-                        "id": 2,
+                        "display": "node-exporter (UDP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
                         "ipaddresses": [
                             {
                                 "address": "172.16.180.1/24",
@@ -609,405 +2086,28 @@
                                     "value": 4
                                 },
                                 "id": 1
-                            },
-                            {
-                                "address": "2001::1:1/64",
-                                "description": "",
-                                "display": "2001::1:1/64",
-                                "family": {
-                                    "label": "IPv6",
-                                    "value": 6
-                                },
-                                "id": 2
                             }
                         ],
-                        "name": "http",
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "dcim.device",
                         "ports": [
-                            80
+                            9100
                         ],
                         "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
+                            "label": "UDP",
+                            "value": "udp"
                         },
-                        "tags": [],
-                        "virtual_machine": null
+                        "tags": []
                     }
                 ],
-                "site": "test-site",
-                "site_groups": [],
-                "status": {
-                    "label": "Active",
-                    "value": "active"
-                },
-                "tags": []
-            },
-            "test100-vm": {
-                "cluster": "Test Cluster",
-                "cluster_group": "test-cluster-group",
-                "cluster_type": "test-cluster-type",
-                "config_context": {},
-                "custom_fields": {},
-                "disk": 170,
-                "interfaces": [
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth0",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/1/",
-                        "enabled": true,
-                        "id": 1,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth0",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test100-vm",
-                            "id": 1,
-                            "name": "test100-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth1",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/2/",
-                        "enabled": true,
-                        "id": 2,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth1",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test100-vm",
-                            "id": 1,
-                            "name": "test100-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth2",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/3/",
-                        "enabled": true,
-                        "id": 3,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth2",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test100-vm",
-                            "id": 1,
-                            "name": "test100-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth3",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/4/",
-                        "enabled": true,
-                        "id": 4,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth3",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test100-vm",
-                            "id": 1,
-                            "name": "test100-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth4",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/5/",
-                        "enabled": true,
-                        "id": 5,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth4",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test100-vm",
-                            "id": 1,
-                            "name": "test100-vm"
-                        },
-                        "vrf": null
-                    }
-                ],
-                "is_virtual": true,
-                "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
-                "serial": "",
-                "services": [],
-                "site": "test-site",
-                "site_groups": [],
-                "status": {
-                    "label": "Active",
-                    "value": "active"
-                },
-                "tags": []
-            },
-            "test101-vm": {
-                "cluster": "Test Cluster",
-                "cluster_group": "test-cluster-group",
-                "cluster_type": "test-cluster-type",
-                "config_context": {},
-                "custom_fields": {},
-                "interfaces": [
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth0",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/6/",
-                        "enabled": true,
-                        "id": 6,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth0",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test101-vm",
-                            "id": 2,
-                            "name": "test101-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth1",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/7/",
-                        "enabled": true,
-                        "id": 7,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth1",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test101-vm",
-                            "id": 2,
-                            "name": "test101-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth2",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/8/",
-                        "enabled": true,
-                        "id": 8,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth2",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test101-vm",
-                            "id": 2,
-                            "name": "test101-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth3",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/9/",
-                        "enabled": true,
-                        "id": 9,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth3",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test101-vm",
-                            "id": 2,
-                            "name": "test101-vm"
-                        },
-                        "vrf": null
-                    },
-                    {
-                        "bridge": null,
-                        "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
-                        "custom_fields": {},
-                        "description": "",
-                        "display": "Eth4",
-                        "display_url": "http://localhost:32768/virtualization/interfaces/10/",
-                        "enabled": true,
-                        "id": 10,
-                        "ip_addresses": [],
-                        "l2vpn_termination": null,
-                        "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
-                        "name": "Eth4",
-                        "parent": null,
-                        "tagged_vlans": [],
-                        "tags": [],
-                        "untagged_vlan": null,
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "test101-vm",
-                            "id": 2,
-                            "name": "test101-vm"
-                        },
-                        "vrf": null
-                    }
-                ],
-                "is_virtual": true,
-                "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
-                "serial": "",
-                "services": [],
-                "site": "test-site",
-                "site_groups": [],
-                "status": {
-                    "label": "Active",
-                    "value": "active"
-                },
-                "tags": []
-            },
-            "test102-vm": {
-                "cluster": "Test Cluster",
-                "cluster_group": "test-cluster-group",
-                "cluster_type": "test-cluster-type",
-                "config_context": {},
-                "custom_fields": {},
-                "interfaces": [],
-                "is_virtual": true,
-                "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
-                "serial": "",
-                "services": [],
-                "site": "test-site",
-                "site_groups": [],
-                "status": {
-                    "label": "Active",
-                    "value": "active"
-                },
-                "tags": []
-            },
-            "test103-vm": {
-                "cluster": "Test Cluster",
-                "cluster_group": "test-cluster-group",
-                "cluster_type": "test-cluster-type",
-                "config_context": {},
-                "custom_fields": {},
-                "interfaces": [],
-                "is_virtual": true,
-                "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
-                "serial": "",
-                "services": [],
                 "site": "test-site",
                 "site_groups": [],
                 "status": {
@@ -1021,67 +2121,45 @@
     "all": {
         "children": [
             "ungrouped",
+            "site_site_with_contact",
             "site_test_site2",
             "region_other_region",
             "region_parent_region",
+            "region_region_with_contact",
             "site_group_other_site_group",
             "site_group_parent_site_group",
+            "site_group_site_group_with_contact",
             "role_core_switch",
-            "device_type_nexus_parent",
-            "manufacturer_cisco",
-            "service_telnet",
-            "status_active",
-            "rack_Test_Rack",
             "device_type_cisco_test",
-            "service_ssh",
-            "service_http",
-            "cluster_Test_Cluster",
-            "cluster_group_test_cluster_group",
-            "cluster_type_test_cluster_type",
-            "is_virtual"
-        ]
-    },
-    "cluster_Test_Cluster": {
-        "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
-        ]
-    },
-    "cluster_group_test_cluster_group": {
-        "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
-        ]
-    },
-    "cluster_type_test_cluster_type": {
-        "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "manufacturer_cisco",
+            "status_staged",
+            "status_active",
+            "service_node_exporter",
+            "tag_first",
+            "tag_second",
+            "tag_third",
+            "tag_nolookup",
+            "device_type_nexus_parent",
+            "rack_Test_Rack"
         ]
     },
     "device_type_cisco_test": {
         "hosts": [
-            "TestDeviceR1",
-            "test100"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "device_type_nexus_parent": {
         "hosts": [
             "Test Nexus One"
-        ]
-    },
-    "is_virtual": {
-        "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
         ]
     },
     "location_parent_rack_group": {
@@ -1092,15 +2170,23 @@
     "location_test_rack_group": {
         "hosts": [
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "manufacturer_cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "rack_Test_Rack": {
@@ -1115,29 +2201,29 @@
     },
     "region_test_region": {
         "children": [
+            "site_test_california",
             "site_test_site"
         ]
     },
     "role_core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
-    "service_http": {
+    "service_node_exporter": {
         "hosts": [
+            "FOR_SERVICE",
             "test100"
-        ]
-    },
-    "service_ssh": {
-        "hosts": [
-            "test100"
-        ]
-    },
-    "service_telnet": {
-        "hosts": [
-            "Test Nexus One"
         ]
     },
     "site_group_parent_site_group": {
@@ -1145,26 +2231,70 @@
             "site_group_test_site_group"
         ]
     },
+    "site_group_test_site_group": {
+        "children": [
+            "site_test_california"
+        ]
+    },
     "site_test_site": {
         "children": [
+            "location_location_with_contact",
+            "location_office_building",
             "location_parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
+        ]
+    },
+    "site_test_site2": {
+        "children": [
+            "location_office_building"
         ]
     },
     "status_active": {
         "hosts": [
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "TestDeviceR1"
+        ]
+    },
+    "status_staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
+        ]
+    },
+    "tag_first": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tag_nolookup": {
+        "hosts": [
+            "L1"
+        ]
+    },
+    "tag_second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tag_third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2-filter.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2-filter.yml
@@ -1,0 +1,33 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+config_context: true
+plurals: false
+interfaces: true
+services: true
+
+group_by:
+  - site
+  - tenant
+  - rack
+  - location
+  - rack_role
+  - tag
+  - role
+  - device_type
+  - manufacturer
+  - platform
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - services
+  - status
+
+query_filters:
+  - site: "{{ 'TEST-SITE' | lower }}"

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2.json
@@ -1,0 +1,390 @@
+{
+    "Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "Test_Rack_Site_2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "rack": "Test Rack Site 2",
+                "rack_id": "1",
+                "rack_role": "test-rack-role",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "rack": "Test Rack",
+                "rack_id": "2",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB12345678",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "VC1": {
+                "ansible_host": "nexus.example.com",
+                "custom_fields": {},
+                "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "local_context_data": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB01234567",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "disk": 170,
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "active": {
+        "hosts": [
+            "R1-Device",
+            "VC1",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "test_site2",
+            "other_region",
+            "parent_region",
+            "other_site_group",
+            "parent_site_group",
+            "Test_Rack_Site_2",
+            "test_rack_role",
+            "core_switch",
+            "cisco_test",
+            "cisco",
+            "active",
+            "nexus_parent",
+            "jinja_test_group",
+            "Test_Rack",
+            "Test_Cluster_2",
+            "test_cluster_type",
+            "is_virtual",
+            "Test_Cluster",
+            "test_cluster_group"
+        ]
+    },
+    "cisco": {
+        "hosts": [
+            "R1-Device",
+            "VC1",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "core_switch": {
+        "hosts": [
+            "R1-Device",
+            "VC1",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "jinja_test_group": {
+        "hosts": [
+            "TestDeviceR1",
+            "Test VM With Spaces"
+        ]
+    },
+    "nexus_parent": {
+        "hosts": [
+            "VC1"
+        ]
+    },
+    "parent_rack_group": {
+        "children": [
+            "test_rack_group"
+        ]
+    },
+    "parent_region": {
+        "children": [
+            "test_region"
+        ]
+    },
+    "parent_site_group": {
+        "children": [
+            "test_site_group"
+        ]
+    },
+    "test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "test_rack_group": {
+        "hosts": [
+            "VC1",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "test_rack_role": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "test_region": {
+        "children": [
+            "test_site"
+        ]
+    },
+    "test_site": {
+        "children": [
+            "parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2.json
@@ -4,7 +4,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "Test_Cluster_2": {
@@ -25,6 +26,147 @@
     },
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "First VC": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "L1": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "custom_fields": {},
@@ -112,7 +254,69 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "custom_fields": {},
                 "device_type": "cisco-test",
@@ -127,6 +331,8 @@
                     "parent-rack-group"
                 ],
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -149,12 +355,8 @@
                 "disk": 170,
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -169,12 +371,8 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -189,12 +387,8 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -209,12 +403,8 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -241,32 +431,45 @@
     },
     "active": {
         "hosts": [
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "VC1",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "all": {
         "children": [
             "ungrouped",
+            "site_with_contact",
             "test_site2",
             "other_region",
             "parent_region",
+            "region_with_contact",
             "other_site_group",
             "parent_site_group",
-            "Test_Rack_Site_2",
-            "test_rack_role",
+            "site_group_with_contact",
             "core_switch",
             "cisco_test",
             "cisco",
+            "staged",
             "active",
+            "first",
+            "second",
+            "third",
+            "nolookup",
+            "lookup",
+            "Test_Rack_Site_2",
+            "test_rack_role",
             "nexus_parent",
             "jinja_test_group",
             "Test_Rack",
@@ -279,25 +482,57 @@
     },
     "cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "VC1",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "VC1",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
+        ]
+    },
+    "first": {
+        "hosts": [
+            "issue-242"
         ]
     },
     "is_virtual": {
@@ -307,7 +542,8 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "jinja_test_group": {
@@ -316,9 +552,19 @@
             "Test VM With Spaces"
         ]
     },
+    "lookup": {
+        "hosts": [
+            "L2"
+        ]
+    },
     "nexus_parent": {
         "hosts": [
             "VC1"
+        ]
+    },
+    "nolookup": {
+        "hosts": [
+            "L1"
         ]
     },
     "parent_rack_group": {
@@ -336,12 +582,28 @@
             "test_site_group"
         ]
     },
+    "second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
     "test_cluster_group": {
         "hosts": [
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_cluster_type": {
@@ -351,14 +613,15 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_rack_group": {
         "hosts": [
             "VC1",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "test_rack_role": {
@@ -368,23 +631,44 @@
     },
     "test_region": {
         "children": [
+            "test_california",
             "test_site"
         ]
     },
     "test_site": {
         "children": [
+            "location_with_contact",
+            "office_building",
             "parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "test_site2": {
+        "children": [
+            "office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
+        ]
+    },
+    "test_site_group": {
+        "children": [
+            "test_california"
+        ]
+    },
+    "third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-jinja2.yml
@@ -1,0 +1,62 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+# Cache is not for performance of tests, but to test the caching option works
+# Also set on test-inventory-plurals.yml so that we actually hit the cache on one of these runs
+cache: true
+cache_timeout: 3600
+cache_plugin: jsonfile
+cache_connection: /tmp/inventory_netbox
+
+config_context: false
+plurals: false
+interfaces: false
+services: false
+group_names_raw: true
+virtual_chassis_name: true
+dns_name: true
+ansible_host_dns_name: true
+
+group_by:
+  - site
+  - tenant
+  - rack
+  - location
+  - rack_role
+  - tag
+  - role
+  - device_type
+  - manufacturer
+  - platform
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - status
+
+query_filters: ""
+
+device_query_filters:
+  - role: "{{ 'CORE-SWITCH' | lower }}"
+
+vm_query_filters:
+  - cluster_type: "{{ 'TEST-CLUSTER-TYPE' | lower }}"
+
+# See Constructed for details
+# https://docs.ansible.com/ansible/latest/plugins/inventory/constructed.html
+
+compose:
+  rack_id: rack.id
+  ntp_servers: config_context.ntp_servers
+
+keyed_groups:
+  - prefix: rack
+    key: rack.name
+
+groups:
+  jinja_test_group: inventory_hostname.startswith('Test')

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-legacy.json
@@ -1,0 +1,441 @@
+{
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "rack_role": "test-rack-role",
+                "racks": [
+                    "Test Rack Site 2"
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "nexus-parent"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "telnet (TCP/23)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
+                        "ipaddresses": [],
+                        "name": "telnet",
+                        "ports": [
+                            23
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": null,
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        }
+                    }
+                ],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "racks": [
+                    "Test Rack"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB12345678",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    {
+                        "ntp_servers": [
+                            "pool.ntp.org"
+                        ]
+                    }
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB01234567",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    },
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "http (TCP/80)",
+                        "display_url": "http://localhost:32768/ipam/services/2/",
+                        "id": 2,
+                        "ipaddresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1
+                            },
+                            {
+                                "address": "2001::1:1/64",
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2
+                            }
+                        ],
+                        "name": "http",
+                        "ports": [
+                            80
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "disk": 170,
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped"
+        ]
+    },
+    "ungrouped": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-legacy.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-legacy.json
@@ -1,6 +1,269 @@
 {
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter (TCP/9100, 9200)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "parent_object_id": 14,
+                        "parent_object_type": "dcim.device",
+                        "ports": [
+                            9100,
+                            9200
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [
+                            {
+                                "color": "9e9e9e",
+                                "display": "Schnozzberry",
+                                "display_url": "http://localhost:32768/extras/tags/4/",
+                                "id": 4,
+                                "name": "Schnozzberry",
+                                "slug": "schnozzberry"
+                            }
+                        ]
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "L1": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "custom_fields": {},
@@ -61,33 +324,7 @@
                     "parent-region"
                 ],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "Test Nexus One",
-                            "id": 4,
-                            "name": "Test Nexus One"
-                        },
-                        "display": "telnet (TCP/23)",
-                        "display_url": "http://localhost:32768/ipam/services/3/",
-                        "id": 3,
-                        "ipaddresses": [],
-                        "name": "telnet",
-                        "ports": [
-                            23
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "sites": [
                     "test-site"
@@ -109,33 +346,7 @@
                 "locations": [],
                 "regions": [],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": null,
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/4/",
-                        "id": 4,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "Test VM With Spaces",
-                            "id": 6,
-                            "name": "Test VM With Spaces"
-                        }
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -181,7 +392,97 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "custom_fields": {},
                 "device_roles": [
@@ -205,6 +506,8 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -215,40 +518,9 @@
                         "comments": "",
                         "custom_fields": {},
                         "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/1/",
-                        "id": 1,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    },
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "http (TCP/80)",
-                        "display_url": "http://localhost:32768/ipam/services/2/",
-                        "id": 2,
+                        "display": "node-exporter (UDP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
                         "ipaddresses": [
                             {
                                 "address": "172.16.180.1/24",
@@ -259,28 +531,26 @@
                                     "value": 4
                                 },
                                 "id": 1
-                            },
-                            {
-                                "address": "2001::1:1/64",
-                                "description": "",
-                                "display": "2001::1:1/64",
-                                "family": {
-                                    "label": "IPv6",
-                                    "value": 6
-                                },
-                                "id": 2
                             }
                         ],
-                        "name": "http",
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "dcim.device",
                         "ports": [
-                            80
+                            9100
                         ],
                         "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
+                            "label": "UDP",
+                            "value": "udp"
                         },
-                        "tags": [],
-                        "virtual_machine": null
+                        "tags": []
                     }
                 ],
                 "site_groups": [],
@@ -304,16 +574,38 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "services": [],
-                "site_groups": [],
-                "sites": [
-                    "test-site"
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter-vm (TCP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "node-exporter-vm",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "virtualization.virtualmachine",
+                        "ports": [
+                            9100
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": []
+                    }
                 ],
+                "site_groups": [],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -330,16 +622,10 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -356,16 +642,10 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -382,16 +662,10 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -426,16 +700,26 @@
     },
     "ungrouped": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-legacy.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-legacy.yml
@@ -1,0 +1,10 @@
+---
+# To generate the json result, I checked out nb_inventory.yml from the v0.2.0 release 2d6894b,
+# and then ran it against this inventory with the latest test data.
+
+# Checks that substantial work on the inventory does not diverge from what existing users are using by default.
+
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-noracks.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-noracks.json
@@ -1,0 +1,1377 @@
+{
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "nexus-parent"
+                ],
+                "dns_name": "nexus.example.com",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "Ethernet1/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/1/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.11/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.11/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/3/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 3,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet1/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/2/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/4/",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/6/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "telnet (TCP/23)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
+                        "ipaddresses": [],
+                        "name": "telnet",
+                        "ports": [
+                            23
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/11/",
+                        "enabled": true,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/12/",
+                        "enabled": true,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": null,
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        }
+                    }
+                ],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB12345678",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "config_context": [
+                    {
+                        "ntp_servers": [
+                            "pool.ntp.org"
+                        ]
+                    }
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/3/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/1/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/4/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [
+                            {
+                                "address": "2001::1:1/64",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/2/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet2",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/5/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    {
+                        "ntp_servers": [
+                            "pool.ntp.org"
+                        ]
+                    }
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB01234567",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    },
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "http (TCP/80)",
+                        "display_url": "http://localhost:32768/ipam/services/2/",
+                        "id": 2,
+                        "ipaddresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1
+                            },
+                            {
+                                "address": "2001::1:1/64",
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2
+                            }
+                        ],
+                        "name": "http",
+                        "ports": [
+                            80
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "disk": 170,
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/1/",
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/2/",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/3/",
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/4/",
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/5/",
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/6/",
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/7/",
+                        "enabled": true,
+                        "id": 7,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/8/",
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/9/",
+                        "enabled": true,
+                        "id": 9,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/10/",
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "sites_test_site2",
+            "region_other_region",
+            "region_parent_region",
+            "site_group_other_site_group",
+            "site_group_parent_site_group",
+            "device_roles_core_switch",
+            "device_types_cisco_test",
+            "manufacturers_cisco",
+            "status_active",
+            "device_types_nexus_parent",
+            "cluster_Test_Cluster_2",
+            "cluster_type_test_cluster_type",
+            "is_virtual",
+            "cluster_Test_Cluster",
+            "cluster_group_test_cluster_group"
+        ]
+    },
+    "cluster_Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "cluster_group_test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_type_test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "device_roles_core_switch": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "device_types_cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "device_types_nexus_parent": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "location_parent_rack_group": {
+        "children": [
+            "location_test_rack_group"
+        ]
+    },
+    "location_test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "manufacturers_cisco": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "region_parent_region": {
+        "children": [
+            "region_test_region"
+        ]
+    },
+    "region_test_region": {
+        "children": [
+            "sites_test_site"
+        ]
+    },
+    "site_group_parent_site_group": {
+        "children": [
+            "site_group_test_site_group"
+        ]
+    },
+    "sites_test_site": {
+        "children": [
+            "location_parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "sites_test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "status_active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-noracks.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-noracks.json
@@ -1,6 +1,745 @@
 {
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Power Tests",
+                            "id": 11,
+                            "name": "Device Power Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/18/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 18,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests",
+                            "id": 12,
+                            "name": "Device Virtual Chassis Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/19/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 19,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests 2",
+                            "id": 13,
+                            "name": "Device Virtual Chassis Tests 2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/20/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 20,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device With Contact",
+                            "id": 10,
+                            "name": "Device With Contact"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/17/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 17,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/21/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 21,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter (TCP/9100, 9200)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "parent_object_id": 14,
+                        "parent_object_type": "dcim.device",
+                        "ports": [
+                            9100,
+                            9200
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [
+                            {
+                                "color": "9e9e9e",
+                                "display": "Schnozzberry",
+                                "display_url": "http://localhost:32768/extras/tags/4/",
+                                "id": 4,
+                                "name": "Schnozzberry",
+                                "slug": "schnozzberry"
+                            }
+                        ]
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "L1": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L1",
+                            "id": 15,
+                            "name": "L1"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/22/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 22,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L2",
+                            "id": 16,
+                            "name": "L2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/23/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 23,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "config_context": [
@@ -13,7 +752,72 @@
                 "device_types": [
                     "cisco-test"
                 ],
-                "interfaces": [],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "R1-Device (345678901)",
+                            "id": 3,
+                            "name": "R1-Device"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/13/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 13,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
                 "is_virtual": false,
                 "local_context_data": [
                     null
@@ -51,13 +855,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -73,6 +878,62 @@
                         "id": 1,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/9/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 9,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/7/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 7,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.11/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -87,6 +948,7 @@
                                 "id": 3,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -103,15 +965,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "Test MAC address",
+                                "display": "AA:BB:CC:DD:EE:F0",
+                                "id": 8,
+                                "mac_address": "AA:BB:CC:DD:EE:F0"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet1/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -126,6 +999,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -134,13 +1008,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -156,6 +1031,62 @@
                         "id": 2,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/10/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 10,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/8/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 8,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.12/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -170,6 +1101,7 @@
                                 "id": 4,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -186,15 +1118,19 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet2/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -209,19 +1145,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -241,18 +1194,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -267,6 +1239,76 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "Updated child interface from parent device",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/15/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 15,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/2",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -286,33 +1328,7 @@
                     "parent-region"
                 ],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "Test Nexus One",
-                            "id": 4,
-                            "name": "Test Nexus One"
-                        },
-                        "display": "telnet (TCP/23)",
-                        "display_url": "http://localhost:32768/ipam/services/3/",
-                        "id": 3,
-                        "ipaddresses": [],
-                        "name": "telnet",
-                        "ports": [
-                            23
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "sites": [
                     "test-site"
@@ -344,10 +1360,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -357,6 +1377,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -372,10 +1393,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -385,6 +1410,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -394,33 +1420,7 @@
                 ],
                 "regions": [],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": null,
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/4/",
-                        "id": 4,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "Test VM With Spaces",
-                            "id": 6,
-                            "name": "Test VM With Spaces"
-                        }
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -463,7 +1463,171 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+                            "id": 9,
+                            "name": "b6b98683-14a0-4991-b4ac-b88e5fe81573"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/8/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "config_context": [
                     {
@@ -483,13 +1647,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 2,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -505,6 +1670,31 @@
                         "id": 3,
                         "ip_addresses": [
                             {
+                                "address": "10.255.255.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.255.255.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/6/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 6,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.1/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -519,6 +1709,7 @@
                                 "id": 1,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -535,15 +1726,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 1,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -558,6 +1760,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -566,13 +1769,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 6,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -588,6 +1792,131 @@
                         "id": 4,
                         "ip_addresses": [
                             {
+                                "address": "10.10.0.1/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.1/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/17/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 17,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.0.2/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.2/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/22/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 22,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.30/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.30/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/16/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 16,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.31/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.31/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/21/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 21,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "192.168.100.2/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "192.168.100.2/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/18/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 18,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "2001::1:1/64",
                                 "comments": "",
                                 "custom_fields": {},
@@ -602,6 +1931,7 @@
                                 "id": 2,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -617,16 +1947,38 @@
                         "lag": null,
                         "link_peers": [],
                         "link_peers_type": null,
-                        "mac_address": null,
+                        "mac_address": "AA:AB:CC:DD:EE:FF",
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:AB:CC:DD:EE:FF",
+                                "id": 2,
+                                "mac_address": "AA:AB:CC:DD:EE:FF"
+                            },
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 3,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet2",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": {
+                            "description": "",
+                            "display": "AA:AB:CC:DD:EE:FF",
+                            "id": 2,
+                            "mac_address": "AA:AB:CC:DD:EE:FF"
+                        },
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -641,19 +1993,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -673,18 +2042,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -699,6 +2087,391 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet3",
+                        "display_url": "http://localhost:32768/dcim/interfaces/11/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet3",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet21",
+                        "display_url": "http://localhost:32768/dcim/interfaces/12/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": true,
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet21",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [
+                            {
+                                "description": "",
+                                "display": "Data (200)",
+                                "id": 2,
+                                "name": "Data",
+                                "vid": 200
+                            },
+                            {
+                                "description": "",
+                                "display": "VoIP (300)",
+                                "id": 3,
+                                "name": "VoIP",
+                                "vid": 300
+                            }
+                        ],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": {
+                            "description": "",
+                            "display": "Wireless (100)",
+                            "id": 1,
+                            "name": "Wireless",
+                            "vid": 100
+                        },
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet4",
+                        "display_url": "http://localhost:32768/dcim/interfaces/14/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 14,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet4",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": true,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet5",
+                        "display_url": "http://localhost:32768/dcim/interfaces/16/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 16,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": true,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet5",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -716,6 +2489,8 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -726,40 +2501,9 @@
                         "comments": "",
                         "custom_fields": {},
                         "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/1/",
-                        "id": 1,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    },
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "http (TCP/80)",
-                        "display_url": "http://localhost:32768/ipam/services/2/",
-                        "id": 2,
+                        "display": "node-exporter (UDP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
                         "ipaddresses": [
                             {
                                 "address": "172.16.180.1/24",
@@ -770,28 +2514,26 @@
                                     "value": 4
                                 },
                                 "id": 1
-                            },
-                            {
-                                "address": "2001::1:1/64",
-                                "description": "",
-                                "display": "2001::1:1/64",
-                                "family": {
-                                    "label": "IPv6",
-                                    "value": 6
-                                },
-                                "id": 2
                             }
                         ],
-                        "name": "http",
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "dcim.device",
                         "ports": [
-                            80
+                            9100
                         ],
                         "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
+                            "label": "UDP",
+                            "value": "udp"
                         },
-                        "tags": [],
-                        "virtual_machine": null
+                        "tags": []
                     }
                 ],
                 "site_groups": [],
@@ -817,22 +2559,64 @@
                     {
                         "bridge": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
+                        "count_ipaddresses": 1,
                         "custom_fields": {},
-                        "description": "",
+                        "description": "Updated test100-vm Eth0 intf",
                         "display": "Eth0",
                         "display_url": "http://localhost:32768/virtualization/interfaces/1/",
-                        "enabled": true,
+                        "enabled": false,
                         "id": 1,
-                        "ip_addresses": [],
+                        "ip_addresses": [
+                            {
+                                "address": "10.188.1.100/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.188.1.100/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/19/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 19,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
                         "l2vpn_termination": null,
                         "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 4,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "mtu": 9000,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
-                        "tags": [],
+                        "tags": [
+                            "schnozzberry"
+                        ],
                         "untagged_vlan": null,
                         "virtual_machine": {
                             "description": "",
@@ -840,6 +2624,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -855,10 +2640,27 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:BC:DD:EE:FF:AA",
+                                "id": 5,
+                                "mac_address": "BB:BC:DD:EE:FF:AA"
+                            },
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 6,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -868,6 +2670,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -883,10 +2686,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -896,6 +2703,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -911,10 +2719,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -924,6 +2736,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -939,10 +2752,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -952,6 +2769,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -959,16 +2777,38 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "services": [],
-                "site_groups": [],
-                "sites": [
-                    "test-site"
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter-vm (TCP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "node-exporter-vm",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "virtualization.virtualmachine",
+                        "ports": [
+                            9100
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": []
+                    }
                 ],
+                "site_groups": [],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -997,10 +2837,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1010,6 +2854,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1025,10 +2870,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1038,6 +2887,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1053,10 +2903,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1066,6 +2920,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1081,10 +2936,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1094,6 +2953,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1109,10 +2969,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1122,6 +2986,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -1129,16 +2994,10 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -1158,16 +3017,10 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -1187,16 +3040,10 @@
                 "local_context_data": [
                     null
                 ],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -1230,15 +3077,24 @@
     "all": {
         "children": [
             "ungrouped",
+            "sites_site_with_contact",
             "sites_test_site2",
             "region_other_region",
             "region_parent_region",
+            "region_region_with_contact",
             "site_group_other_site_group",
             "site_group_parent_site_group",
+            "site_group_site_group_with_contact",
             "device_roles_core_switch",
             "device_types_cisco_test",
             "manufacturers_cisco",
+            "status_staged",
             "status_active",
+            "tags_first",
+            "tags_second",
+            "tags_third",
+            "tags_nolookup",
+            "tags_lookup",
             "device_types_nexus_parent",
             "cluster_Test_Cluster_2",
             "cluster_type_test_cluster_type",
@@ -1252,7 +3108,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_Test_Cluster_2": {
@@ -1266,7 +3123,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_type_test_cluster_type": {
@@ -1276,22 +3134,41 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "device_roles_core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "device_types_cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "device_types_nexus_parent": {
@@ -1306,7 +3183,8 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "location_parent_rack_group": {
@@ -1317,16 +3195,25 @@
     "location_test_rack_group": {
         "hosts": [
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "manufacturers_cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "region_parent_region": {
@@ -1336,6 +3223,7 @@
     },
     "region_test_region": {
         "children": [
+            "sites_test_california",
             "sites_test_site"
         ]
     },
@@ -1344,34 +3232,88 @@
             "site_group_test_site_group"
         ]
     },
+    "site_group_test_site_group": {
+        "children": [
+            "sites_test_california"
+        ]
+    },
     "sites_test_site": {
         "children": [
+            "location_location_with_contact",
+            "location_office_building",
             "location_parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "sites_test_site2": {
+        "children": [
+            "location_office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
         ]
     },
     "status_active": {
         "hosts": [
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
+        ]
+    },
+    "status_staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
+    "tags_first": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tags_lookup": {
+        "hosts": [
+            "L2"
+        ]
+    },
+    "tags_nolookup": {
+        "hosts": [
+            "L1"
+        ]
+    },
+    "tags_second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tags_third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-noracks.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-noracks.yml
@@ -1,0 +1,28 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+config_context: true
+plurals: true
+interfaces: true
+services: true
+racks: false
+
+group_by:
+  - sites
+  - tenants
+  - location
+  - tags
+  - device_roles
+  - device_types
+  - manufacturers
+  - platforms
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - status

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-options-flatten.json
@@ -1,0 +1,1302 @@
+{
+    "Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "Test_Rack_Site_2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "rack": "Test Rack Site 2",
+                "rack_role": "test-rack-role",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "Ethernet1/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/1/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.11/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.11/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/3/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 3,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet1/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/2/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/4/",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/6/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "telnet (TCP/23)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
+                        "ipaddresses": [],
+                        "name": "telnet",
+                        "ports": [
+                            23
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/11/",
+                        "enabled": true,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/12/",
+                        "enabled": true,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": null,
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        }
+                    }
+                ],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "rack": "Test Rack",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB12345678",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/3/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/1/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/4/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [
+                            {
+                                "address": "2001::1:1/64",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/2/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet2",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/5/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "ntp_servers": [
+                    "pool.ntp.org"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB01234567",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    },
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "http (TCP/80)",
+                        "display_url": "http://localhost:32768/ipam/services/2/",
+                        "id": 2,
+                        "ipaddresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1
+                            },
+                            {
+                                "address": "2001::1:1/64",
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2
+                            }
+                        ],
+                        "name": "http",
+                        "ports": [
+                            80
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "disk": 170,
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/1/",
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/2/",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/3/",
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/4/",
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/5/",
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/6/",
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/7/",
+                        "enabled": true,
+                        "id": 7,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/8/",
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/9/",
+                        "enabled": true,
+                        "id": 9,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/10/",
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "test_site2",
+            "other_region",
+            "parent_region",
+            "other_site_group",
+            "parent_site_group",
+            "Test_Rack_Site_2",
+            "test_rack_role",
+            "core_switch",
+            "cisco_test",
+            "cisco",
+            "active",
+            "nexus_parent",
+            "Test_Rack",
+            "Test_Cluster_2",
+            "test_cluster_type",
+            "is_virtual",
+            "Test_Cluster",
+            "test_cluster_group"
+        ]
+    },
+    "cisco": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "core_switch": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "nexus_parent": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "parent_rack_group": {
+        "children": [
+            "test_rack_group"
+        ]
+    },
+    "parent_region": {
+        "children": [
+            "test_region"
+        ]
+    },
+    "parent_site_group": {
+        "children": [
+            "test_site_group"
+        ]
+    },
+    "test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "test_rack_role": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "test_region": {
+        "children": [
+            "test_site"
+        ]
+    },
+    "test_site": {
+        "children": [
+            "parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-options-flatten.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-options-flatten.json
@@ -4,7 +4,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "Test_Cluster_2": {
@@ -25,10 +26,716 @@
     },
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Power Tests",
+                            "id": 11,
+                            "name": "Device Power Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/18/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 18,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests",
+                            "id": 12,
+                            "name": "Device Virtual Chassis Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/19/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 19,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests 2",
+                            "id": 13,
+                            "name": "Device Virtual Chassis Tests 2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/20/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 20,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device With Contact",
+                            "id": 10,
+                            "name": "Device With Contact"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/17/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 17,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/21/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 21,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter (TCP/9100, 9200)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "parent_object_id": 14,
+                        "parent_object_type": "dcim.device",
+                        "ports": [
+                            9100,
+                            9200
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [
+                            {
+                                "color": "9e9e9e",
+                                "display": "Schnozzberry",
+                                "display_url": "http://localhost:32768/extras/tags/4/",
+                                "id": 4,
+                                "name": "Schnozzberry",
+                                "slug": "schnozzberry"
+                            }
+                        ]
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "L1": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L1",
+                            "id": 15,
+                            "name": "L1"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/22/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 22,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L2",
+                            "id": 16,
+                            "name": "L2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/23/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 23,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "device_type": "cisco-test",
-                "interfaces": [],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "R1-Device (345678901)",
+                            "id": 3,
+                            "name": "R1-Device"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/13/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 13,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
                 "is_virtual": false,
                 "locations": [],
                 "manufacturer": "cisco",
@@ -54,13 +761,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -76,6 +784,62 @@
                         "id": 1,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/9/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 9,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/7/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 7,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.11/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -90,6 +854,7 @@
                                 "id": 3,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -106,15 +871,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "Test MAC address",
+                                "display": "AA:BB:CC:DD:EE:F0",
+                                "id": 8,
+                                "mac_address": "AA:BB:CC:DD:EE:F0"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet1/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -129,6 +905,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -137,13 +914,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -159,6 +937,62 @@
                         "id": 2,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/10/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 10,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/8/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 8,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.12/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -173,6 +1007,7 @@
                                 "id": 4,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -189,15 +1024,19 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet2/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -212,19 +1051,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -244,18 +1100,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -270,6 +1145,76 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "Updated child interface from parent device",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/15/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 15,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/2",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -289,33 +1234,7 @@
                 ],
                 "role": "core-switch",
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "Test Nexus One",
-                            "id": 4,
-                            "name": "Test Nexus One"
-                        },
-                        "display": "telnet (TCP/23)",
-                        "display_url": "http://localhost:32768/ipam/services/3/",
-                        "id": 3,
-                        "ipaddresses": [],
-                        "name": "telnet",
-                        "ports": [
-                            23
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    }
-                ],
+                "services": [],
                 "site": "test-site",
                 "site_groups": [],
                 "status": {
@@ -341,10 +1260,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -354,6 +1277,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -369,10 +1293,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -382,6 +1310,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -389,33 +1318,7 @@
                 "locations": [],
                 "regions": [],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": null,
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/4/",
-                        "id": 4,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "Test VM With Spaces",
-                            "id": 6,
-                            "name": "Test VM With Spaces"
-                        }
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -448,20 +1351,151 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+                            "id": 9,
+                            "name": "b6b98683-14a0-4991-b4ac-b88e5fe81573"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/8/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "device_type": "cisco-test",
                 "interfaces": [
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 2,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -477,6 +1511,31 @@
                         "id": 3,
                         "ip_addresses": [
                             {
+                                "address": "10.255.255.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.255.255.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/6/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 6,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.1/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -491,6 +1550,7 @@
                                 "id": 1,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -507,15 +1567,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 1,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -530,6 +1601,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -538,13 +1610,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 6,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -560,6 +1633,131 @@
                         "id": 4,
                         "ip_addresses": [
                             {
+                                "address": "10.10.0.1/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.1/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/17/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 17,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.0.2/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.2/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/22/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 22,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.30/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.30/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/16/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 16,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.31/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.31/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/21/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 21,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "192.168.100.2/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "192.168.100.2/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/18/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 18,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "2001::1:1/64",
                                 "comments": "",
                                 "custom_fields": {},
@@ -574,6 +1772,7 @@
                                 "id": 2,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -589,16 +1788,38 @@
                         "lag": null,
                         "link_peers": [],
                         "link_peers_type": null,
-                        "mac_address": null,
+                        "mac_address": "AA:AB:CC:DD:EE:FF",
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:AB:CC:DD:EE:FF",
+                                "id": 2,
+                                "mac_address": "AA:AB:CC:DD:EE:FF"
+                            },
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 3,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet2",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": {
+                            "description": "",
+                            "display": "AA:AB:CC:DD:EE:FF",
+                            "id": 2,
+                            "mac_address": "AA:AB:CC:DD:EE:FF"
+                        },
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -613,19 +1834,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -645,18 +1883,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -671,6 +1928,391 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet3",
+                        "display_url": "http://localhost:32768/dcim/interfaces/11/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet3",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet21",
+                        "display_url": "http://localhost:32768/dcim/interfaces/12/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": true,
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet21",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [
+                            {
+                                "description": "",
+                                "display": "Data (200)",
+                                "id": 2,
+                                "name": "Data",
+                                "vid": 200
+                            },
+                            {
+                                "description": "",
+                                "display": "VoIP (300)",
+                                "id": 3,
+                                "name": "VoIP",
+                                "vid": 300
+                            }
+                        ],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": {
+                            "description": "",
+                            "display": "Wireless (100)",
+                            "id": 1,
+                            "name": "Wireless",
+                            "vid": 100
+                        },
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet4",
+                        "display_url": "http://localhost:32768/dcim/interfaces/14/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 14,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet4",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": true,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet5",
+                        "display_url": "http://localhost:32768/dcim/interfaces/16/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 16,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": true,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet5",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -686,6 +2328,8 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -697,40 +2341,9 @@
                         "comments": "",
                         "custom_fields": {},
                         "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/1/",
-                        "id": 1,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    },
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "http (TCP/80)",
-                        "display_url": "http://localhost:32768/ipam/services/2/",
-                        "id": 2,
+                        "display": "node-exporter (UDP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
                         "ipaddresses": [
                             {
                                 "address": "172.16.180.1/24",
@@ -741,28 +2354,26 @@
                                     "value": 4
                                 },
                                 "id": 1
-                            },
-                            {
-                                "address": "2001::1:1/64",
-                                "description": "",
-                                "display": "2001::1:1/64",
-                                "family": {
-                                    "label": "IPv6",
-                                    "value": 6
-                                },
-                                "id": 2
                             }
                         ],
-                        "name": "http",
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "dcim.device",
                         "ports": [
-                            80
+                            9100
                         ],
                         "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
+                            "label": "UDP",
+                            "value": "udp"
                         },
-                        "tags": [],
-                        "virtual_machine": null
+                        "tags": []
                     }
                 ],
                 "site": "test-site",
@@ -782,22 +2393,64 @@
                     {
                         "bridge": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
+                        "count_ipaddresses": 1,
                         "custom_fields": {},
-                        "description": "",
+                        "description": "Updated test100-vm Eth0 intf",
                         "display": "Eth0",
                         "display_url": "http://localhost:32768/virtualization/interfaces/1/",
-                        "enabled": true,
+                        "enabled": false,
                         "id": 1,
-                        "ip_addresses": [],
+                        "ip_addresses": [
+                            {
+                                "address": "10.188.1.100/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.188.1.100/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/19/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 19,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
                         "l2vpn_termination": null,
                         "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 4,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "mtu": 9000,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
-                        "tags": [],
+                        "tags": [
+                            "schnozzberry"
+                        ],
                         "untagged_vlan": null,
                         "virtual_machine": {
                             "description": "",
@@ -805,6 +2458,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -820,10 +2474,27 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:BC:DD:EE:FF:AA",
+                                "id": 5,
+                                "mac_address": "BB:BC:DD:EE:FF:AA"
+                            },
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 6,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -833,6 +2504,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -848,10 +2520,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -861,6 +2537,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -876,10 +2553,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -889,6 +2570,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -904,10 +2586,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -917,18 +2603,43 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "services": [],
-                "site": "test-site",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter-vm (TCP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "node-exporter-vm",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "virtualization.virtualmachine",
+                        "ports": [
+                            9100
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": []
+                    }
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -954,10 +2665,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -967,6 +2682,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -982,10 +2698,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -995,6 +2715,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1010,10 +2731,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1023,6 +2748,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1038,10 +2764,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1051,6 +2781,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1066,10 +2797,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1079,18 +2814,15 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1105,13 +2837,9 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1126,13 +2854,9 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1160,32 +2884,45 @@
     },
     "active": {
         "hosts": [
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "all": {
         "children": [
             "ungrouped",
+            "site_with_contact",
             "test_site2",
             "other_region",
             "parent_region",
+            "region_with_contact",
             "other_site_group",
             "parent_site_group",
-            "Test_Rack_Site_2",
-            "test_rack_role",
+            "site_group_with_contact",
             "core_switch",
             "cisco_test",
             "cisco",
+            "staged",
             "active",
+            "first",
+            "second",
+            "third",
+            "nolookup",
+            "lookup",
+            "Test_Rack_Site_2",
+            "test_rack_role",
             "nexus_parent",
             "Test_Rack",
             "Test_Cluster_2",
@@ -1197,25 +2934,57 @@
     },
     "cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
+        ]
+    },
+    "first": {
+        "hosts": [
+            "issue-242"
         ]
     },
     "is_virtual": {
@@ -1225,12 +2994,23 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
+        ]
+    },
+    "lookup": {
+        "hosts": [
+            "L2"
         ]
     },
     "nexus_parent": {
         "hosts": [
             "Test Nexus One"
+        ]
+    },
+    "nolookup": {
+        "hosts": [
+            "L1"
         ]
     },
     "parent_rack_group": {
@@ -1248,12 +3028,28 @@
             "test_site_group"
         ]
     },
+    "second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
     "test_cluster_group": {
         "hosts": [
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_cluster_type": {
@@ -1263,14 +3059,15 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_rack_group": {
         "hosts": [
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "test_rack_role": {
@@ -1280,23 +3077,44 @@
     },
     "test_region": {
         "children": [
+            "test_california",
             "test_site"
         ]
     },
     "test_site": {
         "children": [
+            "location_with_contact",
+            "office_building",
             "parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "test_site2": {
+        "children": [
+            "office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
+        ]
+    },
+    "test_site_group": {
+        "children": [
+            "test_california"
+        ]
+    },
+    "third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-options-flatten.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-options-flatten.yml
@@ -1,0 +1,41 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+# Use cache on this test to make sure interfaces is tested via the cache
+cache: true
+cache_timeout: 3600
+cache_plugin: jsonfile
+cache_connection: /tmp/inventory_netbox
+
+config_context: true
+flatten_config_context: true
+flatten_custom_fields: true
+flatten_local_context_data: true
+plurals: false
+interfaces: true
+services: true
+fetch_all: false
+max_uri_length: 0
+group_names_raw: true
+
+group_by:
+  - site
+  - tenant
+  - rack
+  - location
+  - rack_role
+  - tag
+  - role
+  - device_type
+  - manufacturer
+  - platform
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - status

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-options.json
@@ -1,0 +1,390 @@
+{
+    "Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "Test_Rack_Site_2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "rack": "Test Rack Site 2",
+                "rack_id": "1",
+                "rack_role": "test-rack-role",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "rack": "Test Rack",
+                "rack_id": "2",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB12345678",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "VC1": {
+                "ansible_host": "nexus.example.com",
+                "custom_fields": {},
+                "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "local_context_data": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB01234567",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "disk": 170,
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "active": {
+        "hosts": [
+            "R1-Device",
+            "VC1",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "test_site2",
+            "other_region",
+            "parent_region",
+            "other_site_group",
+            "parent_site_group",
+            "Test_Rack_Site_2",
+            "test_rack_role",
+            "core_switch",
+            "cisco_test",
+            "cisco",
+            "active",
+            "nexus_parent",
+            "jinja_test_group",
+            "Test_Rack",
+            "Test_Cluster_2",
+            "test_cluster_type",
+            "is_virtual",
+            "Test_Cluster",
+            "test_cluster_group"
+        ]
+    },
+    "cisco": {
+        "hosts": [
+            "R1-Device",
+            "VC1",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "core_switch": {
+        "hosts": [
+            "R1-Device",
+            "VC1",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "jinja_test_group": {
+        "hosts": [
+            "TestDeviceR1",
+            "Test VM With Spaces"
+        ]
+    },
+    "nexus_parent": {
+        "hosts": [
+            "VC1"
+        ]
+    },
+    "parent_rack_group": {
+        "children": [
+            "test_rack_group"
+        ]
+    },
+    "parent_region": {
+        "children": [
+            "test_region"
+        ]
+    },
+    "parent_site_group": {
+        "children": [
+            "test_site_group"
+        ]
+    },
+    "test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "test_rack_group": {
+        "hosts": [
+            "VC1",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "test_rack_role": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "test_region": {
+        "children": [
+            "test_site"
+        ]
+    },
+    "test_site": {
+        "children": [
+            "parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-options.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-options.json
@@ -4,7 +4,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "Test_Cluster_2": {
@@ -25,6 +26,147 @@
     },
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "First VC": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "L1": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "custom_fields": {},
@@ -112,7 +254,69 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "custom_fields": {},
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "custom_fields": {},
                 "device_type": "cisco-test",
@@ -127,6 +331,8 @@
                     "parent-rack-group"
                 ],
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -149,12 +355,8 @@
                 "disk": 170,
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -169,12 +371,8 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -189,12 +387,8 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -209,12 +403,8 @@
                 "custom_fields": {},
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -241,32 +431,45 @@
     },
     "active": {
         "hosts": [
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "VC1",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "all": {
         "children": [
             "ungrouped",
+            "site_with_contact",
             "test_site2",
             "other_region",
             "parent_region",
+            "region_with_contact",
             "other_site_group",
             "parent_site_group",
-            "Test_Rack_Site_2",
-            "test_rack_role",
+            "site_group_with_contact",
             "core_switch",
             "cisco_test",
             "cisco",
+            "staged",
             "active",
+            "first",
+            "second",
+            "third",
+            "nolookup",
+            "lookup",
+            "Test_Rack_Site_2",
+            "test_rack_role",
             "nexus_parent",
             "jinja_test_group",
             "Test_Rack",
@@ -279,25 +482,57 @@
     },
     "cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "VC1",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "VC1",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
+        ]
+    },
+    "first": {
+        "hosts": [
+            "issue-242"
         ]
     },
     "is_virtual": {
@@ -307,7 +542,8 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "jinja_test_group": {
@@ -316,9 +552,19 @@
             "Test VM With Spaces"
         ]
     },
+    "lookup": {
+        "hosts": [
+            "L2"
+        ]
+    },
     "nexus_parent": {
         "hosts": [
             "VC1"
+        ]
+    },
+    "nolookup": {
+        "hosts": [
+            "L1"
         ]
     },
     "parent_rack_group": {
@@ -336,12 +582,28 @@
             "test_site_group"
         ]
     },
+    "second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
     "test_cluster_group": {
         "hosts": [
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_cluster_type": {
@@ -351,14 +613,15 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_rack_group": {
         "hosts": [
             "VC1",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "test_rack_role": {
@@ -368,23 +631,44 @@
     },
     "test_region": {
         "children": [
+            "test_california",
             "test_site"
         ]
     },
     "test_site": {
         "children": [
+            "location_with_contact",
+            "office_building",
             "parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "First VC",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "test_site2": {
+        "children": [
+            "office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
+        ]
+    },
+    "test_site_group": {
+        "children": [
+            "test_california"
+        ]
+    },
+    "third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-options.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-options.yml
@@ -1,0 +1,62 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+# Cache is not for performance of tests, but to test the caching option works
+# Also set on test-inventory-plurals.yml so that we actually hit the cache on one of these runs
+cache: true
+cache_timeout: 3600
+cache_plugin: jsonfile
+cache_connection: /tmp/inventory_netbox
+
+config_context: false
+plurals: false
+interfaces: false
+services: false
+group_names_raw: true
+virtual_chassis_name: true
+dns_name: true
+ansible_host_dns_name: true
+
+group_by:
+  - site
+  - tenant
+  - rack
+  - location
+  - rack_role
+  - tag
+  - role
+  - device_type
+  - manufacturer
+  - platform
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - status
+
+query_filters: ""
+
+device_query_filters:
+  - role: core-switch
+
+vm_query_filters:
+  - cluster_type: test-cluster-type
+
+# See Constructed for details
+# https://docs.ansible.com/ansible/latest/plugins/inventory/constructed.html
+
+compose:
+  rack_id: rack.id
+  ntp_servers: config_context.ntp_servers
+
+keyed_groups:
+  - prefix: rack
+    key: rack.name
+
+groups:
+  jinja_test_group: inventory_hostname.startswith('Test')

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals-flatten.json
@@ -1,0 +1,446 @@
+{
+    "Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "Test_Rack_Site_2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "rack_role": "test-rack-role",
+                "racks": [
+                    "Test Rack Site 2"
+                ],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "nexus-parent"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "racks": [
+                    "Test Rack"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB12345678",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    {
+                        "ntp_servers": [
+                            "pool.ntp.org"
+                        ]
+                    }
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "ntp_servers": [
+                    "pool.ntp.org"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB01234567",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "disk": 170,
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "test_site2",
+            "other_region",
+            "parent_region",
+            "other_site_group",
+            "parent_site_group",
+            "Test_Rack_Site_2",
+            "test_rack_role",
+            "core_switch",
+            "cisco_test",
+            "cisco",
+            "active",
+            "nexus_parent",
+            "Test_Rack",
+            "Test_Cluster_2",
+            "test_cluster_type",
+            "is_virtual",
+            "Test_Cluster",
+            "test_cluster_group"
+        ]
+    },
+    "cisco": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "core_switch": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "nexus_parent": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "parent_rack_group": {
+        "children": [
+            "test_rack_group"
+        ]
+    },
+    "parent_region": {
+        "children": [
+            "test_region"
+        ]
+    },
+    "parent_site_group": {
+        "children": [
+            "test_site_group"
+        ]
+    },
+    "test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "test_rack_role": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "test_region": {
+        "children": [
+            "test_site"
+        ]
+    },
+    "test_site": {
+        "children": [
+            "parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals-flatten.json
@@ -4,7 +4,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "Test_Cluster_2": {
@@ -25,6 +26,217 @@
     },
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "L1": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "device_roles": [
@@ -145,7 +357,91 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "device_roles": [
                     "core-switch"
@@ -171,6 +467,8 @@
                 "ntp_servers": [
                     "pool.ntp.org"
                 ],
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -196,15 +494,9 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -220,15 +512,9 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -244,15 +530,9 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -268,15 +548,9 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -304,32 +578,45 @@
     },
     "active": {
         "hosts": [
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "all": {
         "children": [
             "ungrouped",
+            "site_with_contact",
             "test_site2",
             "other_region",
             "parent_region",
+            "region_with_contact",
             "other_site_group",
             "parent_site_group",
-            "Test_Rack_Site_2",
-            "test_rack_role",
+            "site_group_with_contact",
             "core_switch",
             "cisco_test",
             "cisco",
+            "staged",
             "active",
+            "first",
+            "second",
+            "third",
+            "nolookup",
+            "lookup",
+            "Test_Rack_Site_2",
+            "test_rack_role",
             "nexus_parent",
             "Test_Rack",
             "Test_Cluster_2",
@@ -341,25 +628,57 @@
     },
     "cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
+        ]
+    },
+    "first": {
+        "hosts": [
+            "issue-242"
         ]
     },
     "is_virtual": {
@@ -369,12 +688,23 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
+        ]
+    },
+    "lookup": {
+        "hosts": [
+            "L2"
         ]
     },
     "nexus_parent": {
         "hosts": [
             "Test Nexus One"
+        ]
+    },
+    "nolookup": {
+        "hosts": [
+            "L1"
         ]
     },
     "parent_rack_group": {
@@ -392,12 +722,28 @@
             "test_site_group"
         ]
     },
+    "second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
     "test_cluster_group": {
         "hosts": [
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_cluster_type": {
@@ -407,14 +753,15 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "test_rack_group": {
         "hosts": [
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "test_rack_role": {
@@ -424,23 +771,44 @@
     },
     "test_region": {
         "children": [
+            "test_california",
             "test_site"
         ]
     },
     "test_site": {
         "children": [
+            "location_with_contact",
+            "office_building",
             "parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "test_site2": {
+        "children": [
+            "office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
+        ]
+    },
+    "test_site_group": {
+        "children": [
+            "test_california"
+        ]
+    },
+    "third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals-flatten.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals-flatten.yml
@@ -1,0 +1,33 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+config_context: true
+flatten_config_context: true
+flatten_custom_fields: true
+plurals: true
+interfaces: false
+services: false
+fetch_all: true
+group_names_raw: true
+
+group_by:
+  - sites
+  - tenants
+  - racks
+  - location
+  - rack_role
+  - tags
+  - device_roles
+  - device_types
+  - manufacturers
+  - platforms
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - status

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals.json
@@ -1,0 +1,1421 @@
+{
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "rack_role": "test-rack-role",
+                "racks": [
+                    "Test Rack Site 2"
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "nexus-parent"
+                ],
+                "dns_name": "nexus.example.com",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "Ethernet1/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/1/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.11/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.11/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/3/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 3,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet1/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/2/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/4/",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/6/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "telnet (TCP/23)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
+                        "ipaddresses": [],
+                        "name": "telnet",
+                        "ports": [
+                            23
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/11/",
+                        "enabled": true,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/12/",
+                        "enabled": true,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": null,
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        }
+                    }
+                ],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "TestDeviceR1": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "racks": [
+                    "Test Rack"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB12345678",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "config_context": [
+                    {
+                        "ntp_servers": [
+                            "pool.ntp.org"
+                        ]
+                    }
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/3/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/1/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/4/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [
+                            {
+                                "address": "2001::1:1/64",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/2/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet2",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/5/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    {
+                        "ntp_servers": [
+                            "pool.ntp.org"
+                        ]
+                    }
+                ],
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "FAB01234567",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    },
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "http (TCP/80)",
+                        "display_url": "http://localhost:32768/ipam/services/2/",
+                        "id": 2,
+                        "ipaddresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1
+                            },
+                            {
+                                "address": "2001::1:1/64",
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2
+                            }
+                        ],
+                        "name": "http",
+                        "ports": [
+                            80
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "disk": 170,
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/1/",
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/2/",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/3/",
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/4/",
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/5/",
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/6/",
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/7/",
+                        "enabled": true,
+                        "id": 7,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/8/",
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/9/",
+                        "enabled": true,
+                        "id": 9,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/10/",
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "sites_test_site2",
+            "region_other_region",
+            "region_parent_region",
+            "site_group_other_site_group",
+            "site_group_parent_site_group",
+            "racks_Test_Rack_Site_2",
+            "rack_role_test_rack_role",
+            "device_roles_core_switch",
+            "device_types_cisco_test",
+            "manufacturers_cisco",
+            "status_active",
+            "device_types_nexus_parent",
+            "racks_Test_Rack",
+            "cluster_Test_Cluster_2",
+            "cluster_type_test_cluster_type",
+            "is_virtual",
+            "cluster_Test_Cluster",
+            "cluster_group_test_cluster_group"
+        ]
+    },
+    "cluster_Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "cluster_group_test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_type_test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "device_roles_core_switch": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "device_types_cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "device_types_nexus_parent": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "location_parent_rack_group": {
+        "children": [
+            "location_test_rack_group"
+        ]
+    },
+    "location_test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "manufacturers_cisco": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "rack_role_test_rack_role": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "racks_Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "racks_Test_Rack_Site_2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "region_parent_region": {
+        "children": [
+            "region_test_region"
+        ]
+    },
+    "region_test_region": {
+        "children": [
+            "sites_test_site"
+        ]
+    },
+    "site_group_parent_site_group": {
+        "children": [
+            "site_group_test_site_group"
+        ]
+    },
+    "sites_test_site": {
+        "children": [
+            "location_parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "sites_test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "status_active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals.json
@@ -1,6 +1,752 @@
 {
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Power Tests",
+                            "id": 11,
+                            "name": "Device Power Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/18/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 18,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests",
+                            "id": 12,
+                            "name": "Device Virtual Chassis Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/19/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 19,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests 2",
+                            "id": 13,
+                            "name": "Device Virtual Chassis Tests 2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/20/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 20,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "Device With Contact": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device With Contact",
+                            "id": 10,
+                            "name": "Device With Contact"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/17/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 17,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "FOR_SERVICE": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/21/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 21,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter (TCP/9100, 9200)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "parent_object_id": 14,
+                        "parent_object_type": "dcim.device",
+                        "ports": [
+                            9100,
+                            9200
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [
+                            {
+                                "color": "9e9e9e",
+                                "display": "Schnozzberry",
+                                "display_url": "http://localhost:32768/extras/tags/4/",
+                                "id": 4,
+                                "name": "Schnozzberry",
+                                "slug": "schnozzberry"
+                            }
+                        ]
+                    }
+                ],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "L1": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L1",
+                            "id": 15,
+                            "name": "L1"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/22/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 22,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ]
+            },
+            "L2": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L2",
+                            "id": 16,
+                            "name": "L2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/23/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 23,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site2"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ]
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "config_context": [
@@ -13,7 +759,72 @@
                 "device_types": [
                     "cisco-test"
                 ],
-                "interfaces": [],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "R1-Device (345678901)",
+                            "id": 3,
+                            "name": "R1-Device"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/13/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 13,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
                 "is_virtual": false,
                 "local_context_data": [
                     null
@@ -56,13 +867,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -78,6 +890,62 @@
                         "id": 1,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/9/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 9,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/7/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 7,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.11/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -92,6 +960,7 @@
                                 "id": 3,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -108,15 +977,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "Test MAC address",
+                                "display": "AA:BB:CC:DD:EE:F0",
+                                "id": 8,
+                                "mac_address": "AA:BB:CC:DD:EE:F0"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet1/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -131,6 +1011,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -139,13 +1020,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -161,6 +1043,62 @@
                         "id": 2,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/10/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 10,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/8/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 8,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.12/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -175,6 +1113,7 @@
                                 "id": 4,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -191,15 +1130,19 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet2/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -214,19 +1157,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -246,18 +1206,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -272,6 +1251,76 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "Updated child interface from parent device",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/15/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 15,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/2",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -295,33 +1344,7 @@
                     "parent-region"
                 ],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "Test Nexus One",
-                            "id": 4,
-                            "name": "Test Nexus One"
-                        },
-                        "display": "telnet (TCP/23)",
-                        "display_url": "http://localhost:32768/ipam/services/3/",
-                        "id": 3,
-                        "ipaddresses": [],
-                        "name": "telnet",
-                        "ports": [
-                            23
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "sites": [
                     "test-site"
@@ -353,10 +1376,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -366,6 +1393,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -381,10 +1409,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -394,6 +1426,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -404,33 +1437,7 @@
                 "locations": [],
                 "regions": [],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": null,
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/4/",
-                        "id": 4,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "Test VM With Spaces",
-                            "id": 6,
-                            "name": "Test VM With Spaces"
-                        }
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -480,7 +1487,174 @@
                 },
                 "tags": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+                            "id": 9,
+                            "name": "b6b98683-14a0-4991-b4ac-b88e5fe81573"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/8/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "config_context": [
+                    {}
+                ],
+                "custom_fields": {},
+                "device_roles": [
+                    "core-switch"
+                ],
+                "device_types": [
+                    "cisco-test"
+                ],
+                "interfaces": [],
+                "is_virtual": false,
+                "local_context_data": [
+                    null
+                ],
+                "locations": [],
+                "manufacturers": [
+                    "cisco"
+                ],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "sites": [
+                    "test-site"
+                ],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ]
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "config_context": [
                     {
@@ -500,13 +1674,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 2,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -522,6 +1697,31 @@
                         "id": 3,
                         "ip_addresses": [
                             {
+                                "address": "10.255.255.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.255.255.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/6/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 6,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.1/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -536,6 +1736,7 @@
                                 "id": 1,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -552,15 +1753,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 1,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -575,6 +1787,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -583,13 +1796,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 6,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -605,6 +1819,131 @@
                         "id": 4,
                         "ip_addresses": [
                             {
+                                "address": "10.10.0.1/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.1/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/17/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 17,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.0.2/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.2/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/22/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 22,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.30/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.30/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/16/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 16,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.31/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.31/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/21/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 21,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "192.168.100.2/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "192.168.100.2/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/18/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 18,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "2001::1:1/64",
                                 "comments": "",
                                 "custom_fields": {},
@@ -619,6 +1958,7 @@
                                 "id": 2,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -634,16 +1974,38 @@
                         "lag": null,
                         "link_peers": [],
                         "link_peers_type": null,
-                        "mac_address": null,
+                        "mac_address": "AA:AB:CC:DD:EE:FF",
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:AB:CC:DD:EE:FF",
+                                "id": 2,
+                                "mac_address": "AA:AB:CC:DD:EE:FF"
+                            },
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 3,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet2",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": {
+                            "description": "",
+                            "display": "AA:AB:CC:DD:EE:FF",
+                            "id": 2,
+                            "mac_address": "AA:AB:CC:DD:EE:FF"
+                        },
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -658,19 +2020,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -690,18 +2069,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -716,6 +2114,391 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet3",
+                        "display_url": "http://localhost:32768/dcim/interfaces/11/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet3",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet21",
+                        "display_url": "http://localhost:32768/dcim/interfaces/12/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": true,
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet21",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [
+                            {
+                                "description": "",
+                                "display": "Data (200)",
+                                "id": 2,
+                                "name": "Data",
+                                "vid": 200
+                            },
+                            {
+                                "description": "",
+                                "display": "VoIP (300)",
+                                "id": 3,
+                                "name": "VoIP",
+                                "vid": 300
+                            }
+                        ],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": {
+                            "description": "",
+                            "display": "Wireless (100)",
+                            "id": 1,
+                            "name": "Wireless",
+                            "vid": 100
+                        },
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet4",
+                        "display_url": "http://localhost:32768/dcim/interfaces/14/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 14,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet4",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": true,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet5",
+                        "display_url": "http://localhost:32768/dcim/interfaces/16/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 16,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": true,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet5",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -737,6 +2520,8 @@
                 "manufacturers": [
                     "cisco"
                 ],
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -747,40 +2532,9 @@
                         "comments": "",
                         "custom_fields": {},
                         "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/1/",
-                        "id": 1,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    },
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "http (TCP/80)",
-                        "display_url": "http://localhost:32768/ipam/services/2/",
-                        "id": 2,
+                        "display": "node-exporter (UDP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
                         "ipaddresses": [
                             {
                                 "address": "172.16.180.1/24",
@@ -791,28 +2545,26 @@
                                     "value": 4
                                 },
                                 "id": 1
-                            },
-                            {
-                                "address": "2001::1:1/64",
-                                "description": "",
-                                "display": "2001::1:1/64",
-                                "family": {
-                                    "label": "IPv6",
-                                    "value": 6
-                                },
-                                "id": 2
                             }
                         ],
-                        "name": "http",
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "dcim.device",
                         "ports": [
-                            80
+                            9100
                         ],
                         "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
+                            "label": "UDP",
+                            "value": "udp"
                         },
-                        "tags": [],
-                        "virtual_machine": null
+                        "tags": []
                     }
                 ],
                 "site_groups": [],
@@ -838,22 +2590,64 @@
                     {
                         "bridge": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
+                        "count_ipaddresses": 1,
                         "custom_fields": {},
-                        "description": "",
+                        "description": "Updated test100-vm Eth0 intf",
                         "display": "Eth0",
                         "display_url": "http://localhost:32768/virtualization/interfaces/1/",
-                        "enabled": true,
+                        "enabled": false,
                         "id": 1,
-                        "ip_addresses": [],
+                        "ip_addresses": [
+                            {
+                                "address": "10.188.1.100/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.188.1.100/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/19/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 19,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
                         "l2vpn_termination": null,
                         "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 4,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "mtu": 9000,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
-                        "tags": [],
+                        "tags": [
+                            "schnozzberry"
+                        ],
                         "untagged_vlan": null,
                         "virtual_machine": {
                             "description": "",
@@ -861,6 +2655,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -876,10 +2671,27 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:BC:DD:EE:FF:AA",
+                                "id": 5,
+                                "mac_address": "BB:BC:DD:EE:FF:AA"
+                            },
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 6,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -889,6 +2701,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -904,10 +2717,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -917,6 +2734,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -932,10 +2750,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -945,6 +2767,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -960,10 +2783,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -973,6 +2800,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -981,16 +2809,38 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "services": [],
-                "site_groups": [],
-                "sites": [
-                    "test-site"
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter-vm (TCP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "node-exporter-vm",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "virtualization.virtualmachine",
+                        "ports": [
+                            9100
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": []
+                    }
                 ],
+                "site_groups": [],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -1019,10 +2869,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1032,6 +2886,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1047,10 +2902,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1060,6 +2919,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1075,10 +2935,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1088,6 +2952,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1103,10 +2968,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1116,6 +2985,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1131,10 +3001,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1144,6 +3018,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -1152,16 +3027,10 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -1182,16 +3051,10 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -1212,16 +3075,10 @@
                     null
                 ],
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
                 "site_groups": [],
-                "sites": [
-                    "test-site"
-                ],
                 "status": {
                     "label": "Active",
                     "value": "active"
@@ -1256,17 +3113,26 @@
     "all": {
         "children": [
             "ungrouped",
+            "sites_site_with_contact",
             "sites_test_site2",
             "region_other_region",
             "region_parent_region",
+            "region_region_with_contact",
             "site_group_other_site_group",
             "site_group_parent_site_group",
-            "racks_Test_Rack_Site_2",
-            "rack_role_test_rack_role",
+            "site_group_site_group_with_contact",
             "device_roles_core_switch",
             "device_types_cisco_test",
             "manufacturers_cisco",
+            "status_staged",
             "status_active",
+            "tags_first",
+            "tags_second",
+            "tags_third",
+            "tags_nolookup",
+            "tags_lookup",
+            "racks_Test_Rack_Site_2",
+            "rack_role_test_rack_role",
             "device_types_nexus_parent",
             "racks_Test_Rack",
             "cluster_Test_Cluster_2",
@@ -1281,7 +3147,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_Test_Cluster_2": {
@@ -1295,7 +3162,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_type_test_cluster_type": {
@@ -1305,22 +3173,41 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "device_roles_core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "device_types_cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "device_types_nexus_parent": {
@@ -1335,7 +3222,8 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "location_parent_rack_group": {
@@ -1346,16 +3234,25 @@
     "location_test_rack_group": {
         "hosts": [
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "manufacturers_cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "rack_role_test_rack_role": {
@@ -1380,6 +3277,7 @@
     },
     "region_test_region": {
         "children": [
+            "sites_test_california",
             "sites_test_site"
         ]
     },
@@ -1388,34 +3286,88 @@
             "site_group_test_site_group"
         ]
     },
+    "site_group_test_site_group": {
+        "children": [
+            "sites_test_california"
+        ]
+    },
     "sites_test_site": {
         "children": [
+            "location_location_with_contact",
+            "location_office_building",
             "location_parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "sites_test_site2": {
+        "children": [
+            "location_office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
         ]
     },
     "status_active": {
         "hosts": [
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
+        ]
+    },
+    "status_staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
+    "tags_first": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tags_lookup": {
+        "hosts": [
+            "L2"
+        ]
+    },
+    "tags_nolookup": {
+        "hosts": [
+            "L1"
+        ]
+    },
+    "tags_second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tags_third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory-plurals.yml
@@ -1,0 +1,38 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+cache: true
+cache_timeout: 3600
+cache_plugin: jsonfile
+cache_connection: /tmp/inventory_netbox
+
+config_context: true
+plurals: true
+interfaces: true
+services: true
+
+# Enough to fit only 2 devices, so tests chunking logic
+max_uri_length: 80
+fetch_all: false
+
+group_by:
+  - sites
+  - tenants
+  - racks
+  - location
+  - rack_role
+  - tags
+  - device_roles
+  - device_types
+  - manufacturers
+  - platforms
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - status

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory.json
@@ -1,0 +1,1423 @@
+{
+    "_meta": {
+        "hostvars": {
+            "R1-Device": {
+                "asset_tag": "345678901",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "rack": "Test Rack Site 2",
+                "rack_role": "test-rack-role",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "Test Nexus One": {
+                "ansible_host": "172.16.180.12",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "nexus-parent",
+                "dns_name": "nexus.example.com",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "Ethernet1/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/1/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.11/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.11/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/3/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 3,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet1/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/2/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.12/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.12/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/4/",
+                                "dns_name": "nexus.example.com",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 4,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/6/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.12",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus One",
+                            "id": 4,
+                            "name": "Test Nexus One"
+                        },
+                        "display": "telnet (TCP/23)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
+                        "ipaddresses": [],
+                        "name": "telnet",
+                        "ports": [
+                            23
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "Test VM With Spaces": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/11/",
+                        "enabled": true,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/12/",
+                        "enabled": true,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": null,
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "Test VM With Spaces",
+                            "id": 6,
+                            "name": "Test VM With Spaces"
+                        }
+                    }
+                ],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "TestDeviceR1": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "rack": "Test Rack",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB12345678",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "test100": {
+                "asset_tag": "123456789",
+                "config_context": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/3/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/1/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 1,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/4/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [
+                            {
+                                "address": "2001::1:1/64",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/2/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet2",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "cable": null,
+                        "cable_end": "",
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "wlink1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/5/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "wlink1",
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "IEEE 802.11a",
+                            "value": "ieee802.11a"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "local_context_data": {
+                    "ntp_servers": [
+                        "pool.ntp.org"
+                    ]
+                },
+                "locations": [
+                    "test-rack-group",
+                    "parent-rack-group"
+                ],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "FAB01234567",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "ssh (TCP/22)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "ssh",
+                        "ports": [
+                            22
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    },
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "http (TCP/80)",
+                        "display_url": "http://localhost:32768/ipam/services/2/",
+                        "id": 2,
+                        "ipaddresses": [
+                            {
+                                "address": "172.16.180.1/24",
+                                "description": "",
+                                "display": "172.16.180.1/24",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 1
+                            },
+                            {
+                                "address": "2001::1:1/64",
+                                "description": "",
+                                "display": "2001::1:1/64",
+                                "family": {
+                                    "label": "IPv6",
+                                    "value": 6
+                                },
+                                "id": 2
+                            }
+                        ],
+                        "name": "http",
+                        "ports": [
+                            80
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [],
+                        "virtual_machine": null
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": [
+                    {
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "disk1",
+                        "display_url": "http://localhost:32768/virtualization/virtual-disks/1/",
+                        "id": 1,
+                        "name": "disk1",
+                        "size": 60,
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        }
+                    },
+                    {
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "disk2",
+                        "display_url": "http://localhost:32768/virtualization/virtual-disks/2/",
+                        "id": 2,
+                        "name": "disk2",
+                        "size": 110,
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        }
+                    }
+                ]
+            },
+            "test100-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "disk": 170,
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/1/",
+                        "enabled": true,
+                        "id": 1,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/2/",
+                        "enabled": true,
+                        "id": 2,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/3/",
+                        "enabled": true,
+                        "id": 3,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/4/",
+                        "enabled": true,
+                        "id": 4,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/5/",
+                        "enabled": true,
+                        "id": 5,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": [
+                    {
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "disk1",
+                        "display_url": "http://localhost:32768/virtualization/virtual-disks/1/",
+                        "id": 1,
+                        "name": "disk1",
+                        "size": 60,
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        }
+                    },
+                    {
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "disk2",
+                        "display_url": "http://localhost:32768/virtualization/virtual-disks/2/",
+                        "id": 2,
+                        "name": "disk2",
+                        "size": 110,
+                        "tags": [],
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        }
+                    }
+                ]
+            },
+            "test101-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth0",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/6/",
+                        "enabled": true,
+                        "id": 6,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth0",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth1",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/7/",
+                        "enabled": true,
+                        "id": 7,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth1",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth2",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/8/",
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth2",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth3",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/9/",
+                        "enabled": true,
+                        "id": 9,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth3",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    },
+                    {
+                        "bridge": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "Eth4",
+                        "display_url": "http://localhost:32768/virtualization/interfaces/10/",
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "mac_address": null,
+                        "mode": null,
+                        "mtu": null,
+                        "name": "Eth4",
+                        "parent": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "untagged_vlan": null,
+                        "virtual_machine": {
+                            "description": "",
+                            "display": "test101-vm",
+                            "id": 2,
+                            "name": "test101-vm"
+                        },
+                        "vrf": null
+                    }
+                ],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "test102-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "test103-vm": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "test104-vm": {
+                "cluster": "Test Cluster 2",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped",
+            "site_test_site2",
+            "region_other_region",
+            "region_parent_region",
+            "site_group_other_site_group",
+            "site_group_parent_site_group",
+            "rack_Test_Rack_Site_2",
+            "rack_role_test_rack_role",
+            "role_core_switch",
+            "device_type_cisco_test",
+            "manufacturer_cisco",
+            "status_active",
+            "device_type_nexus_parent",
+            "service_telnet",
+            "rack_Test_Rack",
+            "service_ssh",
+            "service_http",
+            "cluster_Test_Cluster_2",
+            "cluster_type_test_cluster_type",
+            "is_virtual",
+            "cluster_Test_Cluster",
+            "cluster_group_test_cluster_group"
+        ]
+    },
+    "cluster_Test_Cluster": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_Test_Cluster_2": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test104-vm"
+        ]
+    },
+    "cluster_group_test_cluster_group": {
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "cluster_type_test_cluster_type": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "device_type_cisco_test": {
+        "hosts": [
+            "R1-Device",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "device_type_nexus_parent": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "is_virtual": {
+        "hosts": [
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    },
+    "location_parent_rack_group": {
+        "children": [
+            "location_test_rack_group"
+        ]
+    },
+    "location_test_rack_group": {
+        "hosts": [
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "manufacturer_cisco": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "rack_Test_Rack": {
+        "hosts": [
+            "TestDeviceR1"
+        ]
+    },
+    "rack_Test_Rack_Site_2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "rack_role_test_rack_role": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "region_parent_region": {
+        "children": [
+            "region_test_region"
+        ]
+    },
+    "region_test_region": {
+        "children": [
+            "site_test_site"
+        ]
+    },
+    "role_core_switch": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100"
+        ]
+    },
+    "service_http": {
+        "hosts": [
+            "test100"
+        ]
+    },
+    "service_ssh": {
+        "hosts": [
+            "test100",
+            "Test VM With Spaces"
+        ]
+    },
+    "service_telnet": {
+        "hosts": [
+            "Test Nexus One"
+        ]
+    },
+    "site_group_parent_site_group": {
+        "children": [
+            "site_group_test_site_group"
+        ]
+    },
+    "site_test_site": {
+        "children": [
+            "location_parent_rack_group"
+        ],
+        "hosts": [
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm"
+        ]
+    },
+    "site_test_site2": {
+        "hosts": [
+            "R1-Device"
+        ]
+    },
+    "status_active": {
+        "hosts": [
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
+            "Test VM With Spaces",
+            "test100-vm",
+            "test101-vm",
+            "test102-vm",
+            "test103-vm",
+            "test104-vm"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory.json
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory.json
@@ -1,12 +1,739 @@
 {
     "_meta": {
         "hostvars": {
+            "Device Power Tests": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Power Tests",
+                            "id": 11,
+                            "name": "Device Power Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/18/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 18,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "Device Virtual Chassis Tests": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests",
+                            "id": 12,
+                            "name": "Device Virtual Chassis Tests"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/19/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 19,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "Device Virtual Chassis Tests 2": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device Virtual Chassis Tests 2",
+                            "id": 13,
+                            "name": "Device Virtual Chassis Tests 2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/20/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 20,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "Device With Contact": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "Device With Contact",
+                            "id": 10,
+                            "name": "Device With Contact"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/17/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 17,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "FOR_SERVICE": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/21/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 21,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter (TCP/9100, 9200)",
+                        "display_url": "http://localhost:32768/ipam/services/1/",
+                        "id": 1,
+                        "ipaddresses": [],
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "FOR_SERVICE",
+                            "id": 14,
+                            "name": "FOR_SERVICE"
+                        },
+                        "parent_object_id": 14,
+                        "parent_object_type": "dcim.device",
+                        "ports": [
+                            9100,
+                            9200
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": [
+                            {
+                                "color": "9e9e9e",
+                                "display": "Schnozzberry",
+                                "display_url": "http://localhost:32768/extras/tags/4/",
+                                "id": 4,
+                                "name": "Schnozzberry",
+                                "slug": "schnozzberry"
+                            }
+                        ]
+                    }
+                ],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "L1": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L1",
+                            "id": 15,
+                            "name": "L1"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/22/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 22,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "nolookup"
+                ],
+                "virtual_disks": []
+            },
+            "L2": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "L2",
+                            "id": 16,
+                            "name": "L2"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/23/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 23,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site2",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "lookup"
+                ],
+                "virtual_disks": []
+            },
             "R1-Device": {
                 "asset_tag": "345678901",
                 "config_context": {},
                 "custom_fields": {},
                 "device_type": "cisco-test",
-                "interfaces": [],
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "R1-Device (345678901)",
+                            "id": 3,
+                            "name": "R1-Device"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/13/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 13,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
                 "is_virtual": false,
                 "locations": [],
                 "manufacturer": "cisco",
@@ -35,13 +762,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -57,6 +785,62 @@
                         "id": 1,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/9/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 9,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/7/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 7,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.11/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -71,6 +855,7 @@
                                 "id": 3,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -87,15 +872,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "Test MAC address",
+                                "display": "AA:BB:CC:DD:EE:F0",
+                                "id": 8,
+                                "mac_address": "AA:BB:CC:DD:EE:F0"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet1/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -110,6 +906,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -118,13 +915,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 3,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -140,6 +938,62 @@
                         "id": 2,
                         "ip_addresses": [
                             {
+                                "address": "1.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "1.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/10/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 10,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "121.121.121.121/32",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "ansible-netbox-1.2.1",
+                                "display": "121.121.121.121/32",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/8/",
+                                "dns_name": "ansible-netbox-1.2.1",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 8,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": {
+                                    "label": "HSRP",
+                                    "value": "hsrp"
+                                },
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.12/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -154,6 +1008,7 @@
                                 "id": 4,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -170,15 +1025,19 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "Ethernet2/1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -193,19 +1052,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -225,18 +1101,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "test100 (123456789)",
+                                    "id": 1,
+                                    "name": "test100"
+                                },
+                                "display": "wlink1",
+                                "id": 5,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -251,6 +1146,76 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "Updated child interface from parent device",
+                        "device": {
+                            "description": "",
+                            "display": "Test Nexus Child One",
+                            "id": 5,
+                            "name": "Test Nexus Child One"
+                        },
+                        "display": "Ethernet2/2",
+                        "display_url": "http://localhost:32768/dcim/interfaces/15/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 15,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "Ethernet2/2",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -270,33 +1235,7 @@
                 ],
                 "role": "core-switch",
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "Test Nexus One",
-                            "id": 4,
-                            "name": "Test Nexus One"
-                        },
-                        "display": "telnet (TCP/23)",
-                        "display_url": "http://localhost:32768/ipam/services/3/",
-                        "id": 3,
-                        "ipaddresses": [],
-                        "name": "telnet",
-                        "ports": [
-                            23
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    }
-                ],
+                "services": [],
                 "site": "test-site",
                 "site_groups": [],
                 "status": {
@@ -325,10 +1264,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -338,6 +1281,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -353,10 +1297,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -366,6 +1314,7 @@
                             "id": 6,
                             "name": "Test VM With Spaces"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
@@ -373,33 +1322,7 @@
                 "locations": [],
                 "regions": [],
                 "serial": "",
-                "services": [
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": null,
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/4/",
-                        "id": 4,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": {
-                            "description": "",
-                            "display": "Test VM With Spaces",
-                            "id": 6,
-                            "name": "Test VM With Spaces"
-                        }
-                    }
-                ],
+                "services": [],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -436,7 +1359,146 @@
                 "tags": [],
                 "virtual_disks": []
             },
+            "Virtual Machine With Contact": {
+                "cluster": "Test Cluster",
+                "cluster_group": "test-cluster-group",
+                "cluster_type": "test-cluster-type",
+                "config_context": {},
+                "custom_fields": {},
+                "interfaces": [],
+                "is_virtual": true,
+                "locations": [],
+                "regions": [],
+                "serial": "",
+                "services": [],
+                "site_groups": [],
+                "status": {
+                    "label": "Active",
+                    "value": "active"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573": {
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+                            "id": 9,
+                            "name": "b6b98683-14a0-4991-b4ac-b88e5fe81573"
+                        },
+                        "display": "SFP+ (10GE)",
+                        "display_url": "http://localhost:32768/dcim/interfaces/8/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 8,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "SFP+ (10GE)",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "SFP+ (10GE)",
+                            "value": "10gbase-x-sfpp"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    }
+                ],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [],
+                "virtual_disks": []
+            },
+            "issue-242": {
+                "asset_tag": "Null",
+                "config_context": {},
+                "custom_fields": {},
+                "device_type": "cisco-test",
+                "interfaces": [],
+                "is_virtual": false,
+                "locations": [],
+                "manufacturer": "cisco",
+                "regions": [
+                    "test-region",
+                    "parent-region"
+                ],
+                "role": "core-switch",
+                "serial": "",
+                "services": [],
+                "site": "test-site",
+                "site_groups": [],
+                "status": {
+                    "label": "Staged",
+                    "value": "staged"
+                },
+                "tags": [
+                    "first",
+                    "second",
+                    "third"
+                ],
+                "virtual_disks": []
+            },
             "test100": {
+                "ansible_host": "2001::1:1",
                 "asset_tag": "123456789",
                 "config_context": {
                     "ntp_servers": [
@@ -449,13 +1511,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 2,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -471,6 +1534,31 @@
                         "id": 3,
                         "ip_addresses": [
                             {
+                                "address": "10.255.255.1/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.255.255.1/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/6/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 6,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "172.16.180.1/24",
                                 "comments": "",
                                 "custom_fields": {},
@@ -485,6 +1573,7 @@
                                 "id": 1,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -501,15 +1590,26 @@
                         "link_peers": [],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 1,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -524,6 +1624,7 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -532,13 +1633,14 @@
                     {
                         "_occupied": false,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
+                        "cable_end": null,
                         "connected_endpoints": null,
                         "connected_endpoints_reachable": null,
                         "connected_endpoints_type": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 1,
+                        "count_ipaddresses": 6,
                         "custom_fields": {},
                         "description": "",
                         "device": {
@@ -554,6 +1656,131 @@
                         "id": 4,
                         "ip_addresses": [
                             {
+                                "address": "10.10.0.1/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.1/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/17/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 17,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.0.2/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.0.2/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/22/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 22,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.30/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.30/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/16/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 16,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "10.10.200.31/16",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.10.200.31/16",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/21/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 21,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
+                                "address": "192.168.100.2/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "192.168.100.2/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/18/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 18,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            },
+                            {
                                 "address": "2001::1:1/64",
                                 "comments": "",
                                 "custom_fields": {},
@@ -568,6 +1795,7 @@
                                 "id": 2,
                                 "nat_inside": null,
                                 "nat_outside": [],
+                                "owner": null,
                                 "role": null,
                                 "status": {
                                     "label": "Active",
@@ -583,16 +1811,38 @@
                         "lag": null,
                         "link_peers": [],
                         "link_peers_type": null,
-                        "mac_address": null,
+                        "mac_address": "AA:AB:CC:DD:EE:FF",
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "AA:AB:CC:DD:EE:FF",
+                                "id": 2,
+                                "mac_address": "AA:AB:CC:DD:EE:FF"
+                            },
+                            {
+                                "description": "",
+                                "display": "AA:BB:CC:DD:EE:FF",
+                                "id": 3,
+                                "mac_address": "AA:BB:CC:DD:EE:FF"
+                            }
+                        ],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "GigabitEthernet2",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": {
+                            "description": "",
+                            "display": "AA:AB:CC:DD:EE:FF",
+                            "id": 2,
+                            "mac_address": "AA:AB:CC:DD:EE:FF"
+                        },
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -607,19 +1857,36 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
                         "wwn": null
                     },
                     {
-                        "_occupied": false,
+                        "_occupied": true,
                         "bridge": null,
+                        "bridge_interfaces": [],
                         "cable": null,
-                        "cable_end": "",
-                        "connected_endpoints": null,
-                        "connected_endpoints_reachable": null,
-                        "connected_endpoints_type": null,
+                        "cable_end": null,
+                        "connected_endpoints": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
+                        "connected_endpoints_reachable": true,
+                        "connected_endpoints_type": "dcim.interface",
                         "count_fhrp_groups": 0,
                         "count_ipaddresses": 0,
                         "custom_fields": {},
@@ -639,18 +1906,37 @@
                         "l2vpn_termination": null,
                         "label": "",
                         "lag": null,
-                        "link_peers": [],
+                        "link_peers": [
+                            {
+                                "_occupied": true,
+                                "cable": null,
+                                "description": "",
+                                "device": {
+                                    "description": "",
+                                    "display": "Test Nexus One",
+                                    "id": 4,
+                                    "name": "Test Nexus One"
+                                },
+                                "display": "wlink1",
+                                "id": 6,
+                                "name": "wlink1"
+                            }
+                        ],
                         "link_peers_type": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mark_connected": false,
                         "mgmt_only": false,
                         "mode": null,
                         "module": null,
                         "mtu": null,
                         "name": "wlink1",
+                        "owner": null,
                         "parent": null,
                         "poe_mode": null,
                         "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "rf_channel": null,
                         "rf_channel_frequency": null,
                         "rf_channel_width": null,
@@ -665,6 +1951,391 @@
                         },
                         "untagged_vlan": null,
                         "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": {
+                            "display": "Wireless Network One",
+                            "display_url": "http://localhost:32768/wireless/wireless-links/2/",
+                            "id": 2,
+                            "ssid": "Wireless Network One"
+                        },
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "port-channel1",
+                        "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 10,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "port-channel1",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "Link Aggregation Group (LAG)",
+                            "value": "lag"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet3",
+                        "display_url": "http://localhost:32768/dcim/interfaces/11/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 11,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet3",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet21",
+                        "display_url": "http://localhost:32768/dcim/interfaces/12/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 12,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": true,
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet21",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [
+                            {
+                                "description": "",
+                                "display": "Data (200)",
+                                "id": 2,
+                                "name": "Data",
+                                "vid": 200
+                            },
+                            {
+                                "description": "",
+                                "display": "VoIP (300)",
+                                "id": 3,
+                                "name": "VoIP",
+                                "vid": 300
+                            }
+                        ],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": {
+                            "description": "",
+                            "display": "Wireless (100)",
+                            "id": 1,
+                            "name": "Wireless",
+                            "vid": 100
+                        },
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": false,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet4",
+                        "display_url": "http://localhost:32768/dcim/interfaces/14/",
+                        "duplex": null,
+                        "enabled": false,
+                        "id": 14,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": {
+                            "_occupied": false,
+                            "cable": null,
+                            "device": {
+                                "display": "test100 (123456789)",
+                                "display_url": "http://localhost:32768/dcim/devices/1/",
+                                "id": 1,
+                                "name": "test100"
+                            },
+                            "display": "port-channel1",
+                            "display_url": "http://localhost:32768/dcim/interfaces/10/",
+                            "id": 10,
+                            "name": "port-channel1"
+                        },
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": false,
+                        "mgmt_only": false,
+                        "mode": {
+                            "label": "Access",
+                            "value": "access"
+                        },
+                        "module": null,
+                        "mtu": 1600,
+                        "name": "GigabitEthernet4",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
+                        "vrf": null,
+                        "wireless_lans": [],
+                        "wireless_link": null,
+                        "wwn": null
+                    },
+                    {
+                        "_occupied": true,
+                        "bridge": null,
+                        "bridge_interfaces": [],
+                        "cable": null,
+                        "cable_end": null,
+                        "connected_endpoints": null,
+                        "connected_endpoints_reachable": null,
+                        "connected_endpoints_type": null,
+                        "count_fhrp_groups": 0,
+                        "count_ipaddresses": 0,
+                        "custom_fields": {},
+                        "description": "",
+                        "device": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "display": "GigabitEthernet5",
+                        "display_url": "http://localhost:32768/dcim/interfaces/16/",
+                        "duplex": null,
+                        "enabled": true,
+                        "id": 16,
+                        "ip_addresses": [],
+                        "l2vpn_termination": null,
+                        "label": "",
+                        "lag": null,
+                        "link_peers": [],
+                        "link_peers_type": null,
+                        "mac_address": null,
+                        "mac_addresses": [],
+                        "mark_connected": true,
+                        "mgmt_only": false,
+                        "mode": null,
+                        "module": null,
+                        "mtu": null,
+                        "name": "GigabitEthernet5",
+                        "owner": null,
+                        "parent": null,
+                        "poe_mode": null,
+                        "poe_type": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
+                        "rf_channel": null,
+                        "rf_channel_frequency": null,
+                        "rf_channel_width": null,
+                        "rf_role": null,
+                        "speed": null,
+                        "tagged_vlans": [],
+                        "tags": [],
+                        "tx_power": null,
+                        "type": {
+                            "label": "1000BASE-T (1GE)",
+                            "value": "1000base-t"
+                        },
+                        "untagged_vlan": null,
+                        "vdcs": [],
+                        "vlan_translation_policy": null,
                         "vrf": null,
                         "wireless_lans": [],
                         "wireless_link": null,
@@ -682,6 +2353,8 @@
                     "parent-rack-group"
                 ],
                 "manufacturer": "cisco",
+                "primary_ip4": "172.16.180.1",
+                "primary_ip6": "2001::1:1",
                 "regions": [
                     "test-region",
                     "parent-region"
@@ -693,40 +2366,9 @@
                         "comments": "",
                         "custom_fields": {},
                         "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "ssh (TCP/22)",
-                        "display_url": "http://localhost:32768/ipam/services/1/",
-                        "id": 1,
-                        "ipaddresses": [],
-                        "name": "ssh",
-                        "ports": [
-                            22
-                        ],
-                        "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
-                        },
-                        "tags": [],
-                        "virtual_machine": null
-                    },
-                    {
-                        "comments": "",
-                        "custom_fields": {},
-                        "description": "",
-                        "device": {
-                            "description": "",
-                            "display": "test100 (123456789)",
-                            "id": 1,
-                            "name": "test100"
-                        },
-                        "display": "http (TCP/80)",
-                        "display_url": "http://localhost:32768/ipam/services/2/",
-                        "id": 2,
+                        "display": "node-exporter (UDP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/3/",
+                        "id": 3,
                         "ipaddresses": [
                             {
                                 "address": "172.16.180.1/24",
@@ -737,28 +2379,26 @@
                                     "value": 4
                                 },
                                 "id": 1
-                            },
-                            {
-                                "address": "2001::1:1/64",
-                                "description": "",
-                                "display": "2001::1:1/64",
-                                "family": {
-                                    "label": "IPv6",
-                                    "value": 6
-                                },
-                                "id": 2
                             }
                         ],
-                        "name": "http",
+                        "name": "node-exporter",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100 (123456789)",
+                            "id": 1,
+                            "name": "test100"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "dcim.device",
                         "ports": [
-                            80
+                            9100
                         ],
                         "protocol": {
-                            "label": "TCP",
-                            "value": "tcp"
+                            "label": "UDP",
+                            "value": "udp"
                         },
-                        "tags": [],
-                        "virtual_machine": null
+                        "tags": []
                     }
                 ],
                 "site": "test-site",
@@ -776,6 +2416,7 @@
                         "display_url": "http://localhost:32768/virtualization/virtual-disks/1/",
                         "id": 1,
                         "name": "disk1",
+                        "owner": null,
                         "size": 60,
                         "tags": [],
                         "virtual_machine": {
@@ -792,6 +2433,7 @@
                         "display_url": "http://localhost:32768/virtualization/virtual-disks/2/",
                         "id": 2,
                         "name": "disk2",
+                        "owner": null,
                         "size": 110,
                         "tags": [],
                         "virtual_machine": {
@@ -814,22 +2456,64 @@
                     {
                         "bridge": null,
                         "count_fhrp_groups": 0,
-                        "count_ipaddresses": 0,
+                        "count_ipaddresses": 1,
                         "custom_fields": {},
-                        "description": "",
+                        "description": "Updated test100-vm Eth0 intf",
                         "display": "Eth0",
                         "display_url": "http://localhost:32768/virtualization/interfaces/1/",
-                        "enabled": true,
+                        "enabled": false,
                         "id": 1,
-                        "ip_addresses": [],
+                        "ip_addresses": [
+                            {
+                                "address": "10.188.1.100/24",
+                                "comments": "",
+                                "custom_fields": {},
+                                "description": "",
+                                "display": "10.188.1.100/24",
+                                "display_url": "http://localhost:32768/ipam/ip-addresses/19/",
+                                "dns_name": "",
+                                "family": {
+                                    "label": "IPv4",
+                                    "value": 4
+                                },
+                                "id": 19,
+                                "nat_inside": null,
+                                "nat_outside": [],
+                                "owner": null,
+                                "role": null,
+                                "status": {
+                                    "label": "Active",
+                                    "value": "active"
+                                },
+                                "tags": [],
+                                "tenant": null,
+                                "vrf": null
+                            }
+                        ],
                         "l2vpn_termination": null,
                         "mac_address": null,
-                        "mode": null,
-                        "mtu": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 4,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
+                        "mode": {
+                            "label": "Tagged",
+                            "value": "tagged"
+                        },
+                        "mtu": 9000,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
-                        "tags": [],
+                        "tags": [
+                            "schnozzberry"
+                        ],
                         "untagged_vlan": null,
                         "virtual_machine": {
                             "description": "",
@@ -837,6 +2521,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -852,10 +2537,27 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [
+                            {
+                                "description": "",
+                                "display": "BB:BC:DD:EE:FF:AA",
+                                "id": 5,
+                                "mac_address": "BB:BC:DD:EE:FF:AA"
+                            },
+                            {
+                                "description": "",
+                                "display": "BB:CC:DD:EE:FF:AA",
+                                "id": 6,
+                                "mac_address": "BB:CC:DD:EE:FF:AA"
+                            }
+                        ],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -865,6 +2567,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -880,10 +2583,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -893,6 +2600,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -908,10 +2616,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -921,6 +2633,7 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -936,10 +2649,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -949,18 +2666,43 @@
                             "id": 1,
                             "name": "test100-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
-                "services": [],
-                "site": "test-site",
+                "services": [
+                    {
+                        "comments": "",
+                        "custom_fields": {},
+                        "description": "",
+                        "display": "node-exporter-vm (TCP/9100)",
+                        "display_url": "http://localhost:32768/ipam/services/4/",
+                        "id": 4,
+                        "ipaddresses": [],
+                        "name": "node-exporter-vm",
+                        "owner": null,
+                        "parent": {
+                            "description": "",
+                            "display": "test100-vm",
+                            "id": 1,
+                            "name": "test100-vm"
+                        },
+                        "parent_object_id": 1,
+                        "parent_object_type": "virtualization.virtualmachine",
+                        "ports": [
+                            9100
+                        ],
+                        "protocol": {
+                            "label": "TCP",
+                            "value": "tcp"
+                        },
+                        "tags": []
+                    }
+                ],
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -975,6 +2717,7 @@
                         "display_url": "http://localhost:32768/virtualization/virtual-disks/1/",
                         "id": 1,
                         "name": "disk1",
+                        "owner": null,
                         "size": 60,
                         "tags": [],
                         "virtual_machine": {
@@ -991,6 +2734,7 @@
                         "display_url": "http://localhost:32768/virtualization/virtual-disks/2/",
                         "id": 2,
                         "name": "disk2",
+                        "owner": null,
                         "size": 110,
                         "tags": [],
                         "virtual_machine": {
@@ -1022,10 +2766,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth0",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1035,6 +2783,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1050,10 +2799,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth1",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1063,6 +2816,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1078,10 +2832,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth2",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1091,6 +2849,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1106,10 +2865,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth3",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1119,6 +2882,7 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     },
                     {
@@ -1134,10 +2898,14 @@
                         "ip_addresses": [],
                         "l2vpn_termination": null,
                         "mac_address": null,
+                        "mac_addresses": [],
                         "mode": null,
                         "mtu": null,
                         "name": "Eth4",
+                        "owner": null,
                         "parent": null,
+                        "primary_mac_address": null,
+                        "qinq_svlan": null,
                         "tagged_vlans": [],
                         "tags": [],
                         "untagged_vlan": null,
@@ -1147,18 +2915,15 @@
                             "id": 2,
                             "name": "test101-vm"
                         },
+                        "vlan_translation_policy": null,
                         "vrf": null
                     }
                 ],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1176,13 +2941,9 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1200,13 +2961,9 @@
                 "interfaces": [],
                 "is_virtual": true,
                 "locations": [],
-                "regions": [
-                    "test-region",
-                    "parent-region"
-                ],
+                "regions": [],
                 "serial": "",
                 "services": [],
-                "site": "test-site",
                 "site_groups": [],
                 "status": {
                     "label": "Active",
@@ -1239,27 +2996,35 @@
     "all": {
         "children": [
             "ungrouped",
+            "site_site_with_contact",
             "site_test_site2",
             "region_other_region",
             "region_parent_region",
+            "region_region_with_contact",
             "site_group_other_site_group",
             "site_group_parent_site_group",
-            "rack_Test_Rack_Site_2",
-            "rack_role_test_rack_role",
+            "site_group_site_group_with_contact",
             "role_core_switch",
             "device_type_cisco_test",
             "manufacturer_cisco",
+            "status_staged",
             "status_active",
+            "service_node_exporter",
+            "tag_first",
+            "tag_second",
+            "tag_third",
+            "tag_nolookup",
+            "tag_lookup",
+            "rack_Test_Rack_Site_2",
+            "rack_role_test_rack_role",
             "device_type_nexus_parent",
-            "service_telnet",
             "rack_Test_Rack",
-            "service_ssh",
-            "service_http",
             "cluster_Test_Cluster_2",
             "cluster_type_test_cluster_type",
             "is_virtual",
             "cluster_Test_Cluster",
-            "cluster_group_test_cluster_group"
+            "cluster_group_test_cluster_group",
+            "service_node_exporter_vm"
         ]
     },
     "cluster_Test_Cluster": {
@@ -1267,7 +3032,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_Test_Cluster_2": {
@@ -1281,7 +3047,8 @@
             "test100-vm",
             "test101-vm",
             "test102-vm",
-            "test103-vm"
+            "test103-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "cluster_type_test_cluster_type": {
@@ -1291,14 +3058,24 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "device_type_cisco_test": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "device_type_nexus_parent": {
@@ -1313,7 +3090,8 @@
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
         ]
     },
     "location_parent_rack_group": {
@@ -1324,16 +3102,25 @@
     "location_test_rack_group": {
         "hosts": [
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "manufacturer_cisco": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
+            "test100",
+            "TestDeviceR1"
         ]
     },
     "rack_Test_Rack": {
@@ -1358,31 +3145,36 @@
     },
     "region_test_region": {
         "children": [
+            "site_test_california",
             "site_test_site"
         ]
     },
     "role_core_switch": {
         "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
-            "test100"
-        ]
-    },
-    "service_http": {
-        "hosts": [
-            "test100"
-        ]
-    },
-    "service_ssh": {
-        "hosts": [
             "test100",
-            "Test VM With Spaces"
+            "TestDeviceR1"
         ]
     },
-    "service_telnet": {
+    "service_node_exporter": {
         "hosts": [
-            "Test Nexus One"
+            "FOR_SERVICE",
+            "test100"
+        ]
+    },
+    "service_node_exporter_vm": {
+        "hosts": [
+            "test100-vm"
         ]
     },
     "site_group_parent_site_group": {
@@ -1390,34 +3182,88 @@
             "site_group_test_site_group"
         ]
     },
+    "site_group_test_site_group": {
+        "children": [
+            "site_test_california"
+        ]
+    },
     "site_test_site": {
         "children": [
+            "location_location_with_contact",
+            "location_office_building",
             "location_parent_rack_group"
         ],
         "hosts": [
-            "test100-vm",
-            "test101-vm",
-            "test102-vm",
-            "test103-vm"
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1"
         ]
     },
     "site_test_site2": {
+        "children": [
+            "location_office_building"
+        ],
         "hosts": [
+            "L2",
             "R1-Device"
         ]
     },
     "status_active": {
         "hosts": [
+            "Device Power Tests",
+            "Device Virtual Chassis Tests",
+            "Device Virtual Chassis Tests 2",
             "R1-Device",
             "Test Nexus One",
-            "TestDeviceR1",
             "test100",
+            "TestDeviceR1",
             "Test VM With Spaces",
             "test100-vm",
             "test101-vm",
             "test102-vm",
             "test103-vm",
-            "test104-vm"
+            "test104-vm",
+            "Virtual Machine With Contact"
+        ]
+    },
+    "status_staged": {
+        "hosts": [
+            "b6b98683-14a0-4991-b4ac-b88e5fe81573",
+            "Device With Contact",
+            "FOR_SERVICE",
+            "issue-242",
+            "L1",
+            "L2"
+        ]
+    },
+    "tag_first": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tag_lookup": {
+        "hosts": [
+            "L2"
+        ]
+    },
+    "tag_nolookup": {
+        "hosts": [
+            "L1"
+        ]
+    },
+    "tag_second": {
+        "hosts": [
+            "issue-242"
+        ]
+    },
+    "tag_third": {
+        "hosts": [
+            "issue-242"
         ]
     }
 }

--- a/tests/integration/targets/inventory-v4.5/files/test-inventory.yml
+++ b/tests/integration/targets/inventory-v4.5/files/test-inventory.yml
@@ -1,0 +1,31 @@
+---
+plugin: netbox.netbox.nb_inventory
+api_endpoint: http://localhost:32768
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+config_context: true
+plurals: false
+interfaces: true
+virtual_disks: true
+services: true
+
+group_by:
+  - site
+  - tenant
+  - rack
+  - location
+  - rack_role
+  - tag
+  - role
+  - device_type
+  - manufacturer
+  - platform
+  - region
+  - site_group
+  - cluster
+  - cluster_group
+  - cluster_type
+  - is_virtual
+  - services
+  - status

--- a/tests/integration/targets/inventory-v4.5/runme.sh
+++ b/tests/integration/targets/inventory-v4.5/runme.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -o xtrace # Print commands as they're run
+set -o errexit # abort on nonzero exitstatus
+set -o nounset # abort on unbound variable
+set -o pipefail # don't hide errors within pipes
+
+# Directory of this script
+SCRIPT_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+RUNME_CONFIG="$SCRIPT_DIR/runme_config"
+INVENTORIES_DIR="$SCRIPT_DIR/files"
+
+# Load runme_config, if exists - the only way to pass environment when run through ansible-test
+if [[ -f "$RUNME_CONFIG" ]]
+then
+    source "$RUNME_CONFIG"
+fi
+
+declare -a COMPARE_OPTIONS # empty array
+
+# Check if NETBOX_VERSION has been set by runme_config, and if so, pass to compare_inventory_json.py
+if [[ "${NETBOX_VERSION:-}" == "v4.1" ]]
+then
+    COMPARE_OPTIONS+=(--netbox-version "${NETBOX_VERSION}")
+fi
+
+# OUTPUT_DIR is set by ansible-test
+# OUTPUT_INVENTORY_JSON is only set if running hacking/update_test_inventories.sh to update the test diff data
+if [[ -n "${OUTPUT_INVENTORY_JSON:-}" ]]
+then
+    OUTPUT_DIR="$OUTPUT_INVENTORY_JSON"
+
+    # Clean up JSON fields we don't want to store and compare against in tests (creation times, etc.)
+    COMPARE_OPTIONS+=(--write)
+fi
+
+echo OUTPUT_DIR="$OUTPUT_DIR"
+
+inventory () {
+    if [[ -n "${OUTPUT_INVENTORY_JSON:-}" ]]
+    then
+        # Running for the purpose of updating test data
+        ansible-inventory "$@"
+    else
+        # Running inside ansible-test
+        # Run through python.py just to make sure we've definitely got the coverage environment set up
+        # Just running ansible-inventory directly may not actually find the right one in PATH
+        python.py "$(command -v ansible-inventory)" "$@"
+    fi
+}
+
+
+RESULT=0
+
+for INVENTORY in "$INVENTORIES_DIR"/*.yml
+do
+    NAME="$(basename "$INVENTORY")"
+    NAME_WITHOUT_EXTENSION="${NAME%.yml}"
+
+    OUTPUT_JSON="$OUTPUT_DIR/$NAME_WITHOUT_EXTENSION.json"
+    inventory -vvvv --list --inventory "$INVENTORY" --output="$OUTPUT_JSON"
+
+    # Compare the output
+    if ! "$SCRIPT_DIR/compare_inventory_json.py" "${COMPARE_OPTIONS[@]}" "$INVENTORIES_DIR/$NAME_WITHOUT_EXTENSION.json" "$OUTPUT_JSON"
+    then
+        # Returned non-zero status
+        RESULT=1
+    fi
+
+done
+
+exit $RESULT

--- a/tests/integration/targets/inventory-v4.5/runme_config.template
+++ b/tests/integration/targets/inventory-v4.5/runme_config.template
@@ -1,0 +1,6 @@
+# runme_config is source'd by runme.sh to set environment variables used to modify the test against different versions of NetBox.
+# .travis.yml uses render_config.sh to generate it from runme_config.template
+# There is no other way to pass environment variables to a runme.sh integration test.
+# (integration_config.yml files are only helpful to ansible yaml-based tests)
+
+export NETBOX_VERSION=${VERSION}

--- a/tests/integration/targets/regression-v4.5/tasks/main.yml
+++ b/tests/integration/targets/regression-v4.5/tasks/main.yml
@@ -1,0 +1,301 @@
+---
+##
+##
+### TEST NETBOX CONNECTION FAILURE
+##
+##
+- name: TEST NETBOX CONNECTION FAILURE
+  connection: local
+  block:
+    - name: 1 - Device with required information
+      netbox.netbox.netbox_device:
+        netbox_url: http://some-random-invalid-URL
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: R1
+          device_type: Cisco Test
+          device_role: Core Switch
+          site: Test Site
+          status: Staged
+        state: present
+      register: test_one
+      ignore_errors: true
+
+    - name: 1 - ASSERT
+      ansible.builtin.assert:
+        that:
+          - test_one is failed
+          - test_one['msg'] == "Failed to establish connection to NetBox API"
+
+    - name: 2 - Check to see if netbox_prefix with parent defined will pass via check-mode
+      netbox.netbox.netbox_prefix:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          parent: 10.10.0.0/16
+          prefix_length: 24
+        first_available: true
+        state: present
+      register: test_two
+      check_mode: true
+
+    - name: 2 - ASSERT
+      ansible.builtin.assert:
+        that:
+          - test_two is changed
+          - test_two['msg'] == "New prefix created within 10.10.0.0/16"
+
+    - name: "3 - Add device with tags - Setup device to test #242"
+      netbox.netbox.netbox_device:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: issue-242
+          device_type: Cisco Test
+          device_role: Core Switch
+          site: Test Site
+          status: Staged
+          tags:
+            - slug: first
+            - slug: second
+
+    - name: "4 - Add device with tags out of order - shouldn't change - Tests #242 is fixed"
+      netbox.netbox.netbox_device:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: issue-242
+          device_type: Cisco Test
+          device_role: Core Switch
+          site: Test Site
+          status: Staged
+          tags:
+            - slug: second
+            - slug: first
+      register: test_four
+      diff: true
+
+    - name: "4 - Assert not changed - Tests #242 is fixed"
+      ansible.builtin.assert:
+        that:
+          - not test_four["changed"]
+
+    - name: "5 - Add device with extra tag - Tests #242 is fixed"
+      netbox.netbox.netbox_device:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: issue-242
+          device_type: Cisco Test
+          device_role: Core Switch
+          site: Test Site
+          status: Staged
+          asset_tag: "1234"
+          tags:
+            - slug: second
+            - slug: third
+            - slug: first
+      register: test_five
+      diff: true
+
+    - name: "5 - Assert added tag - Tests #242 is fixed"
+      ansible.builtin.assert:
+        that:
+          - test_five is changed
+          - test_five["diff"]["after"]["tags"] is defined
+          - test_five["device"]["tags"] is defined
+
+    - name: "6 - Loop through and add interface templates to different device interface templates - Fixes #282"
+      netbox.netbox.netbox_device_interface_template:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: SFP+ (10GE)
+          type: SFP+ (10GE)
+          device_type: "{{ item }}"
+      register: test_six
+      loop:
+        - Cisco Test
+        - Arista Test
+        - Nexus Child
+        - Nexus Parent
+
+    - name: "6 - Assert device type is correct - Fixes #282"
+      ansible.builtin.assert:
+        that:
+          - test_six.results[0]["diff"]["before"]["state"] == "absent"
+          - test_six.results[0]["diff"]["after"]["state"] == "present"
+          - test_six.results[0]["interface_template"]["device_type"] == 1
+          - test_six.results[1]["diff"]["before"]["state"] == "absent"
+          - test_six.results[1]["diff"]["after"]["state"] == "present"
+          - test_six.results[1]["interface_template"]["device_type"] == 2
+          - test_six.results[2]["diff"]["before"]["state"] == "absent"
+          - test_six.results[2]["diff"]["after"]["state"] == "present"
+          - test_six.results[2]["interface_template"]["device_type"] == 4
+          - test_six.results[3]["diff"]["before"]["state"] == "absent"
+          - test_six.results[3]["diff"]["after"]["state"] == "present"
+          - test_six.results[3]["interface_template"]["device_type"] == 3
+
+    - name: 7 - Don't prevent updates to other params if tags are specified
+      netbox.netbox.netbox_device:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: issue-242
+          device_type: Cisco Test
+          device_role: Core Switch
+          site: Test Site
+          status: Staged
+          asset_tag: "Null"
+          tags:
+            # Changed these for issue #407 to be IDs
+            - 2
+            - 3
+            - 1
+      register: test_seven
+
+    - name: "5 - Assert added tag - Tests #242 is fixed"
+      ansible.builtin.assert:
+        that:
+          - test_seven is changed
+          - test_seven["diff"]["after"]["asset_tag"] == "Null"
+          - test_seven["device"]["asset_tag"] == "Null"
+
+    - name: Add ip address to netbox and don't assign it to a device (Issue 372)
+      netbox.netbox.netbox_ip_address:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          address: 10.255.255.1/24
+        query_params:
+          - address
+          - vrf
+        state: present
+
+    - name: Update same ip address to attach to a device interface (Issue 372)
+      netbox.netbox.netbox_ip_address:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          address: 10.255.255.1/24
+          assigned_object:
+            device: test100
+            name: GigabitEthernet1
+        query_params:
+          - address
+          - vrf
+        state: present
+      register: query_params_372
+
+    - name: Assert ip address was updated and added to device interface
+      ansible.builtin.assert:
+        that:
+          - query_params_372 is changed
+          - query_params_372['msg'] == 'ip_address 10.255.255.1/24 updated'
+          - query_params_372['diff']['after']['assigned_object'] == 3
+          - query_params_372['diff']['after']['assigned_object_id'] == 3
+          - query_params_372['diff']['after']['assigned_object_type'] == 'dcim.interface'
+
+    - name: Validate failure due to invalid child params provided by user
+      netbox.netbox.netbox_cable:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          termination_a_type: dcim.interface
+          termination_a:
+            device: test100
+            name: GigabitEthernet1
+          termination_b_type: circuits.circuittermination
+          termination_b:
+            name: XYZ987
+      ignore_errors: true
+      register: test_results
+
+    - name: "Issue #415 - Assert failure message shows the allowed params and what the user provided"
+      ansible.builtin.assert:
+        that:
+          - test_results is failed
+          - 'test_results["msg"] == "One or more of the kwargs provided are invalid for circuits.circuittermination, provided kwargs: name. Acceptable kwargs: circuit,
+            term_side"'
+
+    - name: "Issue #432 - Make sure same IPs get assigned to different device interfaces"
+      netbox.netbox.netbox_ip_address:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data: "{{ item }}"
+      loop: "{{ data }}"
+      register: test_results
+      vars:
+        data:
+          - address: 121.121.121.121/32
+            assigned_object:
+              device: Test Nexus One
+              name: Ethernet1/1
+            description: ansible-netbox-1.2.1
+            dns_name: ansible-netbox-1.2.1
+            role: HSRP
+            status: Active
+          - address: 121.121.121.121/32
+            assigned_object:
+              device: Test Nexus Child One
+              name: Ethernet2/1
+            description: ansible-netbox-1.2.1
+            dns_name: ansible-netbox-1.2.1
+            role: HSRP
+            status: Active
+          - address: 1.121.121.121/32
+            assigned_object:
+              device: Test Nexus One
+              name: Ethernet1/1
+            description: ansible-netbox-1.2.1
+            dns_name: ansible-netbox-1.2.1
+            role: HSRP
+            status: Active
+          - address: 1.121.121.121/32
+            assigned_object:
+              device: Test Nexus Child One
+              name: Ethernet2/1
+            description: ansible-netbox-1.2.1
+            dns_name: ansible-netbox-1.2.1
+            role: HSRP
+            status: Active
+
+    - name: "ASSERT Issue #432 changes reflect correct device"
+      ansible.builtin.assert:
+        that:
+          - test_results | community.general.json_query('results[?ip_address.address==`1.121.121.121/32`]') | length == 2
+          - test_results | community.general.json_query('results[?ip_address.address==`121.121.121.121/32`]') | length == 2
+
+    - name: "Issue #958 - Make sure we can add same location with different sites"
+      netbox.netbox.netbox_location:
+        netbox_url: http://localhost:32768
+        netbox_token: "0123456789abcdef0123456789abcdef01234567"
+        data:
+          name: Office Building
+          site: "{{ item }}"
+      loop:
+        - Test Site
+        - Test Site2
+      register: test_results
+
+    - name: "ASSERT ISSUE #957 - Location has different IDs"
+      ansible.builtin.assert:
+        that:
+          - test_results.results.0.location.id != test_results.results.1.location.id
+
+- name: "Issue #1413 - Update interface primary MAC by ID"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet2
+      primary_mac_address:
+        id: 3
+    state: present
+  register: test_results
+
+- name: "ASSERT Issue #1413"
+  ansible.builtin.assert:
+    that:
+      - test_results['interface']['primary_mac_address'] == 3

--- a/tests/integration/targets/v4.5/tasks/main.yml
+++ b/tests/integration/targets/v4.5/tasks/main.yml
@@ -1,0 +1,776 @@
+---
+- name: NETBOX_DEVICE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_device.yml
+    apply:
+      tags:
+        - netbox_device
+  tags:
+    - netbox_device
+
+- name: NETBOX_DEVICE_INTERFACE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_device_interface.yml
+    apply:
+      tags:
+        - netbox_device_interface
+  tags:
+    - netbox_device_interface
+
+- name: NETBOX_DEVICE_INTERFACE_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_device_interface_template.yml
+    apply:
+      tags:
+        - netbox_device_interface_template
+  tags:
+    - netbox_device_interface_template
+
+- name: NETBOX_IP_ADDRESS TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_ip_address.yml
+    apply:
+      tags:
+        - netbox_ip_address
+  tags:
+    - netbox_ip_address
+
+- name: NETBOX_PREFIX TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_prefix.yml
+    apply:
+      tags:
+        - netbox_prefix
+  tags:
+    - netbox_prefix
+
+- name: NETBOX_SITE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_site.yml
+    apply:
+      tags:
+        - netbox_site
+  tags:
+    - netbox_site
+
+- name: NETBOX_SITE_GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_site_group.yml
+    apply:
+      tags:
+        - netbox_site_group
+  tags:
+    - netbox_site_group
+
+- name: NETBOX_CONTACT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_contact.yml
+    apply:
+      tags:
+        - netbox_contact
+  tags:
+    - netbox_contact
+
+- name: NETBOX_CONTACT_ASSIGNMENT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_contact_assignment.yml
+    apply:
+      tags:
+        - netbox_contact_assignment
+  tags:
+    - netbox_contact_assignment
+
+- name: NETBOX_CONTACT_GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_contact_group.yml
+    apply:
+      tags:
+        - netbox_contact_group
+  tags:
+    - netbox_contact_group
+
+- name: NETBOX_CONTACT_ROLE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_contact_role.yml
+    apply:
+      tags:
+        - netbox_contact_role
+  tags:
+    - netbox_contact_role
+
+- name: NETBOX_TENTANT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_tenant.yml
+    apply:
+      tags:
+        - netbox_tenant
+  tags:
+    - netbox_tenant
+
+- name: NETBOX_TENTANT_GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_tenant_group.yml
+    apply:
+      tags:
+        - netbox_tenant_group
+  tags:
+    - netbox_tenant_group
+
+- name: NETBOX_RACK TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_rack.yml
+    apply:
+      tags:
+        - netbox_rack
+  tags:
+    - netbox_rack
+
+- name: NETBOX_RACK_ROLE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_rack_role.yml
+    apply:
+      tags:
+        - netbox_rack_role
+  tags:
+    - netbox_rack_role
+
+- name: NETBOX_LOCATION TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_location.yml
+    apply:
+      tags:
+        - netbox_location
+  tags:
+    - netbox_location
+
+- name: NETBOX_MANUFACTURER TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_manufacturer.yml
+    apply:
+      tags:
+        - netbox_manufacturer
+  tags:
+    - netbox_manufacturer
+
+- name: NETBOX_PLATFORM TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_platform.yml
+    apply:
+      tags:
+        - netbox_platform
+  tags:
+    - netbox_platform
+
+- name: NETBOX_DEVICE_TYPE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_device_type.yml
+    apply:
+      tags:
+        - netbox_device_type
+  tags:
+    - netbox_device_type
+
+- name: NETBOX_DEVICE_ROLE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_device_role.yml
+    apply:
+      tags:
+        - netbox_device_role
+  tags:
+    - netbox_device_role
+
+- name: NETBOX_IPAM_ROLE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_ipam_role.yml
+    apply:
+      tags:
+        - netbox_ipam_role
+  tags:
+    - netbox_ipam_role
+
+- name: NETBOX_VLAN_GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_vlan_group.yml
+    apply:
+      tags:
+        - netbox_vlan_group
+  tags:
+    - netbox_vlan_group
+
+- name: NETBOX_VLAN TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_vlan.yml
+    apply:
+      tags:
+        - netbox_vlan
+  tags:
+    - netbox_vlan
+
+- name: NETBOX_VRF TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_vrf.yml
+    apply:
+      tags:
+        - netbox_vrf
+  tags:
+    - netbox_vrf
+
+- name: NETBOX_RIR TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_rir.yml
+    apply:
+      tags:
+        - netbox_rir
+  tags:
+    - netbox_rir
+
+- name: NETBOX_AGGREGATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_aggregate.yml
+    apply:
+      tags:
+        - netbox_aggregate
+  tags:
+    - netbox_aggregate
+
+- name: NETBOX_REGION TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_region.yml
+    apply:
+      tags:
+        - netbox_region
+  tags:
+    - netbox_region
+
+- name: NETBOX_DEVICE_BAY TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_device_bay.yml
+    apply:
+      tags:
+        - netbox_device_bay
+  tags:
+    - netbox_device_bay
+
+- name: NETBOX_DEVICE_BAY_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_device_bay_template.yml
+    apply:
+      tags:
+        - netbox_device_bay_template
+  tags:
+    - netbox_device_bay_template
+
+- name: NETBOX_INVENTORY_ITEM TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_inventory_item.yml
+    apply:
+      tags:
+        - netbox_inventory_item
+  tags:
+    - netbox_inventory_item
+
+- name: NETBOX_VIRTUAL_MACHINE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_virtual_machine.yml
+    apply:
+      tags:
+        - netbox_virtual_machine
+  tags:
+    - netbox_virtual_machine
+
+- name: NETBOX_CLUSTER TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_cluster.yml
+    apply:
+      tags:
+        - netbox_cluster
+  tags:
+    - netbox_cluster
+
+- name: NETBOX_CLUSTER_GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_cluster_group.yml
+    apply:
+      tags:
+        - netbox_cluster_group
+  tags:
+    - netbox_cluster_group
+
+- name: NETBOX_CLUSTER_TYPE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_cluster_type.yml
+    apply:
+      tags:
+        - netbox_cluster_type
+  tags:
+    - netbox_cluster_type
+
+- name: NETBOX_VM_INTERFACE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_vm_interface.yml
+    apply:
+      tags:
+        - netbox_vm_interface
+  tags:
+    - netbox_vm_interface
+
+- name: NETBOX_PROVIDER TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_provider.yml
+    apply:
+      tags:
+        - netbox_provider
+  tags:
+    - netbox_provider
+
+- name: NETBOX_PROVIDER_NETWORK TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_provider_network.yml
+    apply:
+      tags:
+        - netbox_provider_network
+  tags:
+    - netbox_provider_network
+
+- name: NETBOX_CIRCUIT_TYPE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_circuit_type.yml
+    apply:
+      tags:
+        - netbox_circuit_type
+  tags:
+    - netbox_circuit_type
+
+- name: NETBOX_CIRCUIT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_circuit.yml
+    apply:
+      tags:
+        - netbox_circuit
+  tags:
+    - netbox_circuit
+
+- name: NETBOX_REAR_PORT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_rear_port.yml
+    apply:
+      tags:
+        - netbox_rear_port
+  tags:
+    - netbox_rear_port
+
+- name: NETBOX_REAR_PORT_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_rear_port_template.yml
+    apply:
+      tags:
+        - netbox_rear_port_template
+  tags:
+    - netbox_rear_port_template
+
+## Skipped: netbox_front_port and netbox_front_port_template
+## NetBox v4.5 replaced rear_port/rear_port_position with the PortMapping model.
+## The modules still require rear_port as an argument and need updating.
+# - name: NETBOX_FRONT_PORT TESTS
+#   ansible.builtin.include_tasks:
+#     file: netbox_front_port.yml
+#     apply:
+#       tags:
+#         - netbox_front_port
+#   tags:
+#     - netbox_front_port
+
+# - name: NETBOX_FRONT_PORT_TEMPLATE TESTS
+#   ansible.builtin.include_tasks:
+#     file: netbox_front_port_template.yml
+#     apply:
+#       tags:
+#         - netbox_front_port_template
+#   tags:
+#     - netbox_front_port_template
+
+- name: NETBOX_CONSOLE_PORT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_console_port.yml
+    apply:
+      tags:
+        - netbox_console_port
+  tags:
+    - netbox_console_port
+
+- name: NETBOX_CONSOLE_PORT_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_console_port_template.yml
+    apply:
+      tags:
+        - netbox_console_port_template
+  tags:
+    - netbox_console_port_template
+
+- name: NETBOX_CONSOLE_SERVER_PORT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_console_server_port.yml
+    apply:
+      tags:
+        - netbox_console_server_port
+  tags:
+    - netbox_console_server_port
+
+- name: NETBOX_CONSOLE_SERVER_PORT_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_console_server_port_template.yml
+    apply:
+      tags:
+        - netbox_console_server_port_template
+  tags:
+    - netbox_console_server_port_template
+
+- name: NETBOX_POWER_PANEL TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_power_panel.yml
+    apply:
+      tags:
+        - netbox_power_panel
+  tags:
+    - netbox_power_panel
+
+- name: NETBOX_POWER_FEED TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_power_feed.yml
+    apply:
+      tags:
+        - netbox_power_feed
+  tags:
+    - netbox_power_feed
+
+- name: NETBOX_POWER_PORT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_power_port.yml
+    apply:
+      tags:
+        - netbox_power_port
+  tags:
+    - netbox_power_port
+
+- name: NETBOX_POWER_PORT_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_power_port_template.yml
+    apply:
+      tags:
+        - netbox_power_port_template
+  tags:
+    - netbox_power_port_template
+
+- name: NETBOX_POWER_OUTLET TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_power_outlet.yml
+    apply:
+      tags:
+        - netbox_power_outlet
+  tags:
+    - netbox_power_outlet
+
+- name: NETBOX_POWER_OUTLET_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_power_outlet_template.yml
+    apply:
+      tags:
+        - netbox_power_outlet_template
+  tags:
+    - netbox_power_outlet_template
+
+- name: NETBOX_VIRTUAL_CHASSIS TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_virtual_chassis.yml
+    apply:
+      tags:
+        - netbox_virtual_chassis
+  tags:
+    - netbox_virtual_chassis
+
+- name: NETBOX_USER_TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_user.yml
+    apply:
+      tags:
+        - netbox_user
+  tags:
+    - netbox_user
+
+- name: NETBOX_USER_GROUP_TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_user_group.yml
+    apply:
+      tags:
+        - netbox_user_group
+  tags:
+    - netbox_user_group
+
+- name: NETBOX_PERMISSION TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_permission.yml
+    apply:
+      tags:
+        - netbox_permission
+  tags:
+    - netbox_permission
+
+## Skipped: netbox_token
+## NetBox v4.5 v2 tokens don't support duplicate detection or key-based lookup.
+## The module needs updating to support v2 tokens.
+# - name: NETBOX_TOKEN_TESTS
+#   ansible.builtin.include_tasks:
+#     file: netbox_token.yml
+#     apply:
+#       tags:
+#         - netbox_token
+#   tags:
+#     - netbox_token
+
+# Module has to be updated for 3.3
+# - name: "NETBOX_CABLE TESTS"
+#  include_tasks: "netbox_cable.yml"
+
+- name: NETBOX_SERVICE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_service.yml
+    apply:
+      tags:
+        - netbox_service
+  tags:
+    - netbox_service
+
+- name: NETBOX_LOOKUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_lookup.yml
+    apply:
+      tags:
+        - netbox_lookup
+  tags:
+    - netbox_lookup
+
+- name: NETBOX_TAG_TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_tag.yml
+    apply:
+      tags:
+        - netbox_tag
+  tags:
+    - netbox_tag
+
+- name: NETBOX_ROUTE_TARGET_TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_route_target.yml
+    apply:
+      tags:
+        - netbox_route_target
+  tags:
+    - netbox_route_target
+
+- name: NETBOX_WIRELESS_LAN TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_wireless_lan.yml
+    apply:
+      tags:
+        - netbox_wireless_lan
+  tags:
+    - netbox_wireless_lan
+
+- name: NETBOX_WIRELESS_LAN_GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_wireless_lan_group.yml
+    apply:
+      tags:
+        - netbox_wireless_lan_group
+  tags:
+    - netbox_wireless_lan_group
+
+- name: NETBOX_WIRELESS_LINK TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_wireless_link.yml
+    apply:
+      tags:
+        - netbox_wireless_link
+  tags:
+    - netbox_wireless_link
+
+- name: NETBOX_CUSTOM_FIELD TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_custom_field.yml
+    apply:
+      tags:
+        - netbox_custom_field
+  tags:
+    - netbox_custom_field
+
+- name: NETBOX_CUSTOM_LINK TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_custom_link.yml
+    apply:
+      tags:
+        - netbox_custom_link
+  tags:
+    - netbox_custom_link
+
+- name: NETBOX_EXPORT_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_export_template.yml
+    apply:
+      tags:
+        - netbox_export_template
+  tags:
+    - netbox_export_template
+
+# Must update for 3.7
+# - name: "NETBOX_WEBHOOK TESTS"
+# include_tasks:
+#   file: "netbox_webhook.yml"
+#   apply:
+#     tags:
+#       - netbox_webhook
+# tags:
+#   - netbox_webhook
+
+# - name: "NETBOX_L2VPN TESTS"
+#  include_tasks:
+#    file: "netbox_l2vpn.yml"
+#    apply:
+#      tags:
+#        - netbox_l2vpn
+#  tags:
+#    - netbox_l2vpn
+
+# - name: "NETBOX_L2VPN_TERMINATION TESTS"
+#  include_tasks:
+#    file: "netbox_l2vpn_termination.yml"
+#    apply:
+#      tags:
+#        - netbox_l2vpn_termination
+#  tags:
+#    - netbox_l2vpn_termination
+
+- name: NETBOX_INVENTORY_ITEM_ROLE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_inventory_item_role.yml
+    apply:
+      tags:
+        - netbox_inventory_item_role
+  tags:
+    - netbox_inventory_item_role
+
+- name: NETBOX_MODULE_TYPE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_module_type.yml
+    apply:
+      tags:
+        - netbox_module_type
+  tags:
+    - netbox_module_type
+
+- name: NETBOX_SERVICE_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_service_template.yml
+    apply:
+      tags:
+        - netbox_service_template
+  tags:
+    - netbox_service_template
+
+- name: NETBOX_ASN TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_asn.yml
+    apply:
+      tags:
+        - netbox_asn
+  tags:
+    - netbox_asn
+
+- name: NETBOX_FHRP_GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_fhrp_group.yml
+    apply:
+      tags:
+        - netbox_fhrp_group
+  tags:
+    - netbox_fhrp_group
+
+- name: NETBOX_JOURNAL_ENTRY TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_journal_entry.yml
+    apply:
+      tags:
+        - netbox_journal_entry
+  tags:
+    - netbox_journal_entry
+
+- name: NETBOX_FHRP_GROUP_ASSIGNMENT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_fhrp_group_assignment.yml
+    apply:
+      tags:
+        - netbox_fhrp_group_assignmen
+  tags:
+    - netbox_fhrp_group_assignmen
+
+- name: NETBOX_CONFIG_TEMPLATE
+  ansible.builtin.include_tasks:
+    file: netbox_config_template.yml
+    apply:
+      tags:
+        - netbox_config_template
+  tags:
+    - netbox_config_template
+
+- name: NETBOX_VIRTUAL_DISK
+  ansible.builtin.include_tasks:
+    file: netbox_virtual_disk.yml
+    apply:
+      tags:
+        - netbox_virtual_disk
+  tags:
+    - netbox_virtual_disk
+
+- name: NETBOX_TUNNEL TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_tunnel.yml
+    apply:
+      tags:
+        - netbox_tunnel
+  tags:
+    - netbox_tunnel
+
+- name: NETBOX_TUNNEL GROUP TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_tunnel_group.yml
+    apply:
+      tags:
+        - netbox_tunnel_group
+  tags:
+    - netbox_tunnel_group
+
+- name: NETBOX_MAC_ADDRESS TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_mac_address.yml
+    apply:
+      tags:
+        - netbox_mac_address
+  tags:
+    - netbox_mac_address
+
+- name: NETBOX_CIRCUIT_TERMINATION TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_circuit_termination.yml
+    apply:
+      tags:
+        - netbox_circuit_termination
+  tags:
+    - netbox_circuit_termination
+
+- name: NETBOX_DATA_SOURCE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_data_source.yml
+    apply:
+      tags:
+        - netbox_data_source
+  tags:
+    - netbox_data_source

--- a/tests/integration/targets/v4.5/tasks/main.yml
+++ b/tests/integration/targets/v4.5/tasks/main.yml
@@ -368,26 +368,23 @@
   tags:
     - netbox_rear_port_template
 
-## Skipped: netbox_front_port and netbox_front_port_template
-## NetBox v4.5 replaced rear_port/rear_port_position with the PortMapping model.
-## The modules still require rear_port as an argument and need updating.
-# - name: NETBOX_FRONT_PORT TESTS
-#   ansible.builtin.include_tasks:
-#     file: netbox_front_port.yml
-#     apply:
-#       tags:
-#         - netbox_front_port
-#   tags:
-#     - netbox_front_port
+- name: NETBOX_FRONT_PORT TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_front_port.yml
+    apply:
+      tags:
+        - netbox_front_port
+  tags:
+    - netbox_front_port
 
-# - name: NETBOX_FRONT_PORT_TEMPLATE TESTS
-#   ansible.builtin.include_tasks:
-#     file: netbox_front_port_template.yml
-#     apply:
-#       tags:
-#         - netbox_front_port_template
-#   tags:
-#     - netbox_front_port_template
+- name: NETBOX_FRONT_PORT_TEMPLATE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_front_port_template.yml
+    apply:
+      tags:
+        - netbox_front_port_template
+  tags:
+    - netbox_front_port_template
 
 - name: NETBOX_CONSOLE_PORT TESTS
   ansible.builtin.include_tasks:
@@ -515,17 +512,14 @@
   tags:
     - netbox_permission
 
-## Skipped: netbox_token
-## NetBox v4.5 v2 tokens don't support duplicate detection or key-based lookup.
-## The module needs updating to support v2 tokens.
-# - name: NETBOX_TOKEN_TESTS
-#   ansible.builtin.include_tasks:
-#     file: netbox_token.yml
-#     apply:
-#       tags:
-#         - netbox_token
-#   tags:
-#     - netbox_token
+- name: NETBOX_TOKEN_TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_token.yml
+    apply:
+      tags:
+        - netbox_token
+  tags:
+    - netbox_token
 
 # Module has to be updated for 3.3
 # - name: "NETBOX_CABLE TESTS"

--- a/tests/integration/targets/v4.5/tasks/netbox_aggregate.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_aggregate.yml
@@ -1,0 +1,115 @@
+---
+##
+##
+### NETBOX_AGGEGATE
+##
+##
+- name: "AGGREGATE 1: Necessary info creation"
+  netbox.netbox.netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.0.0.0/8
+      rir: Example RIR
+    state: present
+  register: test_one
+
+- name: "AGGREGATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['aggregate']['prefix'] == "10.0.0.0/8"
+      # - test_one['aggregate']['family'] == 4
+      - test_one['aggregate']['rir'] == 1
+      - test_one['msg'] == "aggregate 10.0.0.0/8 created"
+
+- name: "AGGREGATE 2: Create duplicate"
+  netbox.netbox.netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.0.0.0/8
+    state: present
+  register: test_two
+
+- name: "AGGREGATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_two['aggregate']['family'] == 4
+      - test_two['aggregate']['rir'] == 1
+      - test_two['msg'] == "aggregate 10.0.0.0/8 already exists"
+
+- name: "AGGREGATE 3: ASSERT - Update"
+  netbox.netbox.netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.0.0.0/8
+      rir: Example RIR
+      date_added: "1989-01-18"
+      description: Test Description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "AGGREGATE 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['date_added'] == "1989-01-18"
+      - test_three['diff']['after']['description'] == "Test Description"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_three['aggregate']['family'] == 4
+      - test_three['aggregate']['rir'] == 1
+      - test_three['aggregate']['date_added'] == "1989-01-18"
+      - test_three['aggregate']['description'] == "Test Description"
+      - test_three['aggregate']['tags'][0] == 4
+      - test_three['msg'] == "aggregate 10.0.0.0/8 updated"
+
+- name: "AGGREGATE 4: ASSERT - Delete"
+  netbox.netbox.netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.0.0.0/8
+    state: absent
+  register: test_four
+
+- name: "AGGREGATE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['aggregate']['prefix'] == "10.0.0.0/8"
+      - test_four['aggregate']['family'] == 4
+      - test_four['aggregate']['rir'] == 1
+      - test_four['aggregate']['date_added'] == "1989-01-18"
+      - test_four['aggregate']['description'] == "Test Description"
+      - test_four['aggregate']['tags'][0] == 4
+      - test_four['msg'] == "aggregate 10.0.0.0/8 deleted"
+
+- name: "AGGREGATE 5: Necessary info creation"
+  netbox.netbox.netbox_aggregate:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 2001::/32
+      rir: Example RIR
+    state: present
+  register: test_five
+
+- name: "AGGREGATE 5: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['aggregate']['prefix'] == "2001::/32"
+      # - test_five['aggregate']['family'] == 6
+      - test_five['aggregate']['rir'] == 1
+      - test_five['msg'] == "aggregate 2001::/32 created"

--- a/tests/integration/targets/v4.5/tasks/netbox_asn.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_asn.yml
@@ -1,0 +1,88 @@
+---
+##
+##
+### NETBOX_ASN
+##
+##
+- name: "ASN 1: Test ASN creation"
+  netbox.netbox.netbox_asn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      asn: 1111111111
+      rir: Example RIR
+    state: present
+  register: test_one
+
+- name: "ASN 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['asn']['asn'] == 1111111111
+      - test_one['asn']['rir'] == 1
+      - test_one['msg'] == "asn 1111111111 created"
+
+- name: "ASN 2: Create duplicate"
+  netbox.netbox.netbox_asn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      asn: 1111111111
+      rir: Example RIR
+    state: present
+  register: test_two
+
+- name: "ASN 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['asn']['asn'] == 1111111111
+      - test_two['asn']['rir'] == 1
+      - test_two['msg'] == "asn 1111111111 already exists"
+
+- name: "ASN 3: Update ASN with other fields"
+  netbox.netbox.netbox_asn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      asn: 1111111111
+      rir: Example RIR
+      tenant: Test Tenant
+      description: Test description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "ASN 3: ASSERT - Update ASN with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['asn']['asn'] == 1111111111
+      - test_three['asn']['rir'] == 1
+      - test_three['asn']['tenant'] == 1
+      - test_three['asn']['description'] == "Test description"
+      - test_three['asn']['tags'][0] == 4
+      - test_three['msg'] == "asn 1111111111 updated"
+
+- name: "ASN 4: ASSERT - Delete"
+  netbox.netbox.netbox_asn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      asn: 1111111111
+    state: absent
+  register: test_four
+
+- name: "ASN 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "asn 1111111111 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_cable.yml
@@ -1,0 +1,193 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_CABLE
+##
+##
+- name: "CABLE 1: Necessary info creation"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      termination_a_type: dcim.interface
+      termination_a:
+        device: Test Nexus Child One
+        name: Ethernet2/2
+      termination_b_type: dcim.interface
+      termination_b:
+        device: Test Nexus Child One
+        name: Ethernet2/1
+    state: present
+  register: test_one
+
+- name: "CABLE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cable']['termination_a_type'] == "dcim.interface"
+      - test_one['cable']['termination_a_id'] == 15
+      - test_one['cable']['termination_b_type'] == "dcim.interface"
+      - test_one['cable']['termination_b_id'] == 2
+      - test_one['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 created"
+
+- name: "CABLE 2: Create duplicate"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      termination_a_type: dcim.interface
+      termination_a:
+        device: Test Nexus Child One
+        name: Ethernet2/2
+      termination_b_type: dcim.interface
+      termination_b:
+        device: Test Nexus Child One
+        name: Ethernet2/1
+    state: present
+  register: test_two
+
+- name: "CABLE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['cable']['termination_a_type'] == "dcim.interface"
+      - test_two['cable']['termination_a_id'] == 15
+      - test_two['cable']['termination_b_type'] == "dcim.interface"
+      - test_two['cable']['termination_b_id'] == 2
+      - test_two['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 already exists"
+
+- name: "CABLE 3: Update Cable with other fields"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      termination_a_type: dcim.interface
+      termination_a:
+        device: Test Nexus Child One
+        name: Ethernet2/2
+      termination_b_type: dcim.interface
+      termination_b:
+        device: Test Nexus Child One
+        name: Ethernet2/1
+      type: mmf-om4
+      status: planned
+      label: label123
+      color: abcdef
+      length: 30
+      length_unit: m
+      tags:
+        - Schnozzberry
+      tenant: Test Tenant
+    state: present
+  register: test_three
+
+- name: "CABLE 3: ASSERT - Update Cable with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "mmf-om4"
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['diff']['after']['label'] == "label123"
+      - test_three['diff']['after']['color'] == "abcdef"
+      - test_three['diff']['after']['length'] == 30
+      - test_three['diff']['after']['length_unit'] == "m"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['cable']['termination_a_type'] == "dcim.interface"
+      - test_three['cable']['termination_a_id'] == 15
+      - test_three['cable']['termination_b_type'] == "dcim.interface"
+      - test_three['cable']['termination_b_id'] == 2
+      - test_three['cable']['type'] == "mmf-om4"
+      - test_three['cable']['status'] == "planned"
+      - test_three['cable']['label'] == "label123"
+      - test_three['cable']['color'] == "abcdef"
+      - test_three['cable']['length'] == 30
+      - test_three['cable']['length_unit'] == "m"
+      - test_three['cable']['tags'][0] == 4
+      - test_three['cable']['tenant'] == 1
+      - test_three['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 updated"
+
+- name: "CABLE 4: ASSERT - Delete"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      termination_a_type: dcim.interface
+      termination_a:
+        device: Test Nexus Child One
+        name: Ethernet2/2
+      termination_b_type: dcim.interface
+      termination_b:
+        device: Test Nexus Child One
+        name: Ethernet2/1
+    state: absent
+  register: test_four
+
+- name: "CABLE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "cable dcim.interface Ethernet2/2 <> dcim.interface Ethernet2/1 deleted"
+
+- name: "CABLE 5: Connect Console Port and Console Server Port"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      termination_a_type: dcim.consoleserverport
+      termination_a:
+        name: Console Server Port
+        device: test100
+      termination_b_type: dcim.consoleport
+      termination_b:
+        name: Console Port
+        device: test100
+    state: present
+  register: test_five
+
+- name: "CABLE 5: ASSERT - Connect Console Port and Console Server Port"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['cable']['termination_a_type'] == "dcim.consoleserverport"
+      - test_five['cable']['termination_a_id'] == 1
+      - test_five['cable']['termination_b_type'] == "dcim.consoleport"
+      - test_five['cable']['termination_b_id'] == 1
+      - test_five['msg'] == "cable dcim.consoleserverport Console Server Port <> dcim.consoleport Console Port created"
+
+- name: "CABLE 6: Circuits Termination as side A"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      termination_a_type: circuits.circuittermination
+      termination_a:
+        circuit: Test Circuit Two
+        term_side: A
+      termination_b_type: dcim.interface
+      termination_b:
+        device: test100
+        name: GigabitEthernet2
+    state: present
+  register: test_six
+
+- name: "CABLE 6: ASSERT - Circuits Termination as side A"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['cable']['termination_a_type'] == "circuits.circuittermination"
+      - test_six['cable']['termination_a_id'] == 1
+      - test_six['cable']['termination_b_type'] == "dcim.interface"
+      - test_six['cable']['termination_b_id'] == 4
+      - test_six['msg'] == "cable circuits.circuittermination 1 <> dcim.interface GigabitEthernet2 created"

--- a/tests/integration/targets/v4.5/tasks/netbox_circuit.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_circuit.yml
@@ -1,0 +1,109 @@
+---
+##
+##
+### NETBOX_CIRCUIT
+##
+##
+- name: "NETBOX_CIRCUIT 1: Create provider within NetBox with only required information"
+  netbox.netbox.netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+    state: present
+  register: test_one
+
+- name: "NETBOX_CIRCUIT 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit']['cid'] == "Test Circuit One"
+      - test_one['circuit']['provider'] == 1
+      - test_one['circuit']['type'] == 1
+      - test_one['msg'] == "circuit Test Circuit One created"
+
+- name: "NETBOX_CIRCUIT 2: Duplicate"
+  netbox.netbox.netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+    state: present
+  register: test_two
+
+- name: "NETBOX_CIRCUIT 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit']['cid'] == "Test Circuit One"
+      - test_two['circuit']['provider'] == 1
+      - test_two['circuit']['type'] == 1
+      - test_two['msg'] == "circuit Test Circuit One already exists"
+
+- name: "NETBOX_CIRCUIT 3: Update provider with other fields"
+  netbox.netbox.netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      cid: Test Circuit One
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+      status: Planned
+      tenant: Test Tenant
+      install_date: "2018-12-25"
+      commit_rate: 10000
+      description: "Test circuit       "
+      comments: FAST CIRCUIT
+    state: present
+  register: test_three
+
+- name: "NETBOX_CIRCUIT 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['diff']['after']['install_date'] == "2018-12-25"
+      - test_three['diff']['after']['commit_rate'] == 10000
+      - test_three['diff']['after']['description'] == "Test circuit"
+      - test_three['diff']['after']['comments'] == "FAST CIRCUIT"
+      - test_three['circuit']['cid'] == "Test Circuit One"
+      - test_three['circuit']['provider'] == 1
+      - test_three['circuit']['type'] == 1
+      - test_three['circuit']['status'] == "planned"
+      - test_three['circuit']['tenant'] == 1
+      - test_three['circuit']['install_date'] == "2018-12-25"
+      - test_three['circuit']['commit_rate'] == 10000
+      - test_three['circuit']['description'] == "Test circuit"
+      - test_three['circuit']['comments'] == "FAST CIRCUIT"
+      - test_three['msg'] == "circuit Test Circuit One updated"
+
+- name: "NETBOX_CIRCUIT 4: Delete provider within netbox"
+  netbox.netbox.netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      cid: Test Circuit One
+    state: absent
+  register: test_four
+
+- name: "NETBOX_CIRCUIT 4 : ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['circuit']['cid'] == "Test Circuit One"
+      - test_four['circuit']['provider'] == 1
+      - test_four['circuit']['type'] == 1
+      - test_four['circuit']['status'] == "planned"
+      - test_four['circuit']['tenant'] == 1
+      - test_four['circuit']['install_date'] == "2018-12-25"
+      - test_four['circuit']['commit_rate'] == 10000
+      - test_four['circuit']['description'] == "Test circuit"
+      - test_four['circuit']['comments'] == "FAST CIRCUIT"
+      - test_four['msg'] == "circuit Test Circuit One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_circuit_termination.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_circuit_termination.yml
@@ -1,0 +1,155 @@
+---
+##
+##
+### NETBOX_CIRCUIT_TERMINATION
+##
+##
+- name: "NETBOX_CIRCUIT_TERMINATION 0: Create provider network within NetBox with only required information"
+  netbox.netbox.netbox_provider_network:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      provider: Test Provider
+      name: Test Provider Network One
+    state: present
+  register: test_one
+
+- name: "NETBOX_CIRCUIT_TERMINATION 0: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['provider_network']['name'] == "Test Provider Network One"
+      - test_one['msg'] == "provider_network Test Provider Network One created"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 1: Create provider within NetBox with only required information"
+  netbox.netbox.netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      circuit: Test Circuit
+      term_side: A
+      termination_id: 2
+      termination_type: circuits.providernetwork
+      port_speed: 10000
+    state: present
+  register: test_one
+
+- name: "NETBOX_CIRCUIT_TERMINATION 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit_termination']['termination_type'] == "circuits.providernetwork"
+      - test_one['circuit_termination']['termination_id'] == 2
+      - test_one['circuit_termination']['circuit'] == 1
+      - test_one['circuit_termination']['term_side'] == "A"
+      - test_one['circuit_termination']['port_speed'] == 10000
+      - test_one['msg'] == "circuit_termination test_circuit_a created"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 2: Duplicate"
+  netbox.netbox.netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      circuit: Test Circuit
+      term_side: A
+    state: present
+  register: test_two
+
+- name: "NETBOX_CIRCUIT_TERMINATION 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_one['circuit_termination']['termination_type'] == "circuits.providernetwork"
+      - test_one['circuit_termination']['termination_id'] == 2
+      - test_two['circuit_termination']['circuit'] == 1
+      - test_two['circuit_termination']['term_side'] == "A"
+      - test_two['circuit_termination']['port_speed'] == 10000
+      - test_two['msg'] == "circuit_termination test_circuit_a already exists"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 3: Update provider with other fields"
+  netbox.netbox.netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      circuit: Test Circuit
+      term_side: A
+      upstream_speed: 1000
+      xconnect_id: 10X100
+      pp_info: PP10-24
+      description: Test description
+    state: present
+  register: test_three
+
+- name: "NETBOX_CIRCUIT_TERMINATION 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_one['circuit_termination']['termination_type'] == "circuits.providernetwork"
+      - test_one['circuit_termination']['termination_id'] == 2
+      - test_three['diff']['after']['upstream_speed'] == 1000
+      - test_three['diff']['after']['xconnect_id'] == "10X100"
+      - test_three['diff']['after']['pp_info'] == "PP10-24"
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['circuit_termination']['circuit'] == 1
+      - test_three['circuit_termination']['term_side'] == "A"
+      - test_three['circuit_termination']['port_speed'] == 10000
+      - test_three['circuit_termination']['upstream_speed'] == 1000
+      - test_three['circuit_termination']['xconnect_id'] == "10X100"
+      - test_three['circuit_termination']['pp_info'] == "PP10-24"
+      - test_three['circuit_termination']['description'] == "Test description"
+      - test_three['msg'] == "circuit_termination test_circuit_a updated"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 4: Create Z Side"
+  netbox.netbox.netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      circuit: Test Circuit
+      term_side: Z
+      termination_id: 2
+      termination_type: circuits.providernetwork
+      port_speed: 10000
+    state: present
+  register: test_four
+
+- name: "NETBOX_CIRCUIT_TERMINATION 4: ASSERT - Create Z Side"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_one['circuit_termination']['termination_type'] == "circuits.providernetwork"
+      - test_one['circuit_termination']['termination_id'] == 2
+      - test_four['circuit_termination']['circuit'] == 1
+      - test_four['circuit_termination']['term_side'] == "Z"
+      - test_four['circuit_termination']['port_speed'] == 10000
+      - test_four['msg'] == "circuit_termination test_circuit_z created"
+
+- name: "NETBOX_CIRCUIT_TERMINATION 5: Delete provider within netbox"
+  netbox.netbox.netbox_circuit_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      circuit: Test Circuit
+      term_side: A
+    state: absent
+  register: test_five
+
+- name: "NETBOX_CIRCUIT_TERMINATION 5: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['circuit_termination']['circuit'] == 1
+      - test_five['circuit_termination']['term_side'] == "A"
+      - test_five['circuit_termination']['port_speed'] == 10000
+      - test_five['circuit_termination']['upstream_speed'] == 1000
+      - test_five['circuit_termination']['xconnect_id'] == "10X100"
+      - test_five['circuit_termination']['pp_info'] == "PP10-24"
+      - test_five['circuit_termination']['description'] == "Test description"
+      - test_one['circuit_termination']['termination_type'] == "circuits.providernetwork"
+      - test_one['circuit_termination']['termination_id'] == 2
+      - test_five['msg'] == "circuit_termination test_circuit_a deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_circuit_type.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_circuit_type.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_CIRCUIT_TYPE
+##
+##
+- name: "CIRCUIT_TYPE 1: Necessary info creation"
+  netbox.netbox.netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Circuit Type One
+    state: present
+  register: test_one
+
+- name: "CIRCUIT_TYPE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['circuit_type']['name'] == "Test Circuit Type One"
+      - test_one['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_one['msg'] == "circuit_type Test Circuit Type One created"
+
+- name: "CIRCUIT_TYPE 2: Create duplicate"
+  netbox.netbox.netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Circuit Type One
+    state: present
+  register: test_two
+
+- name: "CIRCUIT_TYPE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['circuit_type']['name'] == "Test Circuit Type One"
+      - test_two['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_two['msg'] == "circuit_type Test Circuit Type One already exists"
+
+- name: "CIRCUIT_TYPE 3: User specified slug"
+  netbox.netbox.netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Circuit Type Two
+      slug: test-circuit-type-2
+    state: present
+  register: test_three
+
+- name: "CIRCUIT_TYPE 3: ASSERT - User specified slug"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['circuit_type']['name'] == "Test Circuit Type Two"
+      - test_three['circuit_type']['slug'] == "test-circuit-type-2"
+      - test_three['msg'] == "circuit_type Test Circuit Type Two created"
+
+- name: "CIRCUIT_TYPE 4: ASSERT - Delete"
+  netbox.netbox.netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Circuit Type One
+    state: absent
+  register: test_four
+
+- name: "CIRCUIT_TYPE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['circuit_type']['name'] == "Test Circuit Type One"
+      - test_four['circuit_type']['slug'] == "test-circuit-type-one"
+      - test_four['msg'] == "circuit_type Test Circuit Type One deleted"
+
+- name: "CIRCUIT_TYPE 5: ASSERT - Delete"
+  netbox.netbox.netbox_circuit_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Circuit Type Two
+      slug: test-circuit-type-2
+    state: absent
+  register: test_five
+
+- name: "CIRCUIT_TYPE 5: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['circuit_type']['name'] == "Test Circuit Type Two"
+      - test_five['circuit_type']['slug'] == "test-circuit-type-2"
+      - test_five['msg'] == "circuit_type Test Circuit Type Two deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_cluster.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_cluster.yml
@@ -1,0 +1,102 @@
+---
+##
+##
+### NETBOX_CLUSTER
+##
+##
+- name: "CLUSTER 1: Necessary info creation"
+  netbox.netbox.netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster One
+      cluster_type: Test Cluster Type
+    state: present
+  register: test_one
+
+- name: "CLUSTER 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster']['name'] == "Test Cluster One"
+      - test_one['cluster']['type'] == 1
+      - test_one['msg'] == "cluster Test Cluster One created"
+
+- name: "CLUSTER 2: Create duplicate"
+  netbox.netbox.netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster One
+      cluster_type: Test Cluster Type
+    state: present
+  register: test_two
+
+- name: "CLUSTER 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster']['name'] == "Test Cluster One"
+      - test_two['cluster']['type'] == 1
+      - test_two['msg'] == "cluster Test Cluster One already exists"
+
+- name: "CLUSTER 3: Update"
+  netbox.netbox.netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster One
+      cluster_type: Test Cluster Type
+      cluster_group: Test Cluster Group
+      scope_type: "dcim.site"
+      scope: Test Site
+      comments: Updated cluster
+      tenant: Test Tenant
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "CLUSTER 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['group'] == 1
+      - test_three['diff']['after']['scope'] == 1
+      - test_three['diff']['after']['scope_type'] == "dcim.site"
+      - test_three['diff']['after']['comments'] == "Updated cluster"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['cluster']['name'] == "Test Cluster One"
+      - test_three['cluster']['type'] == 1
+      - test_three['cluster']['group'] == 1
+      - test_three['cluster']['scope'] == 1
+      - test_three['cluster']['scope_type'] == "dcim.site"
+      - test_three['cluster']['comments'] == "Updated cluster"
+      - test_three['cluster']['tags'][0] == 4
+      - test_three['cluster']['tenant'] == 1
+      - test_three['msg'] == "cluster Test Cluster One updated"
+
+- name: "CLUSTER 4: Delete"
+  netbox.netbox.netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster One
+    state: absent
+  register: test_four
+
+- name: "CLUSTER 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['cluster']['name'] == "Test Cluster One"
+      - test_four['cluster']['type'] == 1
+      - test_four['cluster']['group'] == 1
+      - test_four['cluster']['scope'] == 1
+      - test_four['cluster']['scope_type'] == "dcim.site"
+      - test_four['cluster']['comments'] == "Updated cluster"
+      - test_four['cluster']['tags'][0] == 4
+      - test_four['msg'] == "cluster Test Cluster One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_cluster_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_cluster_group.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_CLUSTER_GROUP
+##
+##
+- name: "CLUSTER_GROUP 1: Necessary info creation"
+  netbox.netbox.netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Group One
+    state: present
+  register: test_one
+
+- name: "CLUSTER_GROUP 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster_group']['name'] == "Test Cluster Group One"
+      - test_one['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_one['msg'] == "cluster_group Test Cluster Group One created"
+
+- name: "CLUSTER_GROUP 2: Create duplicate"
+  netbox.netbox.netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Group One
+    state: present
+  register: test_two
+
+- name: "CLUSTER_GROUP 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster_group']['name'] == "Test Cluster Group One"
+      - test_two['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_two['msg'] == "cluster_group Test Cluster Group One already exists"
+
+- name: "CLUSTER_GROUP 3: User specified slug"
+  netbox.netbox.netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Group Two
+      slug: test-cluster-group-2
+    state: present
+  register: test_three
+
+- name: "CLUSTER_GROUP 3: ASSERT - User specified slug"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['cluster_group']['name'] == "Test Cluster Group Two"
+      - test_three['cluster_group']['slug'] == "test-cluster-group-2"
+      - test_three['msg'] == "cluster_group Test Cluster Group Two created"
+
+- name: "CLUSTER_GROUP 4: ASSERT - Delete"
+  netbox.netbox.netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Group One
+    state: absent
+  register: test_four
+
+- name: "CLUSTER_GROUP 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['cluster_group']['name'] == "Test Cluster Group One"
+      - test_four['cluster_group']['slug'] == "test-cluster-group-one"
+      - test_four['msg'] == "cluster_group Test Cluster Group One deleted"
+
+- name: "CLUSTER_GROUP 5: ASSERT - Delete"
+  netbox.netbox.netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Group Two
+      slug: test-cluster-group-2
+    state: absent
+  register: test_five
+
+- name: "CLUSTER_GROUP 5: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['cluster_group']['name'] == "Test Cluster Group Two"
+      - test_five['cluster_group']['slug'] == "test-cluster-group-2"
+      - test_five['msg'] == "cluster_group Test Cluster Group Two deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_cluster_type.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_cluster_type.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_CLUSTER_TYPE
+##
+##
+- name: "CLUSTER_TYPE 1: Necessary info creation"
+  netbox.netbox.netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Type One
+    state: present
+  register: test_one
+
+- name: "CLUSTER_TYPE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['cluster_type']['name'] == "Test Cluster Type One"
+      - test_one['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_one['msg'] == "cluster_type Test Cluster Type One created"
+
+- name: "CLUSTER_TYPE 2: Create duplicate"
+  netbox.netbox.netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Type One
+    state: present
+  register: test_two
+
+- name: "CLUSTER_TYPE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['cluster_type']['name'] == "Test Cluster Type One"
+      - test_two['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_two['msg'] == "cluster_type Test Cluster Type One already exists"
+
+- name: "CLUSTER_TYPE 3: User specified slug"
+  netbox.netbox.netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Type Two
+      slug: test-cluster-type-2
+    state: present
+  register: test_three
+
+- name: "CLUSTER_TYPE 3: ASSERT - User specified slug"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['cluster_type']['name'] == "Test Cluster Type Two"
+      - test_three['cluster_type']['slug'] == "test-cluster-type-2"
+      - test_three['msg'] == "cluster_type Test Cluster Type Two created"
+
+- name: "CLUSTER_TYPE 4: ASSERT - Delete"
+  netbox.netbox.netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Type One
+    state: absent
+  register: test_four
+
+- name: "CLUSTER_TYPE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['cluster_type']['name'] == "Test Cluster Type One"
+      - test_four['cluster_type']['slug'] == "test-cluster-type-one"
+      - test_four['msg'] == "cluster_type Test Cluster Type One deleted"
+
+- name: "CLUSTER_TYPE 5: ASSERT - Delete"
+  netbox.netbox.netbox_cluster_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Cluster Type Two
+      slug: test-cluster-type-2
+    state: absent
+  register: test_five
+
+- name: "CLUSTER_TYPE 5: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['cluster_type']['name'] == "Test Cluster Type Two"
+      - test_five['cluster_type']['slug'] == "test-cluster-type-2"
+      - test_five['msg'] == "cluster_type Test Cluster Type Two deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_config_context.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_config_context.yml
@@ -1,0 +1,107 @@
+---
+##
+##
+### NETBOX_CONFIG_CONTEXTS
+##
+##
+- name: "CONFIG_CONTEXT 1: Necessary info creation"
+  netbox.netbox.netbox_config_context:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_context
+      description: Test context
+      data: '{ "testkey": { "testsubkey": [ "testvaule" ] } }'
+    state: present
+  register: test_one
+
+- name: "CONFIG_CONTEXT 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['config_context']['name'] == "test_context"
+      - test_one['config_context']['description'] == "Test context"
+      - test_one['config_context']['is_active'] == true
+      - test_one['config_context']['weight'] == 1000
+      - test_one['config_context']['data'].testkey.testsubkey[0] == "testvaule"
+      - test_one['msg'] == "config_context test_context created"
+
+- name: "CONFIG_CONTEXT 2: Create duplicate"
+  netbox.netbox.netbox_config_context:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_context
+      description: Test context
+      data: '{ "testkey": { "testsubkey": [ "testvaule" ] } }'
+    state: present
+  register: test_two
+
+- name: "CONFIG_CONTEXT 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['config_context']['name'] == "test_context"
+      - test_two['msg'] == "config_context test_context already exists"
+
+- name: "CONFIG_CONTEXT 3: Update data and attach to site"
+  netbox.netbox.netbox_config_context:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_context
+      description: Updated test context
+      data: '{ "testkey": { "testsubkey": [ "updatedvaule" ] } }'
+      weight: 100
+      sites: [test-site]
+    state: present
+  register: test_three
+
+- name: "CONFIG_CONTEXT 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['data'].testkey.testsubkey[0] == "updatedvaule"
+      - test_three['diff']['after']['description'] == "Updated test context"
+      - test_three['diff']['after']['weight'] == 100
+      - test_three['diff']['after']['sites'][0] == 1
+      - test_three['config_context']['name'] == "test_context"
+      - test_three['msg'] == "config_context test_context updated"
+
+- name: "CONFIG_CONTEXT 4: Detach from site"
+  netbox.netbox.netbox_config_context:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_context
+      data: '{ "testkey": { "testsubkey": [ "updatedvaule" ] } }'
+      sites: []
+    state: present
+  register: test_four
+
+- name: "CONFIG_CONTEXT 4: ASSERT - Detached"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['sites']|length == 0
+      - test_four['config_context']['name'] == "test_context"
+      - test_four['msg'] == "config_context test_context updated"
+
+- name: "CONFIG_CONTEXT 5: Delete"
+  netbox.netbox.netbox_config_context:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_context
+    state: absent
+  register: test_five
+
+- name: "CONFIG_CONTEXT 5: ASSERT - Deleted"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['config_context']['name'] == "test_context"
+      - test_five['msg'] == "config_context test_context deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_config_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_config_template.yml
@@ -1,0 +1,82 @@
+---
+##
+##
+### NETBOX_CONFIG_TEMPLATES
+##
+##
+- name: "CONFIG_TEMPLATES 1: Necessary info creation"
+  netbox.netbox.netbox_config_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_template
+      description: Test template
+      template_code: test template
+    state: present
+  register: test_one
+
+- name: "CONFIG_TEMPLATES 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['config_template']['name'] == "test_template"
+      - test_one['config_template']['description'] == "Test template"
+      - test_one['config_template']['template_code'] == "test template"
+      - test_one['msg'] == "config_template test_template created"
+
+- name: "CONFIG_TEMPLATES 2: Create duplicate"
+  netbox.netbox.netbox_config_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_template
+      description: Test template
+      template_code: test template
+    state: present
+  register: test_two
+
+- name: "CONFIG_TEMPLATES 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['config_template']['name'] == "test_template"
+      - test_two['msg'] == "config_template test_template already exists"
+
+- name: "CONFIG_TEMPLATES 3: Update data"
+  netbox.netbox.netbox_config_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_template
+      description: Updated test template
+      template_code: updated test template
+    state: present
+  register: test_three
+
+- name: "CONFIG_TEMPLATES 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['template_code'] == "updated test template"
+      - test_three['diff']['after']['description'] == "Updated test template"
+      - test_three['config_template']['name'] == "test_template"
+      - test_three['msg'] == "config_template test_template updated"
+
+- name: "CONFIG_TEMPLATES 4: Delete"
+  netbox.netbox.netbox_config_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test_template
+    state: absent
+  register: test_four
+
+- name: "CONFIG_TEMPLATES 4: ASSERT - Deleted"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['config_template']['name'] == "test_template"
+      - test_four['msg'] == "config_template test_template deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_console_port.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_console_port.yml
@@ -1,0 +1,108 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_CONSOLE_PORT
+##
+##
+- name: "CONSOLE_PORT 1: Necessary info creation"
+  netbox.netbox.netbox_console_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port
+      device: test100
+    state: present
+  register: test_one
+
+- name: "CONSOLE_PORT 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['console_port']['name'] == "Console Port"
+      - test_one['console_port']['device'] == 1
+      - test_one['msg'] == "console_port Console Port created"
+
+- name: "CONSOLE_PORT 2: Create duplicate"
+  netbox.netbox.netbox_console_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port
+      device: test100
+    state: present
+  register: test_two
+
+- name: "CONSOLE_PORT 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['console_port']['name'] == "Console Port"
+      - test_two['console_port']['device'] == 1
+      - test_two['msg'] == "console_port Console Port already exists"
+
+- name: "CONSOLE_PORT 3: Update Console Port with other fields"
+  netbox.netbox.netbox_console_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port
+      device: test100
+      type: usb-a
+      description: test description
+    state: present
+  register: test_three
+
+- name: "CONSOLE_PORT 3: ASSERT - Update Console Port with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "usb-a"
+      - test_three['diff']['after']['description'] == "test description"
+      - test_three['console_port']['name'] == "Console Port"
+      - test_three['console_port']['device'] == 1
+      - test_three['console_port']['type'] == "usb-a"
+      - test_three['console_port']['description'] == "test description"
+      - test_three['msg'] == "console_port Console Port updated"
+
+- name: "CONSOLE_PORT 4: Create Console Port for Delete Test"
+  netbox.netbox.netbox_console_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port 2
+      device: test100
+    state: present
+  register: test_four
+
+- name: "CONSOLE_PORT 4: ASSERT - Create Console Port for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['console_port']['name'] == "Console Port 2"
+      - test_four['console_port']['device'] == 1
+      - test_four['msg'] == "console_port Console Port 2 created"
+
+- name: "CONSOLE_PORT 5: Delete Console Port"
+  netbox.netbox.netbox_console_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port 2
+      device: test100
+    state: absent
+  register: test_five
+
+- name: "CONSOLE_PORT 5: ASSERT - Delete Console Port"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "console_port Console Port 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_console_port_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_console_port_template.yml
@@ -1,0 +1,105 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_CONSOLE_PORT_TEMPLATE
+##
+##
+- name: "CONSOLE_PORT_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_console_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port Template
+      device_type: Cisco Test
+    state: present
+  register: test_one
+
+- name: "CONSOLE_PORT_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['console_port_template']['name'] == "Console Port Template"
+      - test_one['console_port_template']['device_type'] == 1
+      - test_one['msg'] == "console_port_template Console Port Template created"
+
+- name: "CONSOLE_PORT_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_console_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port Template
+      device_type: Cisco Test
+    state: present
+  register: test_two
+
+- name: "CONSOLE_PORT_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['console_port_template']['name'] == "Console Port Template"
+      - test_two['console_port_template']['device_type'] == 1
+      - test_two['msg'] == "console_port_template Console Port Template already exists"
+
+- name: "CONSOLE_PORT_TEMPLATE 3: Update Console Port Template with other fields"
+  netbox.netbox.netbox_console_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port Template
+      device_type: Cisco Test
+      type: usb-a
+    state: present
+  register: test_three
+
+- name: "CONSOLE_PORT_TEMPLATE 3: ASSERT - Update Console Port Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "usb-a"
+      - test_three['console_port_template']['name'] == "Console Port Template"
+      - test_three['console_port_template']['device_type'] == 1
+      - test_three['console_port_template']['type'] == "usb-a"
+      - test_three['msg'] == "console_port_template Console Port Template updated"
+
+- name: "CONSOLE_PORT_TEMPLATE 4: Create Console Port Template for Delete Test"
+  netbox.netbox.netbox_console_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port Template 2
+      device_type: Cisco Test
+    state: present
+  register: test_four
+
+- name: "CONSOLE_PORT_TEMPLATE 4: ASSERT - Create Console Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['console_port_template']['name'] == "Console Port Template 2"
+      - test_four['console_port_template']['device_type'] == 1
+      - test_four['msg'] == "console_port_template Console Port Template 2 created"
+
+- name: "CONSOLE_PORT_TEMPLATE 5: Delete Console Port Template"
+  netbox.netbox.netbox_console_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Port Template 2
+      device_type: Cisco Test
+    state: absent
+  register: test_five
+
+- name: "CONSOLE_PORT_TEMPLATE 5: ASSERT - Delete Console Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "console_port_template Console Port Template 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_console_server_port.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_console_server_port.yml
@@ -1,0 +1,108 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_CONSOLE_SERVER_PORT
+##
+##
+- name: "CONSOLE_SERVER_PORT 1: Necessary info creation"
+  netbox.netbox.netbox_console_server_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port
+      device: test100
+    state: present
+  register: test_one
+
+- name: "CONSOLE_SERVER_PORT 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['console_server_port']['name'] == "Console Server Port"
+      - test_one['console_server_port']['device'] == 1
+      - test_one['msg'] == "console_server_port Console Server Port created"
+
+- name: "CONSOLE_SERVER_PORT 2: Create duplicate"
+  netbox.netbox.netbox_console_server_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port
+      device: test100
+    state: present
+  register: test_two
+
+- name: "CONSOLE_SERVER_PORT 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['console_server_port']['name'] == "Console Server Port"
+      - test_two['console_server_port']['device'] == 1
+      - test_two['msg'] == "console_server_port Console Server Port already exists"
+
+- name: "CONSOLE_SERVER_PORT 3: Update Console Server Port with other fields"
+  netbox.netbox.netbox_console_server_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port
+      device: test100
+      type: usb-a
+      description: test description
+    state: present
+  register: test_three
+
+- name: "CONSOLE_SERVER_PORT 3: ASSERT - Update Console Server Port with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "usb-a"
+      - test_three['diff']['after']['description'] == "test description"
+      - test_three['console_server_port']['name'] == "Console Server Port"
+      - test_three['console_server_port']['device'] == 1
+      - test_three['console_server_port']['type'] == "usb-a"
+      - test_three['console_server_port']['description'] == "test description"
+      - test_three['msg'] == "console_server_port Console Server Port updated"
+
+- name: "CONSOLE_SERVER_PORT 4: Create Console Server Port for Delete Test"
+  netbox.netbox.netbox_console_server_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port 2
+      device: test100
+    state: present
+  register: test_four
+
+- name: "CONSOLE_SERVER_PORT 4: ASSERT - Create Console Server Port for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['console_server_port']['name'] == "Console Server Port 2"
+      - test_four['console_server_port']['device'] == 1
+      - test_four['msg'] == "console_server_port Console Server Port 2 created"
+
+- name: "CONSOLE_SERVER_PORT 5: Delete Console Server Port"
+  netbox.netbox.netbox_console_server_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port 2
+      device: test100
+    state: absent
+  register: test_five
+
+- name: "CONSOLE_SERVER_PORT 5: ASSERT - Delete Console Server Port"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "console_server_port Console Server Port 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_console_server_port_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_console_server_port_template.yml
@@ -1,0 +1,105 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_CONSOLE_SERVER_PORT_TEMPLATE
+##
+##
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_console_server_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port Template
+      device_type: Cisco Test
+    state: present
+  register: test_one
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['console_server_port_template']['name'] == "Console Server Port Template"
+      - test_one['console_server_port_template']['device_type'] == 1
+      - test_one['msg'] == "console_server_port_template Console Server Port Template created"
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_console_server_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port Template
+      device_type: Cisco Test
+    state: present
+  register: test_two
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['console_server_port_template']['name'] == "Console Server Port Template"
+      - test_two['console_server_port_template']['device_type'] == 1
+      - test_two['msg'] == "console_server_port_template Console Server Port Template already exists"
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 3: Update Console Server Port Template with other fields"
+  netbox.netbox.netbox_console_server_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port Template
+      device_type: Cisco Test
+      type: usb-a
+    state: present
+  register: test_three
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 3: ASSERT - Update Console Server Port Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "usb-a"
+      - test_three['console_server_port_template']['name'] == "Console Server Port Template"
+      - test_three['console_server_port_template']['device_type'] == 1
+      - test_three['console_server_port_template']['type'] == "usb-a"
+      - test_three['msg'] == "console_server_port_template Console Server Port Template updated"
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 4: Create Console Server Port Template for Delete Test"
+  netbox.netbox.netbox_console_server_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port Template 2
+      device_type: Cisco Test
+    state: present
+  register: test_four
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 4: ASSERT - Create Console Server Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['console_server_port_template']['name'] == "Console Server Port Template 2"
+      - test_four['console_server_port_template']['device_type'] == 1
+      - test_four['msg'] == "console_server_port_template Console Server Port Template 2 created"
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 5: Delete Console Server Port Template"
+  netbox.netbox.netbox_console_server_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Console Server Port Template 2
+      device_type: Cisco Test
+    state: absent
+  register: test_five
+
+- name: "CONSOLE_SERVER_PORT_TEMPLATE 5: ASSERT - Delete Console Server Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "console_server_port_template Console Server Port Template 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_contact.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_contact.yml
@@ -1,0 +1,143 @@
+---
+##
+##
+### NETBOX_CONTACT
+##
+##
+- name: 1 - Test contact creation
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact ABC
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['contact']['name'] == "Contact ABC"
+      - test_one['msg'] == "contact Contact ABC created"
+
+- name: Test duplicate contact
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact ABC
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['contact']['name'] == "Contact ABC"
+      - test_two['msg'] == "contact Contact ABC already exists"
+
+- name: 3 - Test update
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact ABC
+      title: New Title
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['title'] == "New Title"
+      - test_three['contact']['name'] == "Contact ABC"
+      - test_three['contact']['title'] == "New Title"
+      - test_three['msg'] == "contact Contact ABC updated"
+
+- name: 4 - Test delete
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact ABC
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "contact Contact ABC deleted"
+
+- name: 5 - Create contact with all parameters
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact ABC
+      title: Fancy title
+      phone: "12345678"
+      email: contact@contact.com
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['contact']['name'] == "Contact ABC"
+      - test_five['contact']['title'] == "Fancy title"
+      - test_five['contact']['phone'] == "12345678"
+      - test_five['contact']['tags'] | length == 3
+      - test_five['msg'] == "contact Contact ABC created"
+
+- name: 6 Setup - Create contact group
+  netbox.netbox.netbox_contact_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact Group With Contacts
+  register: test_group
+
+- name: 6 - Create contact with contact group
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Grouped Contact 1
+      contact_groups:
+        - Contact Group With Contacts
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['contact']['name'] == "Grouped Contact 1"
+      - test_six['contact']['groups'] == [test_group['contact_group']['id']]
+      - test_six['msg'] == "contact Grouped Contact 1 created"
+
+- name: 7 - Try to create contact using contact_group
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Grouped Contact 2
+      contact_group: Contact Group With Contacts
+  register: test_seven
+  ignore_errors: true
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - "'contact_group is not available in Netbox 4.5. Use contact_groups instead.' in test_seven['module_stderr']"

--- a/tests/integration/targets/v4.5/tasks/netbox_contact_assignment.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_contact_assignment.yml
@@ -1,0 +1,503 @@
+---
+##
+##
+### NETBOX_CONTACT_ASSIGNMENT
+##
+##
+- name: Setup - Create contact for assignment
+  netbox.netbox.netbox_contact:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact For Assignment
+    state: present
+
+- name: Setup - Create contact role for assignment
+  netbox.netbox.netbox_contact_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Role For Assignment
+    state: present
+
+- name: 1 - Setup - Create tenant to assign contact to
+  netbox.netbox.netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Tenant With Contact
+    state: present
+
+- name: 1 - Assign contact to tenant
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: tenant
+      object_name: Tenant With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['contact_assignment']['display'] == "Contact For Assignment -> Tenant With Contact"
+      - test_one['msg'] == "contact_assignment Contact For Assignment -> Tenant With Contact created"
+
+- name: Test duplicate contact
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: tenant
+      object_name: Tenant With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "contact_assignment Contact For Assignment -> Tenant With Contact already exists"
+
+- name: 3 - Test update
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: tenant
+      object_name: Tenant With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+      priority: tertiary
+      tags:
+        - tagA
+        - tagB
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['priority'] == None
+      - test_three['diff']['after']['priority'] == "tertiary"
+      - test_three['diff']['before']['tags'] == []
+      - test_three['diff']['after']['tags'] != []
+      - test_three['msg'] == "contact_assignment Contact For Assignment -> Tenant With Contact updated"
+
+- name: 4 - Test delete
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: tenant
+      object_name: Tenant With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "contact_assignment Contact For Assignment -> Tenant With Contact deleted"
+
+- name: 5 - Setup - Create circuit to assign contact to
+  netbox.netbox.netbox_circuit:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      cid: Circuit With Contact
+      provider: Test Provider
+      circuit_type: Test Circuit Type
+    state: present
+
+- name: 5 - Assign contact to circuit
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: circuit
+      object_name: Circuit With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['contact_assignment']['display'] == "Contact For Assignment -> Circuit With Contact"
+      - test_five['msg'] == "contact_assignment Contact For Assignment -> Circuit With Contact created"
+
+- name: 6 - Setup - Create provider to assign contact to
+  netbox.netbox.netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Provider With Contact
+    state: present
+
+- name: 6 - Assign contact to provider
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: provider
+      object_name: Provider With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['contact_assignment']['display'] == "Contact For Assignment -> Provider With Contact"
+      - test_six['msg'] == "contact_assignment Contact For Assignment -> Provider With Contact created"
+
+- name: 7 - Setup - Create device to assign contact to
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Device With Contact
+      device_type:
+        id: "1"
+      device_role: Core Switch
+      site: Test Site
+      status: Staged
+    state: present
+
+- name: 7 - Assign contact to device
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: device
+      object_name: Device With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_seven
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['contact_assignment']['display'] == "Contact For Assignment -> Device With Contact"
+      - test_seven['msg'] == "contact_assignment Contact For Assignment -> Device With Contact created"
+
+- name: 8 - Setup - Create location to assign contact to
+  netbox.netbox.netbox_location:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Location With Contact
+      site: Test Site
+    state: present
+
+- name: 8 - Assign contact to location
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: location
+      object_name: Location With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_eight
+
+- name: 8 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "absent"
+      - test_eight['diff']['after']['state'] == "present"
+      - test_eight['contact_assignment']['display'] == "Contact For Assignment -> Location With Contact"
+      - test_eight['msg'] == "contact_assignment Contact For Assignment -> Location With Contact created"
+
+- name: 9 - Setup - Create manufacturer to assign contact to
+  netbox.netbox.netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Manufacturer With Contact
+    state: present
+
+- name: 9 - Assign contact to manufacturer
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: manufacturer
+      object_name: Manufacturer With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_nine
+
+- name: 9 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['contact_assignment']['display'] == "Contact For Assignment -> Manufacturer With Contact"
+      - test_nine['msg'] == "contact_assignment Contact For Assignment -> Manufacturer With Contact created"
+
+- name: 10 - Setup - Create power panel to assign contact to
+  netbox.netbox.netbox_power_panel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Panel With Contact
+      site: Test Site
+    state: present
+
+- name: 10 - Assign contact to power panel
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: power_panel
+      object_name: Power Panel With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_ten
+
+- name: 10 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['contact_assignment']['display'] == "Contact For Assignment -> Power Panel With Contact"
+      - test_ten['msg'] == "contact_assignment Contact For Assignment -> Power Panel With Contact created"
+
+- name: 11 - Setup - Create rack to assign contact to
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack With Contact
+      site: Test Site
+      location: Test Rack Group
+    state: present
+
+- name: 11 - Assign contact to rack
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: rack
+      object_name: Rack With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_eleven
+
+- name: 11 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "absent"
+      - test_eleven['diff']['after']['state'] == "present"
+      - test_eleven['contact_assignment']['display'] == "Contact For Assignment -> Rack With Contact"
+      - test_eleven['msg'] == "contact_assignment Contact For Assignment -> Rack With Contact created"
+
+- name: 12 - Setup - Create region to assign contact to
+  netbox.netbox.netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Region With Contact
+    state: present
+
+- name: 12 - Assign contact to region
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: region
+      object_name: Region With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_twelve
+
+- name: 12 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_twelve is changed
+      - test_twelve['diff']['before']['state'] == "absent"
+      - test_twelve['diff']['after']['state'] == "present"
+      - test_twelve['contact_assignment']['display'] == "Contact For Assignment -> Region With Contact"
+      - test_twelve['msg'] == "contact_assignment Contact For Assignment -> Region With Contact created"
+
+- name: 13 - Setup - Create site to assign contact to
+  netbox.netbox.netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Site With Contact
+    state: present
+
+- name: 13 - Assign contact to site
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: site
+      object_name: Site With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_thirteen
+
+- name: 13 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_thirteen is changed
+      - test_thirteen['diff']['before']['state'] == "absent"
+      - test_thirteen['diff']['after']['state'] == "present"
+      - test_thirteen['contact_assignment']['display'] == "Contact For Assignment -> Site With Contact"
+      - test_thirteen['msg'] == "contact_assignment Contact For Assignment -> Site With Contact created"
+
+- name: 14 - Setup - Create site group to assign contact to
+  netbox.netbox.netbox_site_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Site Group With Contact
+    state: present
+
+- name: 14 - Assign contact to site group
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: site_group
+      object_name: Site Group With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_fourteen
+
+- name: 14 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_fourteen is changed
+      - test_fourteen['diff']['before']['state'] == "absent"
+      - test_fourteen['diff']['after']['state'] == "present"
+      - test_fourteen['contact_assignment']['display'] == "Contact For Assignment -> Site Group With Contact"
+      - test_fourteen['msg'] == "contact_assignment Contact For Assignment -> Site Group With Contact created"
+
+- name: 15 - Setup - Create cluster to assign contact to
+  netbox.netbox.netbox_cluster:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Cluster With Contact
+      cluster_type: Test Cluster Type
+    state: present
+
+- name: 15 - Assign contact to cluster
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: cluster
+      object_name: Cluster With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_fifteen
+
+- name: 15 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_fifteen is changed
+      - test_fifteen['diff']['before']['state'] == "absent"
+      - test_fifteen['diff']['after']['state'] == "present"
+      - test_fifteen['contact_assignment']['display'] == "Contact For Assignment -> Cluster With Contact"
+      - test_fifteen['msg'] == "contact_assignment Contact For Assignment -> Cluster With Contact created"
+
+- name: 16 - Setup - Create cluster group to assign contact to
+  netbox.netbox.netbox_cluster_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Cluster Group With Contact
+    state: present
+
+- name: 16 - Assign contact to cluster group
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: cluster_group
+      object_name: Cluster Group With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_sixteen
+
+- name: 16 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_sixteen is changed
+      - test_sixteen['diff']['before']['state'] == "absent"
+      - test_sixteen['diff']['after']['state'] == "present"
+      - test_sixteen['contact_assignment']['display'] == "Contact For Assignment -> Cluster Group With Contact"
+      - test_sixteen['msg'] == "contact_assignment Contact For Assignment -> Cluster Group With Contact created"
+
+- name: 17 - Setup - Create virtual machine to assign contact to
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Virtual Machine With Contact
+      cluster: Test Cluster
+    state: present
+
+- name: 17 - Assign contact to virtual machine
+  netbox.netbox.netbox_contact_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_type: virtual_machine
+      object_name: Virtual Machine With Contact
+      contact: Contact For Assignment
+      role: Role For Assignment
+    state: present
+  register: test_seventeen
+
+- name: 17 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seventeen is changed
+      - test_seventeen['diff']['before']['state'] == "absent"
+      - test_seventeen['diff']['after']['state'] == "present"
+      - test_seventeen['contact_assignment']['display'] == "Contact For Assignment -> Virtual Machine With Contact"
+      - test_seventeen['msg'] == "contact_assignment Contact For Assignment -> Virtual Machine With Contact created"

--- a/tests/integration/targets/v4.5/tasks/netbox_contact_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_contact_group.yml
@@ -1,0 +1,119 @@
+---
+##
+##
+### NETBOX_CONTACT_GROUP
+##
+##
+- name: 1 - Test contact group creation
+  netbox.netbox.netbox_contact_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact Group 1
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['contact_group']['name'] == "Contact Group 1"
+      - test_one['msg'] == "contact_group Contact Group 1 created"
+
+- name: Test duplicate contact group
+  netbox.netbox.netbox_contact_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact Group 1
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['contact_group']['name'] == "Contact Group 1"
+      - test_two['msg'] == "contact_group Contact Group 1 already exists"
+
+- name: 3 - Test update
+  netbox.netbox.netbox_contact_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact Group 1
+      description: The first contact group
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "The first contact group"
+      - test_three['contact_group']['name'] == "Contact Group 1"
+      - test_three['contact_group']['description'] == "The first contact group"
+      - test_three['msg'] == "contact_group Contact Group 1 updated"
+
+- name: 4 - Test delete
+  netbox.netbox.netbox_contact_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact Group 1
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "contact_group Contact Group 1 deleted"
+
+- name: 5 - Create contact group with all parameters
+  netbox.netbox.netbox_contact_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact Group Parent
+      slug: the-parent-contact-group
+      description: The parent contact group
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['contact_group']['name'] == "Contact Group Parent"
+      - test_five['contact_group']['slug'] == "the-parent-contact-group"
+      - test_five['contact_group']['description'] == "The parent contact group"
+      - test_five['contact_group']['tags'] | length == 3
+      - test_five['msg'] == "contact_group Contact Group Parent created"
+
+- name: 6 - Create contact group with parent contact group
+  netbox.netbox.netbox_contact_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Contact Group Child
+      parent_contact_group: Contact Group Parent
+    state: present
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['contact_group']['name'] == "Contact Group Child"
+      - test_six['contact_group']['parent'] == test_five['contact_group']['id']
+      - test_six['msg'] == "contact_group Contact Group Child created"

--- a/tests/integration/targets/v4.5/tasks/netbox_contact_role.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_contact_role.yml
@@ -1,0 +1,94 @@
+---
+##
+##
+### NETBOX_CONTACT_ROLE
+##
+##
+- name: "CONTACT_ROLE 1: Necessary info creation"
+  netbox.netbox.netbox_contact_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Contact Role
+    state: present
+  register: test_one
+
+- name: "CONTACT_ROLE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['contact_role']['name'] == "Test Contact Role"
+      - test_one['contact_role']['slug'] == "test-contact-role"
+      - test_one['msg'] == "contact_role Test Contact Role created"
+
+- name: "CONTACT_ROLE 2: Create duplicate"
+  netbox.netbox.netbox_contact_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Contact Role
+    state: present
+  register: test_two
+
+- name: "CONTACT ROLE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['contact_role']['name'] == "Test Contact Role"
+      - test_two['contact_role']['slug'] == "test-contact-role"
+      - test_two['msg'] == "contact_role Test Contact Role already exists"
+
+- name: "CONTACT_ROLE 3: ASSERT - Update"
+  netbox.netbox.netbox_contact_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Contact Role
+      description: Update description
+    state: present
+  register: test_three
+
+- name: "IPAM_ROLE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Update description"
+      - test_three['contact_role']['name'] == "Test Contact Role"
+      - test_three['contact_role']['slug'] == "test-contact-role"
+      - test_three['contact_role']['description'] == "Update description"
+      - test_three['msg'] == "contact_role Test Contact Role updated"
+
+- name: "CONTACT_ROLE 4: ASSERT - Delete"
+  netbox.netbox.netbox_contact_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Contact Role
+    state: absent
+  register: test_four
+
+- name: "CONTACT_ROLE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "contact_role Test Contact Role deleted"
+
+- name: "CONTACT_ROLE 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_contact_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Contact Role
+    state: absent
+  register: test_five
+
+- name: "CONTACT_ROLE 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['contact_role'] == None
+      - test_five['msg'] == "contact_role Test Contact Role already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_custom_field.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_custom_field.yml
@@ -1,0 +1,129 @@
+---
+##
+##
+### NETBOX_CUSTOM_FIELD
+##
+##
+- name: "CUSTOM_FIELD 1: Necessary info creation"
+  netbox.netbox.netbox_custom_field:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: A_CustomField
+      type: text
+    state: present
+  register: test_one
+
+- name: "CUSTOM_FIELD 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['custom_field']['name'] == "A_CustomField"
+      - test_one['custom_field']['required'] == false
+      - test_one['custom_field']['object_types'] == ["dcim.device"]
+      - test_one['custom_field']['type'] == "text"
+      - test_one['custom_field']['weight'] == 100
+      - test_one['msg'] == "custom_field A_CustomField created"
+
+- name: "CUSTOM_FIELD 2: Create duplicate"
+  netbox.netbox.netbox_custom_field:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: A_CustomField
+    state: present
+  register: test_two
+
+- name: "CUSTOM_FIELD 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['custom_field']['name'] == "A_CustomField"
+      - test_two['msg'] == "custom_field A_CustomField already exists"
+
+- name: "CUSTOM_FIELD 3: Update data and make it required"
+  netbox.netbox.netbox_custom_field:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: A_CustomField
+      description: Added a description
+      required: true
+    state: present
+  register: test_three
+
+- name: "CUSTOM_FIELD 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Added a description"
+      - test_three['diff']['after']['required'] == true
+      - test_three['custom_field']['name'] == "A_CustomField"
+      - test_three['msg'] == "custom_field A_CustomField updated"
+
+- name: "CUSTOM_FIELD 4: Change content type"
+  netbox.netbox.netbox_custom_field:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - virtualization.virtualmachine
+      name: A_CustomField
+      description: Added a description
+      required: true
+    state: present
+  register: test_four
+
+- name: "CUSTOM_FIELD 4: ASSERT - Change content type"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['object_types'] == ["virtualization.virtualmachine"]
+      - test_four['custom_field']['name'] == "A_CustomField"
+      - test_four['msg'] == "custom_field A_CustomField updated"
+
+- name: "CUSTOM_FIELD 5: Delete"
+  netbox.netbox.netbox_custom_field:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: A_CustomField
+    state: absent
+  register: test_five
+
+- name: "CUSTOM_FIELD 5: ASSERT - Deleted"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['custom_field']['name'] == "A_CustomField"
+      - test_five['msg'] == "custom_field A_CustomField deleted"
+
+# Change in NetBox 3.7
+# - name: "CUSTOM_FIELD 6: UI Visibility (hidden-ifunset)"
+#  netbox.netbox.netbox_custom_field:
+#   netbox_url: http://localhost:32768
+#   netbox_token: 0123456789abcdef0123456789abcdef01234567
+#   data:
+#     object_types:
+#       - "dcim.device"
+#     name: A_CustomField
+#     type: text
+#     ui_visibility: hidden-ifunset
+#   state: present
+# register: test_six
+
+# - name: "CUSTOM_FIELD 6: UI Visibility (hidden-ifunset)"
+# assert:
+#   that:
+#     - test_six is changed
+#     - test_six['custom_field']['name'] == "A_CustomField"
+#     - test_six['custom_field']['ui_visibility'] == "hidden-ifunset"

--- a/tests/integration/targets/v4.5/tasks/netbox_custom_link.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_custom_link.yml
@@ -1,0 +1,113 @@
+---
+##
+##
+### NETBOX_CUSTOM_LINK
+##
+##
+- name: "CUSTOM_LINK 1: Necessary info creation"
+  netbox.netbox.netbox_custom_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: Custom Link
+      link_text: Open Web management
+      link_url: !unsafe https://{{ obj.name }}.domain.local/
+    state: present
+  register: test_one
+
+- name: "CUSTOM_LINK 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['custom_link']['name'] == "Custom Link"
+      - test_one['custom_link']['object_types'] == ["dcim.device"]
+      - test_one['custom_link']['link_text'] == "Open Web management"
+      - test_one['msg'] == "custom_link Custom Link created"
+
+- name: "CUSTOM_LINK 2: Create duplicate"
+  netbox.netbox.netbox_custom_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: Custom Link
+      link_text: Open Web management
+      link_url: !unsafe https://{{ obj.name }}.domain.local/
+    state: present
+  register: test_two
+
+- name: "CUSTOM_LINK 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['custom_link']['name'] == "Custom Link"
+      - test_two['msg'] == "custom_link Custom Link already exists"
+
+- name: "CUSTOM_FIELD 3: Update data and add weight"
+  netbox.netbox.netbox_custom_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: Custom Link
+      link_text: Open Web management
+      link_url: !unsafe https://{{ obj.name }}.domain.local/
+      weight: 50
+    state: present
+  register: test_three
+
+- name: "CUSTOM_FIELD 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['weight'] == 50
+      - test_three['custom_link']['name'] == "Custom Link"
+      - test_three['msg'] == "custom_link Custom Link updated"
+
+- name: "CUSTOM_LINK 4: Change content type"
+  netbox.netbox.netbox_custom_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - virtualization.virtualmachine
+      name: Custom Link
+      link_text: Open Web management
+      link_url: !unsafe https://{{ obj.name }}.domain.local/
+    state: present
+  register: test_four
+
+- name: "CUSTOM_LINK 4: ASSERT - Change content type"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['object_types'] == ["virtualization.virtualmachine"]
+      - test_four['custom_link']['name'] == "Custom Link"
+      - test_four['msg'] == "custom_link Custom Link updated"
+
+- name: "CUSTOM_LINK 5: Delete"
+  netbox.netbox.netbox_custom_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - virtualization.virtualmachine
+      name: Custom Link
+      link_text: Open Web management
+      link_url: !unsafe https://{{ obj.name }}.domain.local/
+    state: absent
+  register: test_five
+
+- name: "CUSTOM_LINK 5: ASSERT - Deleted"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['custom_link']['name'] == "Custom Link"
+      - test_five['msg'] == "custom_link Custom Link deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_data_source.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_data_source.yml
@@ -1,0 +1,75 @@
+---
+##
+##
+### NETBOX_DATA_SOURCE
+##
+##
+- name: "DATA SOURCE 1: Create"
+  netbox.netbox.netbox_data_source:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "Data Source 1"
+      type: "local"
+      source_url: "/tmp/data-source.txt"
+      enabled: true
+    state: present
+  register: test_one
+
+- name: "DATA SOURCE 1: Assert - Create"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['data_source']['name'] == "Data Source 1"
+      - test_one['data_source']['type'] == "local"
+      - test_one['data_source']['source_url'] == "/tmp/data-source.txt"
+      - test_one['data_source']['enabled'] == true
+      - test_one['msg'] == "data_source Data Source 1 created"
+
+- name: "DATA SOURCE 2: Update"
+  netbox.netbox.netbox_data_source:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "Data Source 1"
+      type: "amazon-s3"
+      source_url: "path/to/bucket"
+      enabled: false
+      description: "My first data source"
+      ignore_rules: ".*\nfoo.txt\n*.yml"
+      sync_interval: 1440
+      comments: "Some commentary on this data source"
+    state: present
+  register: test_two
+
+- name: "DATA SOURCE 2: Assert - Update"
+  ansible.builtin.assert:
+    that:
+      - test_two is changed
+      - test_two['data_source']['name'] == "Data Source 1"
+      - test_two['data_source']['type'] == "amazon-s3"
+      - test_two['data_source']['source_url'] == "path/to/bucket"
+      - test_two['data_source']['enabled'] == false
+      - test_two['data_source']['description'] == "My first data source"
+      - test_two['data_source']['ignore_rules'] == ".*\nfoo.txt\n*.yml"
+      - test_two['data_source']['sync_interval'] == 1440
+      - test_two['data_source']['comments'] == "Some commentary on this data source"
+      - test_two['msg'] == "data_source Data Source 1 updated"
+
+- name: "DATA SOURCE 3: Delete"
+  netbox.netbox.netbox_data_source:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: "Data Source 1"
+    state: absent
+  register: test_three
+
+- name: "DATA SOURCE 3: Assert - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_device.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device.yml
@@ -1,0 +1,243 @@
+---
+##
+##
+### NETBOX_DEVICE
+##
+##
+- name: 1 - Device with required information
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: R1
+      device_type:
+        id: "1"
+      device_role: Core Switch
+      site: Test Site
+      status: Staged
+    state: present
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == 'absent'
+      - test_one['diff']['after']['state'] == 'present'
+      - test_one['device']['name'] == "R1"
+      - test_one['device']['role'] == 1
+      - test_one['device']['device_type'] == 1
+      - test_one['device']['site'] == 1
+      - test_one['device']['status'] == "staged"
+      - test_one['device']['name'] == "R1"
+      - test_one['msg'] == "device R1 created"
+
+- name: 2 - Duplicate device
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: R1
+      device_type: Cisco Test
+      device_role: Core Switch
+      site: Test Site
+      status: Staged
+    state: present
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['device']['name'] == "R1"
+      - test_two['device']['role'] == 1
+      - test_two['device']['device_type'] == 1
+      - test_two['device']['site'] == 1
+      - test_two['device']['status'] == "staged"
+      - test_two['msg'] == "device R1 already exists"
+
+- name: 3 - Update device
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: R1
+      serial: FXS1001
+      local_context_data:
+        bgp_as: "65412"
+      virtual_chassis: VC1
+      vc_position: 3
+      vc_priority: 15
+      location: Test Rack Group
+    state: present
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['serial'] == "FXS1001"
+      - test_three['diff']['after']['local_context_data']["bgp_as"] == "65412"
+      - test_three['diff']['after']['virtual_chassis'] == 1
+      - test_three['diff']['after']['vc_position'] == 3
+      - test_three['diff']['after']['vc_priority'] == 15
+      - test_three['device']['name'] == "R1"
+      - test_three['device']['role'] == 1
+      - test_three['device']['device_type'] == 1
+      - test_three['device']['site'] == 1
+      - test_three['device']['status'] == "staged"
+      - test_three['device']['serial'] == "FXS1001"
+      - test_three['device']['local_context_data']["bgp_as"] == "65412"
+      - test_three['device']['virtual_chassis'] == 1
+      - test_three['device']['vc_position'] == 3
+      - test_three['device']['vc_priority'] == 15
+      - test_three['device']['location'] == 1
+      - test_three['msg'] == "device R1 updated"
+
+- name: 3.1 - Update device name using query_params
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: R1-changed-name
+      serial: FXS1001
+    query_params:
+      - serial
+    state: present
+  register: test_three_dot_one
+
+- name: 3.1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three_dot_one is changed
+      - test_three_dot_one['diff']['after']['name'] == "R1-changed-name"
+      - test_three_dot_one['device']['role'] == 1
+      - test_three_dot_one['device']['device_type'] == 1
+      - test_three_dot_one['device']['site'] == 1
+      - test_three_dot_one['device']['status'] == "staged"
+      - test_three_dot_one['device']['serial'] == "FXS1001"
+      - test_three_dot_one['device']['local_context_data']["bgp_as"] == "65412"
+      - test_three_dot_one['msg'] == "device R1-changed-name updated"
+
+- name: 4 - Create device with tags and assign to rack
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: TestR1
+      device_type: "1841"
+      device_role: Core Switch
+      site: Test Site2
+      rack: Test Rack Site 2
+      position: 35.5
+      face: Front
+      tags:
+        - schnozzberry
+      tenant: Test Tenant
+      asset_tag: "1234"
+    state: present
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['device']['name'] == "TestR1"
+      - test_four['device']['role'] == 1
+      - test_four['device']['device_type'] == 5
+      - test_four['device']['site'] == 2
+      - test_four['device']['status'] == "active"
+      - test_four['device']['rack'] == 1
+      - test_four['device']['tags'][0] == 4
+      - test_four['device']['tenant'] == 1
+      - test_four['device']['asset_tag'] == '1234'
+      - test_four['msg'] == "device TestR1 created"
+
+- name: 5 - Delete previous device
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: TestR1
+    state: absent
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "device TestR1 deleted"
+
+- name: 6 - Delete R1
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: R1-changed-name
+    state: absent
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "present"
+      - test_six['diff']['after']['state'] == "absent"
+      - test_six['msg'] == "device R1-changed-name deleted"
+
+- name: 7 - Add primary_ip4/6 to test100
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test100
+      primary_ip4: 172.16.180.1/24
+      primary_ip6: 2001::1:1/64
+    state: present
+  register: test_seven
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['after']['primary_ip4'] == 1
+      - test_seven['diff']['after']['primary_ip6'] == 2
+      - test_seven['device']['name'] == "test100"
+      - test_seven['device']['role'] == 1
+      - test_seven['device']['device_type'] == 1
+      - test_seven['device']['site'] == 1
+      - test_seven['device']['status'] == "active"
+      - test_seven['device']['primary_ip4'] == 1
+      - test_seven['device']['primary_ip6'] == 2
+      - test_seven['msg'] == "device test100 updated"
+
+- name: 8 - Device with empty string name
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: ""
+      device_type:
+        id: 1
+      device_role: Core Switch
+      site: Test Site
+      status: Staged
+    state: present
+  register: test_eight
+
+- name: 8 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == 'absent'
+      - test_eight['diff']['after']['state'] == 'present'
+      - test_eight['device']['role'] == 1
+      - test_eight['device']['device_type'] == 1
+      - test_eight['device']['site'] == 1
+      - test_eight['device']['status'] == "staged"
+      - "'-' in test_eight['device']['name']"
+      - test_eight['device']['name'] | length == 36

--- a/tests/integration/targets/v4.5/tasks/netbox_device_bay.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device_bay.yml
@@ -1,0 +1,87 @@
+---
+##
+##
+### NETBOX_DEVICE_BAY
+##
+##
+- name: "DEVICE_BAY 1: Necessary info creation"
+  netbox.netbox.netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Device Bay One
+    state: present
+  register: test_one
+
+- name: "DEVICE_BAY 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_bay']['name'] == "Device Bay One"
+      - test_one['device_bay']['device'] == 4
+      - test_one['msg'] == "device_bay Device Bay One created"
+
+- name: "DEVICE_BAY 2: Create duplicate"
+  netbox.netbox.netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Device Bay One
+    state: present
+  register: test_two
+
+- name: "DEVICE_BAY 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['device_bay']['name'] == "Device Bay One"
+      - test_two['device_bay']['device'] == 4
+      - test_two['msg'] == "device_bay Device Bay One already exists"
+
+- name: "DEVICE_BAY 3: ASSERT - Update"
+  netbox.netbox.netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Device Bay One
+      installed_device: Test Nexus Child One
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "DEVICE_BAY 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['installed_device'] == 5
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['device_bay']['name'] == "Device Bay One"
+      - test_three['device_bay']['device'] == 4
+      - test_three['device_bay']['installed_device'] == 5
+      - test_three['device_bay']['tags'][0] == 4
+      - test_three['msg'] == "device_bay Device Bay One updated"
+
+- name: "DEVICE_BAY 4: ASSERT - Delete"
+  netbox.netbox.netbox_device_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Device Bay One
+    state: absent
+  register: test_four
+
+- name: "DEVICE_BAY 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['device_bay']['name'] == "Device Bay One"
+      - test_four['device_bay']['device'] == 4
+      - test_four['device_bay']['installed_device'] == 5
+      - test_four['device_bay']['tags'][0] == 4
+      - test_four['msg'] == "device_bay Device Bay One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_device_bay_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device_bay_template.yml
@@ -1,0 +1,81 @@
+---
+##
+##
+### NETBOX_DEVICE_BAY_TEMPLATE
+##
+##
+- name: "DEVICE_BAY_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_device_bay_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: WS Test 3850
+      name: Device Bay Template One
+    state: present
+  register: test_one
+
+- name: "DEVICE_BAY_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_bay_template']['name'] == "Device Bay Template One"
+      - test_one['device_bay_template']['device_type'] == 7
+      - test_one['msg'] == "device_bay_template Device Bay Template One created"
+
+- name: "DEVICE_BAY_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_device_bay_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: WS Test 3850
+      name: Device Bay Template One
+    state: present
+  register: test_two
+
+- name: "DEVICE_BAY_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['device_bay_template']['name'] == "Device Bay Template One"
+      - test_two['device_bay_template']['device_type'] == 7
+      - test_two['msg'] == "device_bay_template Device Bay Template One already exists"
+
+- name: "DEVICE_BAY_TEMPLATE 3: ASSERT - Create Device Bay Template for Delete Test"
+  netbox.netbox.netbox_device_bay_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: WS Test 3850
+      name: Device Bay Template Two
+    state: present
+  register: test_three
+
+- name: "DEVICE_BAY_TEMPLATE 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['device_bay_template']['name'] == "Device Bay Template Two"
+      - test_three['device_bay_template']['device_type'] == 7
+      - test_three['msg'] == "device_bay_template Device Bay Template Two created"
+
+- name: "DEVICE_BAY_TEMPLATE 4: ASSERT - Delete"
+  netbox.netbox.netbox_device_bay_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Device Bay Template Two
+      device_type: WS Test 3850
+    state: absent
+  register: test_four
+
+- name: "DEVICE_BAY_TEMPLATE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['device_bay_template']['name'] == "Device Bay Template Two"
+      - test_four['device_bay_template']['device_type'] == 7
+      - test_four['msg'] == "device_bay_template Device Bay Template Two deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device_interface.yml
@@ -1,0 +1,332 @@
+---
+# NETBOX_DEVICE_INTERFACE
+
+- name: 1 - Interface with required information
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      type: 1000Base-T (1GE)
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['msg'] == "interface GigabitEthernet3 created"
+      - test_one['diff']['before']['state'] == 'absent'
+      - test_one['diff']['after']['state'] == 'present'
+      - test_one['interface']['name'] == "GigabitEthernet3"
+      - test_one['interface']['device'] == 1
+
+- name: 2 - Update test100 - GigabitEthernet3
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      mtu: 1600
+      enabled: false
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_two is changed
+      - test_two['msg'] == "interface GigabitEthernet3 updated"
+      - test_two['diff']['after']['enabled'] == false
+      - test_two['diff']['after']['mtu'] == 1600
+      - test_two['interface']['name'] == "GigabitEthernet3"
+      - test_two['interface']['device'] == 1
+      - test_two['interface']['enabled'] == false
+      - test_two['interface']['mtu'] == 1600
+
+- name: 3 - Delete interface test100 - GigabitEthernet3
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+    state: absent
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['msg'] == "interface GigabitEthernet3 deleted"
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+
+- name: 4 - Create LAG with several specified options
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: port-channel1
+      type: Link Aggregation Group (LAG)
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['msg'] == "interface port-channel1 created"
+      - test_four['diff']['before']['state'] == 'absent'
+      - test_four['diff']['after']['state'] == 'present'
+      - test_four['interface']['name'] == "port-channel1"
+      - test_four['interface']['device'] == 1
+      - test_four['interface']['enabled'] == true
+      - test_four['interface']['type'] == "lag"
+      - test_four['interface']['mgmt_only'] == false
+      - test_four['interface']['mode'] == "access"
+      - test_four['interface']['mtu'] == 1600
+
+- name: 5 - Create interface and assign it to parent LAG
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet3
+      enabled: false
+      type: 1000Base-T (1GE)
+      lag:
+        name: port-channel1
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['msg'] == "interface GigabitEthernet3 created"
+      - test_five['diff']['before']['state'] == 'absent'
+      - test_five['diff']['after']['state'] == 'present'
+      - test_five['interface']['name'] == "GigabitEthernet3"
+      - test_five['interface']['device'] == 1
+      - test_five['interface']['enabled'] == false
+      - test_five['interface']['type'] == "1000base-t"
+      - test_five['interface']['mgmt_only'] == false
+      - test_five['interface']['lag'] == test_four["interface"]["id"]
+      - test_five['interface']['mode'] == "access"
+      - test_five['interface']['mtu'] == 1600
+
+- name: 6 - Create interface as trunk port
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet21
+      enabled: false
+      type: 1000Base-T (1GE)
+      untagged_vlan:
+        name: Wireless
+        site: Test Site
+      tagged_vlans:
+        - name: Data
+          site: Test Site
+        - name: VoIP
+          site: Test Site
+      mtu: 1600
+      mgmt_only: true
+      mode: Tagged
+    state: present
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['msg'] == "interface GigabitEthernet21 created"
+      - test_six['diff']['before']['state'] == 'absent'
+      - test_six['diff']['after']['state'] == 'present'
+      - test_six['interface']['name'] == "GigabitEthernet21"
+      - test_six['interface']['device'] == 1
+      - test_six['interface']['enabled'] == false
+      - test_six['interface']['type'] == "1000base-t"
+      - test_six['interface']['mgmt_only'] == true
+      - test_six['interface']['mode'] == "tagged"
+      - test_six['interface']['mtu'] == 1600
+      - test_six['interface']['tagged_vlans'] == [2, 3]
+      - test_six['interface']['untagged_vlan'] == 1
+
+- name: 7 - Duplicate Interface
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet1
+  register: test_seven
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['msg'] == "interface GigabitEthernet1 already exists"
+      - test_seven['interface']['name'] == "GigabitEthernet1"
+      - test_seven['interface']['device'] == 1
+
+- name: Add port-channel1 to R1 to test finding proper port-channel1
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: R1-Device
+      name: port-channel1
+      type: Link Aggregation Group (LAG)
+
+- name: 8 - Create interface and assign it to parent LAG - non dict
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet4
+      enabled: false
+      type: 1000Base-T (1GE)
+      lag: port-channel1
+      mtu: 1600
+      mgmt_only: false
+      mode: Access
+    state: present
+  register: test_eight
+
+- name: 8 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eight is changed
+      - test_eight['msg'] == "interface GigabitEthernet4 created"
+      - test_eight['diff']['before']['state'] == 'absent'
+      - test_eight['diff']['after']['state'] == 'present'
+      - test_eight['interface']['name'] == "GigabitEthernet4"
+      - test_eight['interface']['device'] == 1
+      - test_eight['interface']['enabled'] == false
+      - test_eight['interface']['type'] == "1000base-t"
+      - test_eight['interface']['mgmt_only'] == false
+      - test_eight['interface']['lag'] == 10
+      - test_eight['interface']['mode'] == "access"
+      - test_eight['interface']['mtu'] == 1600
+
+- name: 9 - Create interface on VC child
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus Child One
+      name: Ethernet2/2
+      type: 1000Base-T (1GE)
+    state: present
+  register: test_nine
+
+- name: 9 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['msg'] == "interface Ethernet2/2 created"
+      - test_nine['diff']['before']['state'] == 'absent'
+      - test_nine['diff']['after']['state'] == 'present'
+      - test_nine['interface']['name'] == "Ethernet2/2"
+      - test_nine['interface']['device'] == 5
+      - test_nine['interface']['enabled'] == true
+      - test_nine['interface']['type'] == "1000base-t"
+
+- name: 10 - Update interface on VC child
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Ethernet2/2
+      description: Updated child interface from parent device
+      type: 1000Base-T (1GE)
+    update_vc_child: true
+    state: present
+  register: test_ten
+
+- name: 10 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['msg'] == "interface Ethernet2/2 updated"
+      - test_ten['diff']['after']['description'] == 'Updated child interface from parent device'
+      - test_ten['interface']['name'] == "Ethernet2/2"
+      - test_ten['interface']['device'] == 5
+      - test_ten['interface']['enabled'] == true
+      - test_ten['interface']['type'] == "1000base-t"
+      - test_ten['interface']['description'] == 'Updated child interface from parent device'
+
+- name: 11 - Update interface on VC child w/o update_vc_child
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: Test Nexus One
+      name: Ethernet2/2
+      description: Updated child interface from parent device - test
+      type: 1000Base-T (1GE)
+    state: present
+  ignore_errors: true
+  register: test_eleven
+
+- name: 11 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eleven is failed
+      - test_eleven['msg'] == "Must set update_vc_child to True to allow child device interface modification"
+
+- name: 12 - Create interface and mark it as connected
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet5
+      type: 1000Base-T (1GE)
+      mark_connected: true
+  register: test_twelve
+
+- name: 12- ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_twelve is changed
+      - test_twelve['msg'] == "interface GigabitEthernet5 created"
+      - test_twelve['diff']['before']['state'] == 'absent'
+      - test_twelve['diff']['after']['state'] == 'present'
+      - test_twelve['interface']['name'] == "GigabitEthernet5"
+      - test_twelve['interface']['device'] == 1
+      - test_twelve['interface']['mark_connected'] == true
+
+- name: "13 - Update interface primary MAC address"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: GigabitEthernet2
+      primary_mac_address: "AA:AB:CC:DD:EE:FF"
+    state: present
+  register: test_thirteen
+
+- name: "13 - ASSERT"
+  ansible.builtin.assert:
+    that:
+      - test_thirteen is changed
+      - test_thirteen['msg'] == "interface GigabitEthernet2 updated"
+      - test_thirteen['interface']['name'] == "GigabitEthernet2"
+      - test_thirteen['interface']['device'] == 1
+      - test_thirteen['interface']['primary_mac_address'] == 2

--- a/tests/integration/targets/v4.5/tasks/netbox_device_interface_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device_interface_template.yml
@@ -1,0 +1,109 @@
+---
+##
+##
+### NETBOX_DEVICE_INTERFACE_TEMPLATE
+##
+##
+- name: 1 - Interface with required information
+  netbox.netbox.netbox_device_interface_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: Arista Test
+      name: 10GBASE-T (10GE)
+      type: 10gbase-t
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['msg'] == "interface_template 10GBASE-T (10GE) created"
+      - test_one['diff']['before']['state'] == 'absent'
+      - test_one['diff']['after']['state'] == 'present'
+      - test_one['interface_template']['name'] == "10GBASE-T (10GE)"
+      - test_one['interface_template']['device_type'] == 2
+      - test_one['interface_template']['type'] == '10gbase-t'
+
+- name: 2 - Update 10GBASE-T (10GE)
+  netbox.netbox.netbox_device_interface_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: Arista Test
+      name: 10GBASE-T (10GE)
+      type: 10gbase-t
+      mgmt_only: true
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_two is changed
+      - test_two['msg'] == "interface_template 10GBASE-T (10GE) updated"
+      - test_two['diff']['after']['mgmt_only'] == true
+      - test_two['interface_template']['name'] == "10GBASE-T (10GE)"
+      - test_two['interface_template']['device_type'] == 2
+      - test_two['interface_template']['mgmt_only'] == true
+
+- name: 3 - Delete interface template 10GBASE-T (10GE)
+  netbox.netbox.netbox_device_interface_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: Arista Test
+      name: 10GBASE-T (10GE)
+      type: 10gbase-t
+    state: absent
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['msg'] == "interface_template 10GBASE-T (10GE) deleted"
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+
+- name: 4 - Create LAG with several specified options
+  netbox.netbox.netbox_device_interface_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: Arista Test
+      name: port channel template
+      type: lag
+      mgmt_only: false
+    state: present
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['msg'] == "interface_template port channel template created"
+      - test_four['diff']['before']['state'] == 'absent'
+      - test_four['diff']['after']['state'] == 'present'
+      - test_four['interface_template']['name'] == "port channel template"
+      - test_four['interface_template']['device_type'] == 2
+      - test_four['interface_template']['type'] == "lag"
+      - test_four['interface_template']['mgmt_only'] == false
+
+- name: 5 - Duplicate Interface Template port channel template
+  netbox.netbox.netbox_device_interface_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device_type: Arista Test
+      name: port channel template
+      type: lag
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['msg'] == "interface_template port channel template already exists"
+      - test_five['interface_template']['name'] == "port channel template"
+      - test_five['interface_template']['device_type'] == 2
+      - test_five['interface_template']['type'] == "lag"

--- a/tests/integration/targets/v4.5/tasks/netbox_device_role.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device_role.yml
@@ -1,0 +1,101 @@
+---
+##
+##
+### NETBOX_DEVICE_ROLE
+##
+##
+- name: "DEVICE_ROLE 1: Necessary info creation"
+  netbox.netbox.netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Device Role
+      color: FFFFFF
+    state: present
+  register: test_one
+
+- name: "DEVICE_ROLE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_role']['name'] == "Test Device Role"
+      - test_one['device_role']['slug'] == "test-device-role"
+      - test_one['device_role']['color'] == "ffffff"
+      - test_one['msg'] == "device_role Test Device Role created"
+
+- name: "DEVICE_ROLE 2: Create duplicate"
+  netbox.netbox.netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Device Role
+      color: FFFFFF
+    state: present
+  register: test_two
+
+- name: "DEVICE_ROLE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['device_role']['name'] == "Test Device Role"
+      - test_two['device_role']['slug'] == "test-device-role"
+      - test_two['device_role']['color'] == "ffffff"
+      - test_two['msg'] == "device_role Test Device Role already exists"
+
+- name: "DEVICE_ROLE 3: ASSERT - Update"
+  netbox.netbox.netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Device Role
+      color: "003EFF"
+      vm_role: false
+    state: present
+  register: test_three
+
+- name: "DEVICE_ROLE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "003eff"
+      - test_three['diff']['after']['vm_role'] == false
+      - test_three['device_role']['name'] == "Test Device Role"
+      - test_three['device_role']['slug'] == "test-device-role"
+      - test_three['device_role']['color'] == "003eff"
+      - test_three['device_role']['vm_role'] == false
+      - test_three['msg'] == "device_role Test Device Role updated"
+
+- name: "DEVICE_ROLE 4: ASSERT - Delete"
+  netbox.netbox.netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Device Role
+    state: absent
+  register: test_four
+
+- name: "DEVICE_ROLE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "device_role Test Device Role deleted"
+
+- name: "DEVICE_ROLE 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_device_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Device Role
+    state: absent
+  register: test_five
+
+- name: "DEVICE_ROLE 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['device_role'] == None
+      - test_five['msg'] == "device_role Test Device Role already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_device_type.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device_type.yml
@@ -1,0 +1,132 @@
+---
+##
+##
+### NETBOX_DEVICE_TYPE
+##
+##
+- name: "DEVICE_TYPE 1: Necessary info creation"
+  netbox.netbox.netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      slug: test-device-type
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_one
+
+- name: "DEVICE_TYPE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['device_type']['slug'] == "test-device-type"
+      - test_one['device_type']['model'] == "ws-test-3750"
+      - test_one['device_type']['manufacturer'] == 3
+      - test_one['msg'] == "device_type test-device-type created"
+
+- name: "DEVICE_TYPE 2: Create duplicate"
+  netbox.netbox.netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      slug: test-device-type
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_two
+
+- name: "DEVICE_TYPE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_one['device_type']['slug'] == "test-device-type"
+      - test_one['device_type']['model'] == "ws-test-3750"
+      - test_one['device_type']['manufacturer'] == 3
+      - test_two['msg'] == "device_type test-device-type already exists"
+
+- name: "DEVICE_TYPE 3: ASSERT - Update"
+  netbox.netbox.netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      slug: test-device-type
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+      part_number: ws-3750g-v2
+      u_height: 1.5
+      is_full_depth: false
+      subdevice_role: parent
+    state: present
+  register: test_three
+
+- name: "DEVICE_TYPE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['is_full_depth'] == false
+      - test_three['diff']['after']['part_number'] == "ws-3750g-v2"
+      - test_three['diff']['after']['subdevice_role'] == "parent"
+      - test_three['device_type']['slug'] == "test-device-type"
+      - test_three['device_type']['model'] == "ws-test-3750"
+      - test_three['device_type']['manufacturer'] == 3
+      - test_three['device_type']['is_full_depth'] == false
+      - test_three['device_type']['part_number'] == "ws-3750g-v2"
+      - test_three['device_type']['subdevice_role'] == "parent"
+      - test_three['msg'] == "device_type test-device-type updated"
+
+- name: "DEVICE_TYPE 4: ASSERT - Delete"
+  netbox.netbox.netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: test-device-type
+    state: absent
+  register: test_four
+
+- name: "DEVICE_TYPE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "device_type test-device-type deleted"
+
+- name: "DEVICE_TYPE 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Test Device Type
+    state: absent
+  register: test_five
+
+- name: "DEVICE_TYPE 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['device_type'] == None
+      - test_five['msg'] == "device_type Test Device Type already absent"
+
+- name: "DEVICE_TYPE 6: Without Slug"
+  netbox.netbox.netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: WS Test 3850
+      manufacturer: Test Manufacturer
+      subdevice_role: parent
+    state: present
+  register: test_six
+
+- name: "DEVICE_TYPE 6: ASSERT - Without Slug"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['device_type']['slug'] == "ws-test-3850"
+      - test_six['device_type']['model'] == "WS Test 3850"
+      - test_six['device_type']['manufacturer'] == 3
+      - test_six['msg'] == "device_type WS Test 3850 created"

--- a/tests/integration/targets/v4.5/tasks/netbox_export_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_export_template.yml
@@ -1,0 +1,118 @@
+---
+##
+##
+### NETBOX_EXPORT_TEMPLATE
+##
+##
+- name: "EXPORT_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_export_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: Example Export Template
+      description: Export Devices
+      template_code: !unsafe >-
+        {% for obj in queryset %}{{ obj.name }}{% endfor %}
+    state: present
+  register: test_one
+
+- name: "EXPORT_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['export_template']['name'] == "Example Export Template"
+      - test_one['export_template']['object_types'] == ["dcim.device"]
+      - test_one['export_template']['description'] == "Export Devices"
+      - test_one['msg'] == "export_template Example Export Template created"
+
+- name: "EXPORT_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_export_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: Example Export Template
+      description: Export Devices
+      template_code: !unsafe >-
+        {% for obj in queryset %}{{ obj.name }}{% endfor %}
+    state: present
+  register: test_two
+
+- name: "EXPORT_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['export_template']['name'] == "Example Export Template"
+      - test_two['msg'] == "export_template Example Export Template already exists"
+
+- name: "EXPORT_TEMPLATE 3: Update data and remove as_attachment"
+  netbox.netbox.netbox_export_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - dcim.device
+      name: Example Export Template
+      description: Export Devices
+      template_code: !unsafe >-
+        {% for obj in queryset %}{{ obj.name }}{% endfor %}
+      as_attachment: false
+    state: present
+  register: test_three
+
+- name: "EXPORT_TEMPLATE 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['as_attachment'] == false
+      - test_three['export_template']['name'] == "Example Export Template"
+      - test_three['msg'] == "export_template Example Export Template updated"
+
+- name: "EXPORT_TEMPLATE 4: Change content type"
+  netbox.netbox.netbox_export_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - virtualization.virtualmachine
+      name: Example Export Template
+      description: Export Devices
+      template_code: !unsafe >-
+        {% for obj in queryset %}{{ obj.name }}{% endfor %}
+    state: present
+  register: test_four
+
+- name: "EXPORT_TEMPLATE 4: ASSERT - Change content type"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['object_types'] == ["virtualization.virtualmachine"]
+      - test_four['export_template']['name'] == "Example Export Template"
+      - test_four['msg'] == "export_template Example Export Template updated"
+
+- name: "EXPORT_TEMPLATE 5: Delete"
+  netbox.netbox.netbox_export_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      object_types:
+        - virtualization.virtualmachine
+      name: Example Export Template
+      description: Export Devices
+      template_code: !unsafe >-
+        {% for obj in queryset %}{{ obj.name }}{% endfor %}
+    state: absent
+  register: test_five
+
+- name: "EXPORT_TEMPLATE 5: ASSERT - Deleted"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['export_template']['name'] == "Example Export Template"
+      - test_five['msg'] == "export_template Example Export Template deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_fhrp_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_fhrp_group.yml
@@ -1,0 +1,91 @@
+---
+##
+##
+### NETBOX_FHRP_GROUP
+##
+##
+- name: "FHRP group 1: Test FHRP group creation"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      protocol: glbp
+      group_id: 111
+    state: present
+  register: test_one
+
+- name: "FHRP group: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['fhrp_group']['group_id'] == 111
+      - test_one['fhrp_group']['protocol'] == "glbp"
+      - test_one['msg'] == "fhrp_group 111 created"
+
+- name: "FHRP group 2: Create duplicate"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      protocol: glbp
+      group_id: 111
+    state: present
+  register: test_two
+
+- name: "FHRP group 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['fhrp_group']['group_id'] == 111
+      - test_two['fhrp_group']['protocol'] == "glbp"
+      - test_two['msg'] == "fhrp_group 111 already exists"
+
+- name: "FHRP group 3: Update FHRP group with other fields"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      protocol: glbp
+      group_id: 111
+      auth_type: md5
+      auth_key: 11111
+      description: Test description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "FHRP group 3: ASSERT - Update FHRP group with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['auth_type'] == "md5"
+      - test_three['diff']['after']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['diff']['after']['description'] == "Test description"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['fhrp_group']['group_id'] == 111
+      - test_three['fhrp_group']['protocol'] == "glbp"
+      - test_three['fhrp_group']['auth_type'] == "md5"
+      - test_three['fhrp_group']['auth_key'] == "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+      - test_three['fhrp_group']['description'] == "Test description"
+      - test_three['fhrp_group']['tags'][0] == 4
+      - test_three['msg'] == "fhrp_group 111 updated"
+
+- name: "FHRP group 4: ASSERT - Delete"
+  netbox.netbox.netbox_fhrp_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      group_id: 111
+    state: absent
+  register: test_four
+
+- name: "FHRP group 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "fhrp_group 111 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_fhrp_group_assignment.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_fhrp_group_assignment.yml
@@ -1,0 +1,92 @@
+---
+##
+##
+### NETBOX_FHRP_GROUP_ASSIGNMENT
+##
+##
+- name: "FHRP group assignment 1: Test FHRP group assignment creation"
+  netbox.netbox.netbox_fhrp_group_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      fhrp_group: 1
+      interface_type: dcim.interface
+      interface_id: 1
+      priority: 1
+    state: present
+  register: test_one
+
+- name: "FHRP group assignment: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['fhrp_group_assignment']['group'] == 1
+      - test_one['fhrp_group_assignment']['interface_type'] == "dcim.interface"
+      - test_one['fhrp_group_assignment']['interface_id'] == 1
+      - test_one['fhrp_group_assignment']['priority'] ==  1
+      - test_one['msg'] == "fhrp_group_assignment fhrp_group 1 > dcim.interface 1 created"
+
+- name: "FHRP group assignment 2: Create duplicate"
+  netbox.netbox.netbox_fhrp_group_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      fhrp_group: 1
+      interface_type: dcim.interface
+      interface_id: 1
+      priority: 1
+    state: present
+  register: test_two
+
+- name: "FHRP group assignment 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['fhrp_group_assignment']['group'] == 1
+      - test_two['fhrp_group_assignment']['interface_type'] == "dcim.interface"
+      - test_two['fhrp_group_assignment']['interface_id'] == 1
+      - test_two['fhrp_group_assignment']['priority'] ==  1
+      - test_two['msg'] == "fhrp_group_assignment fhrp_group 1 > dcim.interface 1 already exists"
+
+- name: "FHRP group assignment 3: Update FHRP group assignment"
+  netbox.netbox.netbox_fhrp_group_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      fhrp_group: 1
+      interface_type: dcim.interface
+      interface_id: 1
+      priority: 2
+    state: present
+  register: test_three
+
+- name: "FHRP group assignment 3: ASSERT - Update FHRP group assignment"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['fhrp_group_assignment']['group'] == 1
+      - test_three['fhrp_group_assignment']['interface_type'] == "dcim.interface"
+      - test_three['fhrp_group_assignment']['interface_id'] == 1
+      - test_three['fhrp_group_assignment']['priority'] ==  2
+      - test_three['msg'] == "fhrp_group_assignment fhrp_group 1 > dcim.interface 1 updated"
+
+- name: "FHRP group assignment 4: Delete FHRP group assignment"
+  netbox.netbox.netbox_fhrp_group_assignment:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      fhrp_group: 1
+      interface_type: dcim.interface
+      interface_id: 1
+    state: absent
+  register: test_four
+
+- name: "FHRP group assignment 3: ASSERT - Delete FHRP group assignment"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "fhrp_group_assignment fhrp_group 1 > dcim.interface 1 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_front_port.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_front_port.yml
@@ -1,0 +1,137 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_FRONT_PORT
+##
+## Note: In NetBox v4.5, rear_port and rear_port_position fields were replaced
+## by the PortMapping model (rear_ports). These fields are removed from test
+## data and assertions.
+##
+- name: "FRONT_PORT 1: Necessary info creation"
+  netbox.netbox.netbox_front_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port
+      device: test100
+      type: bnc
+    state: present
+  register: test_one
+
+- name: "FRONT_PORT 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['front_port']['name'] == "Front Port"
+      - test_one['front_port']['device'] == 1
+      - test_one['front_port']['type'] == "bnc"
+      - test_one['msg'] == "front_port Front Port created"
+
+- name: "FRONT_PORT 2: Create duplicate"
+  netbox.netbox.netbox_front_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port
+      device: test100
+      type: bnc
+    state: present
+  register: test_two
+
+- name: "FRONT_PORT 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['front_port']['name'] == "Front Port"
+      - test_two['front_port']['device'] == 1
+      - test_two['front_port']['type'] == "bnc"
+      - test_two['msg'] == "front_port Front Port already exists"
+
+- name: "FRONT_PORT 3: Update Front Port with other fields"
+  netbox.netbox.netbox_front_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port
+      device: test100
+      type: bnc
+      description: test description
+    state: present
+  register: test_three
+
+- name: "FRONT_PORT 3: ASSERT - Update Front Port with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "test description"
+      - test_three['front_port']['name'] == "Front Port"
+      - test_three['front_port']['device'] == 1
+      - test_three['front_port']['type'] == "bnc"
+      - test_three['front_port']['description'] == "test description"
+      - test_three['msg'] == "front_port Front Port updated"
+
+- name: "FRONT_PORT 4: Create Front Port for Delete Test"
+  netbox.netbox.netbox_front_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port 2
+      device: test100
+      type: bnc
+    state: present
+  register: test_four
+
+- name: "FRONT_PORT 4: ASSERT - Create Front Port for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['front_port']['name'] == "Front Port 2"
+      - test_four['front_port']['device'] == 1
+      - test_four['front_port']['type'] == "bnc"
+      - test_four['msg'] == "front_port Front Port 2 created"
+
+- name: "FRONT_PORT 5: Delete Front Port"
+  netbox.netbox.netbox_front_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port 2
+      device: test100
+      type: bnc
+    state: absent
+  register: test_five
+
+- name: "FRONT_PORT 5: ASSERT - Delete Front Port"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "front_port Front Port 2 deleted"
+
+- name: "FRONT_PORT 6: Create duplicate (idempotency check)"
+  netbox.netbox.netbox_front_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port
+      device: test100
+      type: bnc
+    state: present
+  register: test_six
+
+- name: "FRONT_PORT 6: ASSERT - Create duplicate (idempotency check)"
+  ansible.builtin.assert:
+    that:
+      - not test_six['changed']
+      - test_six['front_port']['name'] == "Front Port"
+      - test_six['front_port']['device'] == 1
+      - test_six['front_port']['type'] == "bnc"
+      - test_six['msg'] == "front_port Front Port already exists"

--- a/tests/integration/targets/v4.5/tasks/netbox_front_port_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_front_port_template.yml
@@ -1,0 +1,262 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_FRONT_PORT_TEMPLATE
+##
+## Note: In NetBox v4.5, rear_port and rear_port_position fields were replaced
+## by the PortMapping model. These fields are removed from test data and
+## assertions.
+##
+- name: "NETBOX_FRONT_PORT_TEMPLATE 0.1: Create module type for testing power ports on module types"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Module Type Front And Rear Port Tests
+      manufacturer: Test Manufacturer
+    state: present
+
+- name: "FRONT_PORT_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port Template
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_one
+
+- name: "FRONT_PORT_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['front_port_template']['name'] == "Front Port Template"
+      - test_one['front_port_template']['device_type'] == 1
+      - test_one['front_port_template']['type'] == "bnc"
+      - test_one['msg'] == "front_port_template Front Port Template created"
+
+- name: "FRONT_PORT_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port Template
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_two
+
+- name: "FRONT_PORT_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['front_port_template']['name'] == "Front Port Template"
+      - test_two['front_port_template']['device_type'] == 1
+      - test_two['front_port_template']['type'] == "bnc"
+      - test_two['msg'] == "front_port_template Front Port Template already exists"
+
+- name: "FRONT_PORT_TEMPLATE 3: Update Front Port Template with other fields"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port Template
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_three
+
+- name: "FRONT_PORT_TEMPLATE 3: ASSERT - Update Front Port Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three['front_port_template']['name'] == "Front Port Template"
+      - test_three['front_port_template']['device_type'] == 1
+      - test_three['front_port_template']['type'] == "bnc"
+
+- name: "FRONT_PORT_TEMPLATE 4: Create Front Port Template for Delete Test"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port Template 2
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_four
+
+- name: "FRONT_PORT_TEMPLATE 4: ASSERT - Create Front Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['front_port_template']['name'] == "Front Port Template 2"
+      - test_four['front_port_template']['device_type'] == 1
+      - test_four['front_port_template']['type'] == "bnc"
+      - test_four['msg'] == "front_port_template Front Port Template 2 created"
+
+- name: "FRONT_PORT_TEMPLATE 5: Delete Front Port Template"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port Template 2
+      device_type: Cisco Test
+      type: bnc
+    state: absent
+  register: test_five
+
+- name: "FRONT_PORT_TEMPLATE 5: ASSERT - Delete Front Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "front_port_template Front Port Template 2 deleted"
+
+- name: "FRONT_PORT_TEMPLATE 6: Create duplicate (idempotency check)"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Front Port Template
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_six
+
+- name: "FRONT_PORT_TEMPLATE 6: ASSERT - Create duplicate (idempotency check)"
+  ansible.builtin.assert:
+    that:
+      - not test_six['changed']
+      - test_six['front_port_template']['name'] == "Front Port Template"
+      - test_six['front_port_template']['device_type'] == 1
+      - test_six['front_port_template']['type'] == "bnc"
+      - test_six['msg'] == "front_port_template Front Port Template already exists"
+
+- name: "FRONT_PORT_TEMPLATE 7: Necessary info creation (module type)"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_seven
+
+- name: "FRONT_PORT_TEMPLATE 7: ASSERT - Necessary info creation (module type)"
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_seven['front_port_template']['module_type'] == 1
+      - test_seven['front_port_template']['type'] == "bnc"
+      - test_seven['msg'] == "front_port_template Module Type Front Port Template created"
+
+- name: "FRONT_PORT_TEMPLATE 8: Create duplicate (module type)"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_eight
+
+- name: "FRONT_PORT_TEMPLATE 8: ASSERT - Create duplicate (module type)"
+  ansible.builtin.assert:
+    that:
+      - not test_eight['changed']
+      - test_eight['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_eight['front_port_template']['module_type'] == 1
+      - test_eight['front_port_template']['type'] == "bnc"
+      - test_eight['msg'] == "front_port_template Module Type Front Port Template already exists"
+
+- name: "FRONT_PORT_TEMPLATE 9: Update Front Port Template with other fields (module type)"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_nine
+
+- name: "FRONT_PORT_TEMPLATE 9: ASSERT - Update Front Port Template with other fields (module type)"
+  ansible.builtin.assert:
+    that:
+      - test_nine['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_nine['front_port_template']['module_type'] == 1
+      - test_nine['front_port_template']['type'] == "bnc"
+
+- name: "FRONT_PORT_TEMPLATE 10: Create Front Port Template for Delete Test (module type)"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_ten
+
+- name: "FRONT_PORT_TEMPLATE 10: ASSERT - Create Front Port Template for Delete Test (module type)"
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['front_port_template']['name'] == "Module Type Front Port Template 2"
+      - test_ten['front_port_template']['module_type'] == 1
+      - test_ten['front_port_template']['type'] == "bnc"
+      - test_ten['msg'] == "front_port_template Module Type Front Port Template 2 created"
+
+- name: "FRONT_PORT_TEMPLATE 11: Delete Front Port Template (module type)"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: absent
+  register: test_eleven
+
+- name: "FRONT_PORT_TEMPLATE 11: ASSERT - Delete Front Port Template (module type)"
+  ansible.builtin.assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "present"
+      - test_eleven['diff']['after']['state'] == "absent"
+      - test_eleven['msg'] == "front_port_template Module Type Front Port Template 2 deleted"
+
+- name: "FRONT_PORT_TEMPLATE 12: Create duplicate (module type, idempotency check)"
+  netbox.netbox.netbox_front_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Front Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_twelve
+
+- name: "FRONT_PORT_TEMPLATE 12: ASSERT - Create duplicate (module type, idempotency check)"
+  ansible.builtin.assert:
+    that:
+      - not test_twelve['changed']
+      - test_twelve['front_port_template']['name'] == "Module Type Front Port Template"
+      - test_twelve['front_port_template']['module_type'] == 1
+      - test_twelve['front_port_template']['type'] == "bnc"
+      - test_twelve['msg'] == "front_port_template Module Type Front Port Template already exists"

--- a/tests/integration/targets/v4.5/tasks/netbox_inventory_item.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_inventory_item.yml
@@ -1,0 +1,203 @@
+---
+##
+##
+### NETBOX_INVENTORY_ITEM
+##
+##
+- name: "INVENTORY_ITEM 1: Necessary info creation"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: 10G-SFP+
+    state: present
+  register: test_one
+
+- name: "INVENTORY_ITEM 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one.diff.before.state == "absent"
+      - test_one.diff.after.state == "present"
+      - test_one.inventory_item.name == "10G-SFP+"
+      - test_one.inventory_item.device == 1
+      - test_one.msg == "inventory_item 10G-SFP+ created"
+
+- name: "INVENTORY_ITEM 2: Create duplicate"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: 10G-SFP+
+    state: present
+  register: test_two
+
+- name: "INVENTORY_ITEM 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two.changed
+      - test_two.inventory_item.name == "10G-SFP+"
+      - test_two.inventory_item.device == 1
+      - test_two.msg == "inventory_item 10G-SFP+ already exists"
+
+- name: "INVENTORY_ITEM 3: Update properties"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: 10G-SFP+
+      manufacturer: Cisco
+      part_id: 10G-SFP+
+      serial: "1234"
+      asset_tag: "1234"
+      description: New SFP
+      discovered: true
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "INVENTORY_ITEM 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three.diff.after.asset_tag == "1234"
+      - test_three.diff.after.serial == "1234"
+      - test_three.diff.after.description == "New SFP"
+      - test_three.diff.after.manufacturer == 1
+      - test_three.diff.after.part_id == "10G-SFP+"
+      - test_three.diff.after.tags[0] == 4
+      - test_three.diff.after.discovered == True
+      - test_three.inventory_item.name == "10G-SFP+"
+      - test_three.inventory_item.device == 1
+      - test_three.inventory_item.asset_tag == "1234"
+      - test_three.inventory_item.serial == "1234"
+      - test_three.inventory_item.description == "New SFP"
+      - test_three.inventory_item.manufacturer == 1
+      - test_three.inventory_item.part_id == "10G-SFP+"
+      - test_three.inventory_item.tags[0] == 4
+      - test_three.inventory_item.discovered == True
+      - test_three.msg == "inventory_item 10G-SFP+ updated"
+
+- name: "INVENTORY_ITEM 4: Delete inventory item"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: 10G-SFP+
+    state: absent
+  register: test_four
+
+- name: "INVENTORY_ITEM 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four.inventory_item.name == "10G-SFP+"
+      - test_four.inventory_item.device == 1
+      - test_four.inventory_item.asset_tag == "1234"
+      - test_four.inventory_item.serial == "1234"
+      - test_four.inventory_item.description == "New SFP"
+      - test_four.inventory_item.manufacturer == 1
+      - test_four.inventory_item.part_id == "10G-SFP+"
+      - test_four.inventory_item.tags[0] == 4
+      - test_four.msg == "inventory_item 10G-SFP+ deleted"
+
+- name: "INVENTORY_ITEM 5: PREWORK - Create inventory item role"
+  netbox.netbox.netbox_inventory_item_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Processor
+      color: FFFFFF
+    state: present
+  register: test_five_prework
+
+- name: "INVENTORY_ITEM 5: Create inventory item with role"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: test_processor
+      inventory_item_role: Processor
+    state: present
+  register: test_five
+
+- name: "INVENTORY_ITEM 5: ASSERT - Inventory item creation with role"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five.diff.before.state == "absent"
+      - test_five.diff.after.state == "present"
+      - test_five.inventory_item.name == "test_processor"
+      - test_five.inventory_item.role == test_five_prework.inventory_item_role.id
+      - test_five.inventory_item.device == 1
+      - test_five.msg == "inventory_item test_processor created"
+
+- name: "INVENTORY_ITEM 6: Create inventory item with missing role"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: test_processor
+      inventory_item_role: Foo
+    state: present
+  ignore_errors: true
+  register: test_six
+
+- name: "INVENTORY_ITEM 6: ASSERT - Inventory item creation with missing role"
+  ansible.builtin.assert:
+    that:
+      - test_six.failed
+      - test_six.msg == "Could not resolve id of inventory_item_role: Foo"
+
+- name: "INVENTORY_ITEM 7: Create inventory item with component"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: test_component
+      component_type: dcim.interface
+      component:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  register: test_seven
+
+- name: "INVENTORY_ITEM 7: ASSERT - Inventory item creation with component"
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven.diff.before.state == "absent"
+      - test_seven.diff.after.state == "present"
+      - test_seven.inventory_item.name == "test_component"
+      - test_seven.inventory_item.component_type == "dcim.interface"
+      - test_seven.inventory_item.component_id == 4
+      - test_seven.inventory_item.device == 1
+      - test_seven.msg == "inventory_item test_component created"
+
+- name: "INVENTORY_ITEM 8: Create inventory item with missing component_type"
+  netbox.netbox.netbox_inventory_item:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: test_component
+      component:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  ignore_errors: true
+  register: test_eight
+
+- name: "INVENTORY_ITEM 8: ASSERT - Inventory item creation with missing component_type"
+  ansible.builtin.assert:
+    that:
+      - test_eight.failed
+      - test_eight.msg == "parameters are required together: component_type, component"

--- a/tests/integration/targets/v4.5/tasks/netbox_inventory_item_role.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_inventory_item_role.yml
@@ -1,0 +1,98 @@
+---
+##
+##
+### NETBOX_INVENTORY_ITEM_ROLE
+##
+##
+- name: "INVENTORY_ITEM_ROLE 1: Necessary info creation"
+  netbox.netbox.netbox_inventory_item_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Inventory Item Role
+      color: FFFFFF
+    state: present
+  register: test_one
+
+- name: "INVENTORY_ITEM_ROLE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['inventory_item_role']['name'] == "Test Inventory Item Role"
+      - test_one['inventory_item_role']['slug'] == "test-inventory-item-role"
+      - test_one['inventory_item_role']['color'] == "ffffff"
+      - test_one['msg'] == "inventory_item_role Test Inventory Item Role created"
+
+- name: "INVENTORY_ITEM_ROLE 2: Create duplicate"
+  netbox.netbox.netbox_inventory_item_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Inventory Item Role
+      color: FFFFFF
+    state: present
+  register: test_two
+
+- name: "INVENTORY_ITEM_ROLE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['inventory_item_role']['name'] == "Test Inventory Item Role"
+      - test_two['inventory_item_role']['slug'] == "test-inventory-item-role"
+      - test_two['inventory_item_role']['color'] == "ffffff"
+      - test_two['msg'] == "inventory_item_role Test Inventory Item Role already exists"
+
+- name: "INVENTORY_ITEM_ROLE 3: ASSERT - Update"
+  netbox.netbox.netbox_inventory_item_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Inventory Item Role
+      color: "003EFF"
+    state: present
+  register: test_three
+
+- name: "INVENTORY_ITEM_ROLE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "003eff"
+      - test_three['inventory_item_role']['name'] == "Test Inventory Item Role"
+      - test_three['inventory_item_role']['slug'] == "test-inventory-item-role"
+      - test_three['inventory_item_role']['color'] == "003eff"
+      - test_three['msg'] == "inventory_item_role Test Inventory Item Role updated"
+
+- name: "INVENTORY_ITEM_ROLE 4: ASSERT - Delete"
+  netbox.netbox.netbox_inventory_item_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Inventory Item Role
+    state: absent
+  register: test_four
+
+- name: "INVENTORY_ITEM_ROLE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "inventory_item_role Test Inventory Item Role deleted"
+
+- name: "INVENTORY_ITEM_ROLE 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_inventory_item_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Inventory Item Role
+    state: absent
+  register: test_five
+
+- name: "INVENTORY_ITEM_ROLE 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['inventory_item_role'] == None
+      - test_five['msg'] == "inventory_item_role Test Inventory Item Role already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_ip_address.yml
@@ -1,0 +1,401 @@
+---
+##
+##
+### NETBOX_IP_ADDRESS
+##
+##
+- name: "1 - Create IP address within NetBox with only required information - State: Present"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      address: 192.168.1.10/30
+    state: present
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['msg'] == "ip_address 192.168.1.10/30 created"
+      - test_one['ip_address']['address'] == "192.168.1.10/30"
+
+- name: 2 - Update 192.168.1.10/30
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      address: 192.168.1.10/30
+      description: Updated ip address
+      tags:
+        - Updated
+    state: present
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_two is changed
+      - test_two['diff']['after']['description'] == "Updated ip address"
+      - test_two['diff']['after']['tags'][0] == 10
+      - test_two['msg'] == "ip_address 192.168.1.10/30 updated"
+      - test_two['ip_address']['address'] == "192.168.1.10/30"
+      - test_two['ip_address']['tags'][0] == 10
+      - test_two['ip_address']['description'] == "Updated ip address"
+
+- name: "3 - Delete IP - 192.168.1.10 - State: Absent"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      address: 192.168.1.10/30
+    state: absent
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "ip_address 192.168.1.10/30 deleted"
+
+- name: "4 - Create IP in global VRF - 192.168.1.20/30 - State: Present"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      address: 192.168.1.20/30
+    state: present
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['msg'] == "ip_address 192.168.1.20/30 created"
+      - test_four['ip_address']['address'] == "192.168.1.20/30"
+
+# Enforce uniqueness in NetBox 3.7
+# - name: "5 - Create IP in global VRF - 192.168.1.20/30 - State: New"
+#  netbox.netbox.netbox_ip_address:
+#    netbox_url: http://localhost:32768
+#    netbox_token: 0123456789abcdef0123456789abcdef01234567
+#    data:
+#      address: 192.168.1.20/30
+#    state: new
+#  register: test_five
+
+# - name: "5 - ASSERT"
+#  assert:
+#    that:
+#      - test_five is changed
+#      - test_five['diff']['before']['state'] == "absent"
+#      - test_five['diff']['after']['state'] == "present"
+#      - test_five['msg'] == "ip_address 192.168.1.20/30 created"
+#      - test_five['ip_address']['address'] == "192.168.1.20/30"
+
+- name: "6 - Create new address with only prefix specified - State: new"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 192.168.100.0/24
+    state: new
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['msg'] == "ip_address 192.168.100.1/24 created"
+      - test_six['ip_address']['address'] == "192.168.100.1/24"
+
+- name: 7 - Create IP address with several specified
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      address: 172.16.1.20/24
+      vrf: Test VRF
+      tenant: Test Tenant
+      status: Reserved
+      role: Loopback
+      description: Test description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_seven
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['msg'] == "ip_address 172.16.1.20/24 created"
+      - test_seven['ip_address']['address'] == "172.16.1.20/24"
+      - test_seven['ip_address']['description'] == "Test description"
+      - test_seven['ip_address']['family'] == 4
+      - test_seven['ip_address']['role'] == "loopback"
+      - test_seven['ip_address']['status'] == "reserved"
+      - test_seven['ip_address']['tags'][0] == 4
+      - test_seven['ip_address']['tenant'] == 1
+      - test_seven['ip_address']['vrf'] == 1
+
+- name: 8 - Create IP address and assign a nat_inside IP
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      address: 10.10.1.30/16
+      vrf: Test VRF
+      nat_inside:
+        address: 172.16.1.20
+        vrf: Test VRF
+  register: test_eight
+
+- name: 8 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "absent"
+      - test_eight['diff']['after']['state'] == "present"
+      - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
+      - test_eight['ip_address']['address'] == "10.10.1.30/16"
+      - test_eight['ip_address']['family'] == 4
+      - test_eight['ip_address'].get('nat_inside')
+      - test_eight['ip_address']['vrf'] == 1
+
+- name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      address: 10.10.200.30/16
+      assigned_object:
+        name: GigabitEthernet2
+        device: test100
+  register: test_nine
+
+- name: 9 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['msg'] == "ip_address 10.10.200.30/16 created"
+      - test_nine['ip_address']['address'] == "10.10.200.30/16"
+      - test_nine['ip_address']['family'] == 4
+      - test_nine['ip_address']['assigned_object_type'] == "dcim.interface"
+      - test_nine['ip_address']['assigned_object_id'] == 4
+
+- name: "10 - Create IP address on GigabitEthernet2 - test100 - State: new"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      prefix: 10.10.0.0/16
+      assigned_object:
+        name: GigabitEthernet2
+        device: test100
+    state: new
+  register: test_ten
+
+- name: 10 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['msg'] == "ip_address 10.10.0.1/16 created"
+      - test_ten['ip_address']['address'] == "10.10.0.1/16"
+      - test_ten['ip_address']['family'] == 4
+      - test_ten['ip_address']['assigned_object_type'] == "dcim.interface"
+      - test_ten['ip_address']['assigned_object_id'] == 4
+
+- name: "11 - Create IP address on GigabitEthernet2 - test100 - State: present"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      prefix: 192.168.100.0/24
+      assigned_object:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  register: test_eleven
+
+- name: 11 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "absent"
+      - test_eleven['diff']['after']['state'] == "present"
+      - test_eleven['msg'] == "ip_address 192.168.100.2/24 created"
+      - test_eleven['ip_address']['address'] == "192.168.100.2/24"
+
+- name: 12 - Duplicate - 192.168.100.2/24 on interface
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      address: 192.168.100.2/24
+      assigned_object:
+        name: GigabitEthernet2
+        device: test100
+    state: present
+  register: test_twelve
+
+- name: 12 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_twelve['changed']
+      - test_twelve['msg'] == "ip_address 192.168.100.2/24 already exists"
+      - test_twelve['ip_address']['address'] == "192.168.100.2/24"
+      - test_twelve['ip_address']['assigned_object_type'] == "dcim.interface"
+      - test_twelve['ip_address']['assigned_object_id'] == 4
+
+- name: 13 - Duplicate - 192.168.100.2/24
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      address: 192.168.100.2/24
+    state: present
+  register: test_thirteen
+
+- name: 13 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_thirteen['changed']
+      - test_thirteen['msg'] == "ip_address 192.168.100.2/24 already exists"
+      - test_thirteen['ip_address']['address'] == "192.168.100.2/24"
+
+- name: "14 - Create IP address on Eth0 - test100-vm - State: present"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      address: 10.188.1.100/24
+      assigned_object:
+        name: Eth0
+        virtual_machine: test100-vm
+  register: test_fourteen
+
+- name: 14 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_fourteen is changed
+      - test_fourteen['diff']['before']['state'] == "absent"
+      - test_fourteen['diff']['after']['state'] == "present"
+      - test_fourteen['msg'] == "ip_address 10.188.1.100/24 created"
+      - test_fourteen['ip_address']['address'] == "10.188.1.100/24"
+      - test_fourteen['ip_address']['family'] == 4
+      - test_fourteen['ip_address']['assigned_object_type'] == "virtualization.vminterface"
+      - test_fourteen['ip_address']['assigned_object_id'] == 1
+
+# Enforce uniqueness in NetBox 3.7
+# - name: "15 - Create same IP address on Eth0 - test101-vm - State: present"
+#  netbox.netbox.netbox_ip_address:
+#    netbox_url: http://localhost:32768
+#    netbox_token: 0123456789abcdef0123456789abcdef01234567
+#    data:
+#      family: 4
+#      address: 10.188.1.100/24
+#      assigned_object:
+#        name: Eth0
+#        virtual_machine: test101-vm
+#    state: "present"
+#  register: test_fifteen
+
+# - name: "15 - ASSERT"
+#  assert:
+#    that:
+#      - test_fifteen is changed
+#      - test_fifteen['diff']['before']['state'] == "absent"
+#      - test_fifteen['diff']['after']['state'] == "present"
+#      - test_fifteen['msg'] == "ip_address 10.188.1.100/24 created"
+#      - test_fifteen['ip_address']['address'] == "10.188.1.100/24"
+#      - test_fifteen['ip_address']['family'] == 4
+#      - test_fifteen['ip_address']['assigned_object_type'] == "virtualization.vminterface"
+#      - test_fifteen['ip_address']['assigned_object_id'] == 6
+
+- name: "16 - Create IP address with no mask - State: Present"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      address: 10.120.10.1
+    state: present
+  register: test_sixteen
+
+- name: 16 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_sixteen is changed
+      - test_sixteen['diff']['before']['state'] == "absent"
+      - test_sixteen['diff']['after']['state'] == "present"
+      - test_sixteen['msg'] == "ip_address 10.120.10.1/32 created"
+      - test_sixteen['ip_address']['address'] == "10.120.10.1/32"
+
+- name: "17 - Create IP address on GigabitEthernet2 - test100 with interface value - State: present"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      address: 10.10.200.31/16
+      interface:
+        device: test100
+        name: GigabitEthernet2
+  register: test_seventeen
+
+- name: 17 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seventeen is changed
+      - test_seventeen['diff']['before']['state'] == "absent"
+      - test_seventeen['diff']['after']['state'] == "present"
+      - test_seventeen['msg'] == "ip_address 10.10.200.31/16 created"
+      - test_seventeen['ip_address']['address'] == "10.10.200.31/16"
+      - test_seventeen['ip_address']['family'] == 4
+      - test_seventeen['ip_address']['assigned_object_type'] == "dcim.interface"
+      - test_seventeen['ip_address']['assigned_object_id'] == 4
+
+- name: "18 - Create IP address on GigabitEthernet2 - test100 with interface value - State: new"
+  netbox.netbox.netbox_ip_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      prefix: 10.10.0.0/16
+      interface:
+        name: GigabitEthernet2
+        device: test100
+    state: new
+  register: test_eighteen
+
+- name: 18 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eighteen is changed
+      - test_eighteen['diff']['before']['state'] == "absent"
+      - test_eighteen['diff']['after']['state'] == "present"
+      - test_eighteen['msg'] == "ip_address 10.10.0.2/16 created"
+      - test_eighteen['ip_address']['address'] == "10.10.0.2/16"
+      - test_eighteen['ip_address']['family'] == 4
+      - test_eighteen['ip_address']['assigned_object_type'] == "dcim.interface"
+      - test_eighteen['ip_address']['assigned_object_id'] == 4

--- a/tests/integration/targets/v4.5/tasks/netbox_ipam_role.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_ipam_role.yml
@@ -1,0 +1,94 @@
+---
+##
+##
+### NETBOX_IPAM_ROLE
+##
+##
+- name: "IPAM_ROLE 1: Necessary info creation"
+  netbox.netbox.netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test IPAM Role
+    state: present
+  register: test_one
+
+- name: "IPAM_ROLE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['role']['name'] == "Test IPAM Role"
+      - test_one['role']['slug'] == "test-ipam-role"
+      - test_one['msg'] == "role Test IPAM Role created"
+
+- name: "IPAM_ROLE 2: Create duplicate"
+  netbox.netbox.netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test IPAM Role
+    state: present
+  register: test_two
+
+- name: "IPAM_ROLE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['role']['name'] == "Test IPAM Role"
+      - test_two['role']['slug'] == "test-ipam-role"
+      - test_two['msg'] == "role Test IPAM Role already exists"
+
+- name: "IPAM_ROLE 3: ASSERT - Update"
+  netbox.netbox.netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test IPAM Role
+      weight: 4096
+    state: present
+  register: test_three
+
+- name: "IPAM_ROLE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['weight'] == 4096
+      - test_three['role']['name'] == "Test IPAM Role"
+      - test_three['role']['slug'] == "test-ipam-role"
+      - test_three['role']['weight'] == 4096
+      - test_three['msg'] == "role Test IPAM Role updated"
+
+- name: "IPAM_ROLE 4: ASSERT - Delete"
+  netbox.netbox.netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test IPAM Role
+    state: absent
+  register: test_four
+
+- name: "IPAM_ROLE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "role Test IPAM Role deleted"
+
+- name: "IPAM_ROLE 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_ipam_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test IPAM Role
+    state: absent
+  register: test_five
+
+- name: "IPAM_ROLE 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['role'] == None
+      - test_five['msg'] == "role Test IPAM Role already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_journal_entry.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_journal_entry.yml
@@ -1,0 +1,26 @@
+---
+##
+##
+### NETBOX_JOURNAL_ENTRY
+##
+##
+- name: "JOURNAL ENTRY 1: Creation"
+  netbox.netbox.netbox_journal_entry:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      assigned_object_type: dcim.device
+      assigned_object_id: 1
+      comments: |
+        Comment on device
+    state: new
+  register: test_one
+
+- name: "JOURNAL_ENTRY 1: ASSERT - Creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['journal_entry']['kind'] == "info"
+      - test_one['msg'] == "journal_entry created"

--- a/tests/integration/targets/v4.5/tasks/netbox_l2vpn.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_l2vpn.yml
@@ -1,0 +1,99 @@
+---
+##
+##
+### NETBOX_L2VPN
+##
+##
+- name: "L2VPN 1: Necessary info creation"
+  netbox.netbox.netbox_l2vpn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test L2VPN
+      type: vxlan
+    state: present
+  register: test_one
+
+- name: "L2VPN 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['l2vpn']['name'] == "Test L2VPN"
+      - test_one['l2vpn']['type'] == "vxlan"
+      - test_one['msg'] == "l2vpn Test L2VPN created"
+
+- name: "L2VPN 2: Create duplicate"
+  netbox.netbox.netbox_l2vpn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test L2VPN
+      type: vxlan
+    state: present
+  register: test_two
+
+- name: "L2VPN 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['l2vpn']['name'] == "Test L2VPN"
+      - test_two['l2vpn']['type'] == "vxlan"
+      - test_two['msg'] == "l2vpn Test L2VPN already exists"
+
+- name: "L2VPN 4: ASSERT - Update"
+  netbox.netbox.netbox_l2vpn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test L2VPN
+      type: vxlan
+      tenant: Test Tenant
+      description: Updated description
+      import_targets:
+        - 4000:4000
+        - 5000:5000
+      export_targets:
+        - 6000:6000
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four
+
+- name: "L2VPN: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['description'] == "Updated description"
+      - test_four['diff']['after']['import_targets'] == [1, 2]
+      - test_four['diff']['after']['export_targets'] == [3]
+      - test_four['diff']['after']['tags'][0] == 4
+      - test_four['l2vpn']['name'] == "Test L2VPN"
+      - test_four['l2vpn']['tenant'] == 1
+      - test_four['l2vpn']['import_targets'] == [1, 2]
+      - test_four['l2vpn']['export_targets'] == [3]
+      - test_four['l2vpn']['description'] == "Updated description"
+      - test_four['l2vpn']['tags'][0] == 4
+      - test_four['msg'] == "l2vpn Test L2VPN updated"
+
+- name: "L2VPN: ASSERT - Delete"
+  netbox.netbox.netbox_l2vpn:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test L2VPN
+      type: vxlan
+    state: absent
+  register: test_six
+
+- name: "L2VPN 6: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['l2vpn']['name'] == "Test L2VPN"
+      - test_six['l2vpn']['tenant'] == 1
+      - test_six['l2vpn']['type'] == "vxlan"
+      - test_six['l2vpn']['description'] == "Updated description"
+      - test_six['l2vpn']['tags'][0] == 4
+      - test_six['msg'] == "l2vpn Test L2VPN deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_l2vpn_termination.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_l2vpn_termination.yml
@@ -1,0 +1,94 @@
+---
+##
+##
+### NETBOX_L2VPN_TERMINATION
+##
+##
+- name: "L2VPN_TERMINATION 1: Necessary info creation"
+  netbox.netbox.netbox_l2vpn_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      l2vpn: 1
+      assigned_object_type: dcim.interface
+      assigned_object_id: 1
+    state: present
+  register: test_one
+
+- name: "L2VPN_TERMINATION 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['l2vpn_termination']['l2vpn'] == 1
+      - test_one['l2vpn_termination']['assigned_object_type'] == "dcim.interface"
+      - test_one['l2vpn_termination']['assigned_object_id'] == 1
+      - test_one['msg'] == "l2vpn_termination l2vpn 1 <> dcim.interface 1 created"
+
+- name: "L2VPN_TERMINATION 2: Create duplicate"
+  netbox.netbox.netbox_l2vpn_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      l2vpn: 1
+      assigned_object_type: dcim.interface
+      assigned_object_id: 1
+    state: present
+  register: test_two
+
+- name: "L2VPN_TERMINATION 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['l2vpn_termination']['l2vpn'] == 1
+      - test_two['l2vpn_termination']['assigned_object_type'] == "dcim.interface"
+      - test_two['l2vpn_termination']['assigned_object_id'] == 1
+      - test_two['msg'] == "l2vpn_termination l2vpn 1 <> dcim.interface 1 already exists"
+
+- name: "L2VPN_TERMINATION 3: Update"
+  netbox.netbox.netbox_l2vpn_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      l2vpn: 1
+      assigned_object_type: dcim.interface
+      assigned_object_id: 1
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "L2VPN_TERMINATION 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['l2vpn_termination']['l2vpn'] == 1
+      - test_three['l2vpn_termination']['assigned_object_type'] == "dcim.interface"
+      - test_three['l2vpn_termination']['assigned_object_id'] == 1
+      - test_three['l2vpn_termination']['tags'][0] == 4
+      - test_three['msg'] == "l2vpn_termination l2vpn 1 <> dcim.interface 1 updated"
+
+- name: "L2VPN_TERMINATION 4: Delete"
+  netbox.netbox.netbox_l2vpn_termination:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      l2vpn: 1
+      assigned_object_type: dcim.interface
+      assigned_object_id: 1
+    state: absent
+  register: test_four
+
+- name: "L2VPN_TERMINATION 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['l2vpn_termination']['l2vpn'] == 1
+      - test_four['l2vpn_termination']['assigned_object_type'] == "dcim.interface"
+      - test_four['l2vpn_termination']['assigned_object_id'] == 1
+      - test_four['l2vpn_termination']['tags'][0] == 4
+      - test_four['msg'] == "l2vpn_termination l2vpn 1 <> dcim.interface 1 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_location.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_location.yml
@@ -1,0 +1,85 @@
+---
+##
+##
+### NETBOX_LOCATION
+##
+##
+- name: "LOCATION 1: Necessary info creation"
+  netbox.netbox.netbox_location:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Location
+      site: Test Site
+    state: present
+  register: test_one
+
+- name: "LOCATION 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['location']['name'] == "Location"
+      - test_one['location']['slug'] == "location"
+      - test_one['location']['site'] == 1
+      - test_one['msg'] == "location Location created"
+
+- name: "LOCATION 2: Create duplicate"
+  netbox.netbox.netbox_location:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Location
+      site: Test Site
+    state: present
+  register: test_two
+
+- name: "LOCATION 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['location']['name'] == "Location"
+      - test_two['location']['slug'] == "location"
+      - test_two['location']['site'] == 1
+      - test_two['msg'] == "location Location already exists"
+
+- name: "LOCATION 3: Update"
+  netbox.netbox.netbox_location:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Location
+      parent_location: Parent Rack Group
+      description: This is a location
+    state: present
+  register: test_three
+
+- name: "LOCATION 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['parent'] == 2
+      - test_three['diff']['after']['description'] == "This is a location"
+      - test_three['location']['name'] == "Location"
+      - test_three['location']['slug'] == "location"
+      - test_three['location']['parent'] == 2
+      - test_three['location']['description'] == "This is a location"
+      - test_three['msg'] == "location Location updated"
+
+- name: "LOCATION 4: Delete"
+  netbox.netbox.netbox_location:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Location
+    state: absent
+  register: test_four
+
+- name: "LOCATION 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "location Location deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_lookup.yml
@@ -1,0 +1,105 @@
+---
+##
+##
+### NETBOX_LOOKUP
+##
+##
+- name: "NETBOX_LOOKUP 1: Lookup returns exactly four sites"
+  ansible.builtin.assert:
+    that: query_result == "4"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | count }}"
+
+- name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
+  ansible.builtin.assert:
+    that: query_result == "0"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`Wibble`]')
+      | count }}"
+
+- name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
+  ansible.builtin.assert:
+    that: query_result == "1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`TestDeviceR1`]')
+      | count }}"
+
+- name: "NETBOX_LOOKUP 4: VLAN ID 400 can be queried and is named 'Test VLAN'"
+  ansible.builtin.assert:
+    that: query_result == 'Test VLAN'
+  vars:
+    query_result: "{{ (query('netbox.netbox.nb_lookup', 'vlans', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.vid==`400`].value.name'))[0]
+      }}"
+
+- name: "NETBOX_LOOKUP 5: Add one of two devices for lookup filter test."
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: L1
+      device_type: Cisco Test
+      device_role: Core Switch
+      site: Test Site
+      status: Staged
+      tags:
+        - nolookup
+    state: present
+
+- name: "NETBOX_LOOKUP 6: Add two of two devices for lookup filter test."
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: L2
+      device_type: Cisco Test
+      device_role: Core Switch
+      site: Test Site2
+      status: Staged
+      tags:
+        - lookup
+    state: present
+
+- name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
+  ansible.builtin.assert:
+    that: query_result == "1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
+      | community.general.json_query('[?value.display==`L2`]') | count }}"
+
+- name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
+  ansible.builtin.assert:
+    that: query_result == "1"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567',
+      raw_data=True) | community.general.json_query('[?display==`L2`]') | count }}"
+
+- name: "NETBOX_LOOKUP 9: Device query specifying multiple sites, Make sure L1 and L2 are in the results"
+  ansible.builtin.assert:
+    that:
+      - "'L1' in query_result"
+      - "'L2' in query_result"
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch site=test-site site=test-site2', api_endpoint='http://localhost:32768',
+      token='0123456789abcdef0123456789abcdef01234567', raw_data=True) | community.general.json_query('[*].display') }}"
+
+- name: "NETBOX_LOOKUP 10: Device query by ID"
+  ansible.builtin.assert:
+    that: query_result
+  vars:
+    query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='id=1', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
+      }}"
+
+- name: "NETBOX_LOOKUP 11: Device query by ansible variable"
+  ansible.builtin.set_fact:
+    hostname: "L2"
+
+- name: "NETBOX LOOKUP 11.1: Obtain details of a single device from NetBox"
+  ansible.builtin.debug:
+    msg: >
+      "Device {{item.0.value.display}} (ID: {{item.0.key}}) was
+       manufactured by {{ item.0.value.device_type.manufacturer.name }}"
+  loop:
+    - '{{ query("netbox.netbox.nb_lookup", "devices",
+      api_filter="name=" ~hostname,
+      api_endpoint="http://localhost:32768",
+      token="0123456789abcdef0123456789abcdef01234567") }}'

--- a/tests/integration/targets/v4.5/tasks/netbox_mac_address.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_mac_address.yml
@@ -1,0 +1,70 @@
+---
+##
+##
+### NETBOX_MAC_ADDRESS
+##
+##
+- name: "MAC 1: Create MAC address with required parameters"
+  netbox.netbox.netbox_mac_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      mac_address: "00:11:22:33:44:55"
+    state: present
+  register: test_one
+
+- name: "MAC 1: ASSERT - Create MAC address"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['mac_address']['mac_address'] == "00:11:22:33:44:55"
+      - test_one['msg'] == "mac_address 00:11:22:33:44:55 created"
+
+- name: "MAC 2: Create MAC address with all parameters"
+  netbox.netbox.netbox_mac_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      mac_address: "AA:BB:CC:DD:EE:F0"
+      assigned_object:
+        device: Test Nexus One
+        name: Ethernet1/1
+      description: "Test MAC address"
+      comments: "Test MAC address comment"
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_two
+
+- name: "MAC 2: ASSERT - Create MAC address with all parameters"
+  ansible.builtin.assert:
+    that:
+      - test_two is changed
+      - test_two['diff']['before']['state'] == "absent"
+      - test_two['diff']['after']['state'] == "present"
+      - test_two['mac_address']['mac_address'] == "AA:BB:CC:DD:EE:F0"
+      - test_two['mac_address']['assigned_object_type'] == "dcim.interface"
+      - test_two['mac_address']['assigned_object_id'] == 1
+      - test_two['mac_address']['description'] == "Test MAC address"
+      - test_two['mac_address']['comments'] == "Test MAC address comment"
+      - test_two['mac_address']['tags'][0] == 4
+      - test_two['msg'] == "mac_address AA:BB:CC:DD:EE:F0 created"
+
+- name: "MAC 3: Delete MAC address"
+  netbox.netbox.netbox_mac_address:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      mac_address: "00:11:22:33:44:55"
+    state: absent
+  register: test_three
+
+- name: "MAC 3: ASSERT - Delete MAC address"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "mac_address 00:11:22:33:44:55 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_manufacturer.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_manufacturer.yml
@@ -1,0 +1,91 @@
+---
+##
+##
+### NETBOX_MANUFACTURER
+##
+##
+- name: "MANUFACTURER 1: Necessary info creation"
+  netbox.netbox.netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Manufacturer Two
+    state: present
+  register: test_one
+
+- name: "MANUFACTURER 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['manufacturer']['name'] == "Test Manufacturer Two"
+      - test_one['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_one['msg'] == "manufacturer Test Manufacturer Two created"
+
+- name: "MANUFACTURER 2: Create duplicate"
+  netbox.netbox.netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Manufacturer Two
+    state: present
+  register: test_two
+
+- name: "MANUFACTURER 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['manufacturer']['name'] == "Test Manufacturer Two"
+      - test_two['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_two['msg'] == "manufacturer Test Manufacturer Two already exists"
+
+- name: "MANUFACTURER 3: Update"
+  netbox.netbox.netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test manufacturer two
+    state: present
+  register: test_three
+
+- name: "MANUFACTURER 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three['changed']
+      - test_three['manufacturer']['name'] == "test manufacturer two"
+      - test_three['manufacturer']['slug'] == "test-manufacturer-two"
+      - test_three['msg'] == "manufacturer test manufacturer two updated"
+
+- name: "MANUFACTURER 4: ASSERT - Delete"
+  netbox.netbox.netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: test manufacturer two
+    state: absent
+  register: test_four
+
+- name: "MANUFACTURER 3: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "manufacturer test manufacturer two deleted"
+
+- name: "MANUFACTURER 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_manufacturer:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Manufacturer Two
+    state: absent
+  register: test_five
+
+- name: "MANUFACTURER 5: ASSERT - Delete non existing"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['manufacturer'] == None
+      - test_five['msg'] == "manufacturer Test Manufacturer Two already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_module.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_module.yml
@@ -1,0 +1,107 @@
+---
+##
+##
+### NETBOX_MODULE
+##
+##
+- name: "MODULE 1: Necessary info creation"
+  netbox.netbox.netbox_module:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      module_bay: Network Module
+      module_type: C9300-NM-8X
+    state: present
+  register: test_one
+
+- name: "MODULE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['module']['device'] == "C9300-DEMO"
+      - test_one['module']['module_bay'] == "Network Module"
+      - test_one['module']['module_type'] == "C9300-NM-8X"
+      - test_one['msg'] == "module ws-test-3750 created"
+
+- name: "MODULE 2: Create duplicate"
+  netbox.netbox.netbox_module:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      module_bay: Network Module
+      module_type: C9300-NM-8X
+    state: present
+  register: test_two
+
+- name: "MODULE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['module']['device'] == "C9300-DEMO"
+      - test_two['module']['module_bay'] == "Network Module"
+      - test_two['module']['module_type'] == "C9300-NM-8X"
+      - test_two['msg'] == "module C9300-NM-8X already exists in slot Network Module of C9300-DEMO"
+
+- name: "MODULE 3: ASSERT - Update"
+  netbox.netbox.netbox_module:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      module_bay: Network Module
+      module_type: C9300-NM-8X
+      serial: XXXNNNNXXXX
+    state: present
+  register: test_three
+
+- name: "MODULE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['serial'] == "XXXNNNNXXXX"
+      - test_three['module']['device'] == "C9300-DEMO"
+      - test_three['module']['module_bay'] == "Network Module"
+      - test_three['module']['module_type'] == "C9300-NM-8X"
+      - test_three['module']['serial'] == "XXXNNNNXXXX"
+      - test_three['msg'] == "module C9300-DEMO - Network Module - C9300-NM-8X updated"
+
+- name: "MODULE 4: ASSERT - Delete"
+  netbox.netbox.netbox_module:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      module_bay: Network Module
+      module_type: C9300-NM-8X
+    state: absent
+  register: test_four
+
+- name: "MODULE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "module C9300-NM-8X deleted in slot Network Module of C9300-DEMO"
+
+- name: "MODULE 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_module:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      module_bay: Network Module
+      module_type: C9300-NM-2Y
+    state: absent
+  register: test_five
+
+- name: "MODULE 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['module'] == None
+      - test_five['msg'] == "module Test Module Type already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_module_bay.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_module_bay.yml
@@ -1,0 +1,105 @@
+---
+##
+##
+### NETBOX_MODULE_BAY
+##
+##
+- name: "MODULE 1: Necessary info creation"
+  netbox.netbox.netbox_module_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      name: Network Module
+      position: 0
+    state: present
+  register: test_one
+
+- name: "MODULE BAY 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['module_bay']['device'] == "C9300-DEMO"
+      - test_one['module_bay']['name'] == "Network Module"
+      - test_one['module_bay']['position'] == "0"
+      - test_one['msg'] == "module_bay Network Module in C9300-DEMO position 0 created"
+
+- name: "MODULE BAY 2: Create duplicate"
+  netbox.netbox.netbox_module_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      name: Network Module
+      position: 0
+    state: present
+  register: test_two
+
+- name: "MODULE BAY 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['module_bay']['device'] == "C9300-DEMO"
+      - test_two['module_bay']['name'] == "Network Module"
+      - test_two['module_bay']['position'] == "0"
+      - test_two['msg'] == "module_bay Network Module in C9300-DEMO position 0 already exists"
+
+- name: "MODULE BAY 3: ASSERT - Update"
+  netbox.netbox.netbox_module_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      name: Network Module
+      position: 0
+      label: TEST
+    state: present
+  register: test_three
+
+- name: "MODULE BAY 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['label'] == "TEST"
+      - test_three['module_bay']['device'] == "C9300-DEMO"
+      - test_three['module_bay']['name'] == "Network Module"
+      - test_three['module_bay']['position'] == "0"
+      - test_three['module_bay']['label'] == "TEST"
+      - test_three['msg'] == "module_bay Network Module in C9300-DEMO position 0 updated with label TEST"
+
+- name: "MODULE BAY 4: ASSERT - Delete"
+  netbox.netbox.netbox_module_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      name: Network Module
+    state: absent
+  register: test_four
+
+- name: "MODULE BAY 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "module_bay Network Module in C9300-DEMO position 0 deleted"
+
+- name: "MODULE BAY 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_module_bay:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: C9300-DEMO
+      name: Network Module
+    state: absent
+  register: test_five
+
+- name: "MODULE BAY 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['module_bay'] == None
+      - test_five['msg'] == "module_bay Network Module already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_module_type.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_module_type.yml
@@ -1,0 +1,97 @@
+---
+##
+##
+### NETBOX_MODULE_TYPE
+##
+##
+- name: "MODULE_TYPE 1: Necessary info creation"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_one
+
+- name: "MODULE_TYPE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['module_type']['model'] == "ws-test-3750"
+      - test_one['module_type']['manufacturer'] == 3
+      - test_one['msg'] == "module_type ws-test-3750 created"
+
+- name: "MODULE_TYPE 2: Create duplicate"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_two
+
+- name: "MODULE_TYPE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_one['module_type']['model'] == "ws-test-3750"
+      - test_one['module_type']['manufacturer'] == 3
+      - test_two['msg'] == "module_type ws-test-3750 already exists"
+
+- name: "MODULE_TYPE 3: ASSERT - Update"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: ws-test-3750
+      manufacturer: Test Manufacturer
+      part_number: ws-3750g-v2
+    state: present
+  register: test_three
+
+- name: "MODULE_TYPE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['part_number'] == "ws-3750g-v2"
+      - test_three['module_type']['model'] == "ws-test-3750"
+      - test_three['module_type']['manufacturer'] == 3
+      - test_three['module_type']['part_number'] == "ws-3750g-v2"
+      - test_three['msg'] == "module_type ws-test-3750 updated"
+
+- name: "MODULE_TYPE 4: ASSERT - Delete"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: ws-test-3750
+    state: absent
+  register: test_four
+
+- name: "MODULE_TYPE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "module_type ws-test-3750 deleted"
+
+- name: "MODULE_TYPE 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Test Module Type
+    state: absent
+  register: test_five
+
+- name: "MODULE_TYPE 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['module_type'] == None
+      - test_five['msg'] == "module_type Test Module Type already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_permission.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_permission.yml
@@ -1,0 +1,214 @@
+---
+##
+##
+### NETBOX_PERMISSION
+##
+##
+- name: "PERMISSION 1: Necessary info creation"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: test_one
+
+- name: "PERMISSION 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['permission']['name'] == "Test Permission"
+      - test_one['msg'] == "permission Test Permission created"
+
+- name: "PERMISSION 2: Create duplicate"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: test_two
+
+- name: "PERMISSION 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['permission']['name'] == "Test Permission"
+      - test_two['msg'] == "permission Test Permission already exists"
+
+- name: "PERMISSION 3: Update"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission
+      description: The test permission
+      enabled: false
+      actions:
+        - view
+        - add
+        - change
+        - delete
+        - extreme_administration
+      object_types:
+        - vpn.tunneltermination
+        - wireless.wirelesslan
+      constraints:
+        name: Foo
+    state: present
+  register: test_three
+
+- name: "PERMISSION 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "The test permission"
+      - test_three['permission']['name'] == "Test Permission"
+      - test_three['permission']['description'] == "The test permission"
+      - test_three['permission']['enabled'] == False
+      - test_three['permission']['actions'] == ["view", "add", "change", "delete", "extreme_administration"]
+      - test_three['permission']['object_types'] == ["vpn.tunneltermination", "wireless.wirelesslan"]
+      - test_three['permission']['constraints']["name"] == "Foo"
+      - test_three['msg'] == "permission Test Permission updated"
+
+- name: "PERMISSION 4: Create second permission"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission 2
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: test_four
+
+- name: "PERMISSION 4: Create second permission"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['permission']['name'] == "Test Permission 2"
+      - test_four['msg'] == "permission Test Permission 2 created"
+
+- name: "PERMISSION 5: Add permission to group"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+      permissions:
+        - Test Permission
+    state: present
+  register: test_five
+
+- name: "PERMISSION 5: ASSERT - Add permission to group"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['user_group']['permissions'] == [test_one['permission']['id']]
+
+- name: "PERMISSION 6: Add permission to user"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+      password: TestPassword6
+      permissions:
+        - Test Permission 2
+    state: present
+  register: test_six
+
+- name: "PERMISSION 6: ASSERT - Add permission to user"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['user']['permissions'] == [test_four['permission']['id']]
+
+- name: "PERMISSION 7: Delete"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission
+    state: absent
+  register: test_seven
+
+- name: "PERMISSION 7: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "present"
+      - test_seven['diff']['after']['state'] == "absent"
+      - test_seven['msg'] == "permission Test Permission deleted"
+
+- name: "PERMISSION 8: Delete non existing"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission
+    state: absent
+  register: test_eight
+
+- name: "PERMISSION 8: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_eight['changed']
+      - test_eight['permission'] == None
+      - test_eight['msg'] == "permission Test Permission already absent"
+
+- name: "PERMISSION 9: Necessary permission"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission
+      description: The test permission
+      enabled: true
+      actions:
+        - view
+        - add
+        - change
+        - delete
+        - extreme_administration
+      object_types:
+        - vpn.tunneltermination
+        - wireless.wirelesslan
+    state: present
+
+- name: "PERMISSION 9: Re-create permission with lists in wrong order"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission
+      description: The test permission
+      enabled: true
+      actions:
+        - extreme_administration
+        - delete
+        - change
+        - add
+        - view
+      object_types:
+        - wireless.wirelesslan
+        - vpn.tunneltermination
+    state: present
+  register: test_nine
+
+- name: "PERMISSION 9: ASSERT - The same lists in a new order do not update the permission"
+  ansible.builtin.assert:
+    that:
+      - not test_nine['changed']
+      # actions and object_types seem to be ordered randomly so we cannot test them here

--- a/tests/integration/targets/v4.5/tasks/netbox_platform.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_platform.yml
@@ -1,0 +1,92 @@
+---
+##
+##
+### NETBOX_PLATFORM
+##
+##
+- name: "PLATFORM 1: Necessary info creation"
+  netbox.netbox.netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Platform
+    state: present
+  register: test_one
+
+- name: "PLATFORM 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['platform']['name'] == "Test Platform"
+      - test_one['platform']['slug'] == "test-platform"
+      - test_one['msg'] == "platform Test Platform created"
+
+- name: "PLATFORM 2: Create duplicate"
+  netbox.netbox.netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Platform
+    state: present
+  register: test_two
+
+- name: "PLATFORM 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['platform']['name'] == "Test Platform"
+      - test_two['platform']['slug'] == "test-platform"
+      - test_two['msg'] == "platform Test Platform already exists"
+
+- name: "PLATFORM 3: ASSERT - Update"
+  netbox.netbox.netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Platform
+      manufacturer: Test Manufacturer
+    state: present
+  register: test_three
+
+- name: "PLATFORM 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['manufacturer'] == 3
+      - test_three['platform']['manufacturer'] == 3
+      - test_three['msg'] == "platform Test Platform updated"
+
+- name: "PLATFORM 4: ASSERT - Delete"
+  netbox.netbox.netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Platform
+    state: absent
+  register: test_four
+
+- name: "PLATFORM 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "platform Test Platform deleted"
+
+- name: "PLATFORM 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_platform:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Platform
+    state: absent
+  register: test_five
+
+- name: "PLATFORM 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['platform'] == None
+      - test_five['msg'] == "platform Test Platform already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_power_feed.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_power_feed.yml
@@ -1,0 +1,125 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_POWER_FEED
+##
+##
+- name: "POWER_FEED 1: Necessary info creation"
+  netbox.netbox.netbox_power_feed:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Feed
+      power_panel: Power Panel
+    state: present
+  register: test_one
+
+- name: "POWER_FEED 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['power_feed']['name'] == "Power Feed"
+      - test_one['msg'] == "power_feed Power Feed created"
+
+- name: "POWER_FEED 2: Create duplicate"
+  netbox.netbox.netbox_power_feed:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Feed
+      power_panel: Power Panel
+    state: present
+  register: test_two
+
+- name: "POWER_FEED 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['power_feed']['name'] == "Power Feed"
+      - test_two['power_feed']['power_panel'] == test_one['power_feed']['power_panel']
+      - test_two['msg'] == "power_feed Power Feed already exists"
+
+- name: "POWER_FEED 3: Update power_feed with other fields"
+  netbox.netbox.netbox_power_feed:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Feed
+      power_panel: Power Panel
+      status: offline
+      type: redundant
+      supply: dc
+      phase: three-phase
+      voltage: 400
+      amperage: 32
+      max_utilization: 25
+      comments: totally normal power feed
+    state: present
+  register: test_three
+
+- name: "POWER_FEED 3: ASSERT - Update power_feed with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == "offline"
+      - test_three['diff']['after']['type'] == "redundant"
+      - test_three['diff']['after']['supply'] == "dc"
+      - test_three['diff']['after']['phase'] == "three-phase"
+      - test_three['diff']['after']['voltage'] == 400
+      - test_three['diff']['after']['amperage'] == 32
+      - test_three['diff']['after']['max_utilization'] == 25
+      - test_three['diff']['after']['comments'] == "totally normal power feed"
+      - test_three['power_feed']['name'] == "Power Feed"
+      - test_three['power_feed']['power_panel'] == test_one['power_feed']['power_panel']
+      - test_three['power_feed']['status'] == "offline"
+      - test_three['power_feed']['type'] == "redundant"
+      - test_three['power_feed']['supply'] == "dc"
+      - test_three['power_feed']['phase'] == "three-phase"
+      - test_three['power_feed']['voltage'] == 400
+      - test_three['power_feed']['amperage'] == 32
+      - test_three['power_feed']['max_utilization'] == 25
+      - test_three['power_feed']['comments'] == "totally normal power feed"
+      - test_three['msg'] == "power_feed Power Feed updated"
+
+- name: "POWER_FEED 4: Create Power Feed for Delete Test"
+  netbox.netbox.netbox_power_feed:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Feed 2
+      power_panel: Power Panel
+    state: present
+  register: test_four
+
+- name: "POWER_FEED 4: ASSERT - Create Power Feed for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['power_feed']['name'] == "Power Feed 2"
+      - test_four['power_feed']['power_panel'] == test_one['power_feed']['power_panel']
+      - test_four['msg'] == "power_feed Power Feed 2 created"
+
+- name: "POWER_FEED 5: Delete Power Feed"
+  netbox.netbox.netbox_power_feed:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Feed 2
+      power_panel: Power Panel
+    state: absent
+  register: test_five
+
+- name: "POWER_FEED 5: ASSERT - Delete Power Feed"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "power_feed Power Feed 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_power_outlet.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_power_outlet.yml
@@ -1,0 +1,113 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_POWER_OUTLET
+##
+##
+- name: "POWER_OUTLET 1: Necessary info creation"
+  netbox.netbox.netbox_power_outlet:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet
+      device: Device Power Tests
+    state: present
+  register: test_one
+
+- name: "POWER_OUTLET 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['power_outlet']['name'] == "Power Outlet"
+      - test_one['msg'] == "power_outlet Power Outlet created"
+
+- name: "POWER_OUTLET 2: Create duplicate"
+  netbox.netbox.netbox_power_outlet:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet
+      device: Device Power Tests
+    state: present
+  register: test_two
+
+- name: "POWER_OUTLET 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['power_outlet']['name'] == "Power Outlet"
+      - test_two['power_outlet']['device'] == test_one['power_outlet']['device']
+      - test_two['msg'] == "power_outlet Power Outlet already exists"
+
+- name: "POWER_OUTLET 3: Update power_outlet with other fields"
+  netbox.netbox.netbox_power_outlet:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet
+      device: Device Power Tests
+      type: ita-e
+      power_port: Power Port
+      feed_leg: B
+      description: test description
+    state: present
+  register: test_three
+
+- name: "POWER_OUTLET 3: ASSERT - Update power_outlet with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "ita-e"
+      - test_three['diff']['after']['power_port'] == 1
+      - test_three['diff']['after']['feed_leg'] == "B"
+      - test_three['diff']['after']['description'] == "test description"
+      - test_three['power_outlet']['name'] == "Power Outlet"
+      - test_three['power_outlet']['device'] == test_one['power_outlet']['device']
+      - test_three['power_outlet']['type'] == "ita-e"
+      - test_three['power_outlet']['power_port'] == 1
+      - test_three['power_outlet']['feed_leg'] == "B"
+      - test_three['power_outlet']['description'] == "test description"
+      - test_three['msg'] == "power_outlet Power Outlet updated"
+
+- name: "POWER_OUTLET 4: Create Power Outlet for Delete Test"
+  netbox.netbox.netbox_power_outlet:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet 2
+      device: Device Power Tests
+    state: present
+  register: test_four
+
+- name: "POWER_OUTLET 4: ASSERT - Create Power Outlet for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['power_outlet']['name'] == "Power Outlet 2"
+      - test_four['power_outlet']['device'] == test_one['power_outlet']['device']
+      - test_four['msg'] == "power_outlet Power Outlet 2 created"
+
+- name: "POWER_OUTLET 5: Delete Power Outlet"
+  netbox.netbox.netbox_power_outlet:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet 2
+      device: Device Power Tests
+    state: absent
+  register: test_five
+
+- name: "POWER_OUTLET 5: ASSERT - Delete Power Outlet"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "power_outlet Power Outlet 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_power_outlet_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_power_outlet_template.yml
@@ -1,0 +1,111 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_POWER_OUTLET_TEMPLATE
+##
+##
+- name: "POWER_OUTLET_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_power_outlet_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet Template
+      device_type: Device Type Power Tests
+    state: present
+  register: test_one
+
+- name: "POWER_OUTLET_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['power_outlet_template']['name'] == "Power Outlet Template"
+      - test_one['power_outlet_template']['device_type'] == 8
+      - test_one['msg'] == "power_outlet_template Power Outlet Template created"
+
+- name: "POWER_OUTLET_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_power_outlet_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet Template
+      device_type: Device Type Power Tests
+    state: present
+  register: test_two
+
+- name: "POWER_OUTLET_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['power_outlet_template']['name'] == "Power Outlet Template"
+      - test_two['power_outlet_template']['device_type'] == 8
+      - test_two['msg'] == "power_outlet_template Power Outlet Template already exists"
+
+- name: "POWER_OUTLET_TEMPLATE 3: Update power_outlet_template with other fields"
+  netbox.netbox.netbox_power_outlet_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet Template
+      device_type: Device Type Power Tests
+      type: ita-e
+      power_port_template: Power Port Template
+      feed_leg: B
+    state: present
+  register: test_three
+
+- name: "POWER_OUTLET_TEMPLATE 3: ASSERT - Update power_outlet_template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "ita-e"
+      - test_three['diff']['after']['power_port'] == 1
+      - test_three['diff']['after']['feed_leg'] == "B"
+      - test_three['power_outlet_template']['name'] == "Power Outlet Template"
+      - test_three['power_outlet_template']['device_type'] == 8
+      - test_three['power_outlet_template']['type'] == "ita-e"
+      - test_three['power_outlet_template']['power_port'] == 1
+      - test_three['power_outlet_template']['feed_leg'] == "B"
+      - test_three['msg'] == "power_outlet_template Power Outlet Template updated"
+
+- name: "POWER_OUTLET_TEMPLATE 4: Create Power Outlet Template for Delete Test"
+  netbox.netbox.netbox_power_outlet_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet Template 2
+      device_type: Device Type Power Tests
+    state: present
+  register: test_four
+
+- name: "POWER_OUTLET_TEMPLATE 4: ASSERT - Create Power Outlet Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['power_outlet_template']['name'] == "Power Outlet Template 2"
+      - test_four['power_outlet_template']['device_type'] == 8
+      - test_four['msg'] == "power_outlet_template Power Outlet Template 2 created"
+
+- name: "POWER_OUTLET_TEMPLATE 5: Delete Power Outlet Template"
+  netbox.netbox.netbox_power_outlet_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Outlet Template 2
+      device_type: Device Type Power Tests
+    state: absent
+  register: test_five
+
+- name: "POWER_OUTLET_TEMPLATE 5: ASSERT - Delete Power Outlet Template"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "power_outlet_template Power Outlet Template 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_power_panel.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_power_panel.yml
@@ -1,0 +1,105 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_POWER_PANEL
+##
+##
+- name: "POWER_PANEL 1: Necessary info creation"
+  netbox.netbox.netbox_power_panel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Panel
+      site: Test Site
+    state: present
+  register: test_one
+
+- name: "POWER_PANEL 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['power_panel']['name'] == "Power Panel"
+      - test_one['power_panel']['site'] == 1
+      - test_one['msg'] == "power_panel Power Panel created"
+
+- name: "POWER_PANEL 2: Create duplicate"
+  netbox.netbox.netbox_power_panel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Panel
+      site: Test Site
+    state: present
+  register: test_two
+
+- name: "POWER_PANEL 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['power_panel']['name'] == "Power Panel"
+      - test_two['power_panel']['site'] == 1
+      - test_two['msg'] == "power_panel Power Panel already exists"
+
+- name: "POWER_PANEL 3: Update power_panel with other fields"
+  netbox.netbox.netbox_power_panel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Panel
+      site: Test Site
+      location: Test Rack Group
+    state: present
+  register: test_three
+
+- name: "POWER_PANEL 3: ASSERT - Update power_panel with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['location'] == 1
+      - test_three['power_panel']['name'] == "Power Panel"
+      - test_three['power_panel']['site'] == 1
+      - test_three['power_panel']['location'] == 1
+      - test_three['msg'] == "power_panel Power Panel updated"
+
+- name: "POWER_PANEL 4: Create Power Panel for Delete Test"
+  netbox.netbox.netbox_power_panel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Panel 2
+      site: Test Site
+    state: present
+  register: test_four
+
+- name: "POWER_PANEL 4: ASSERT - Create Power Panel for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['power_panel']['name'] == "Power Panel 2"
+      - test_four['power_panel']['site'] == 1
+      - test_four['msg'] == "power_panel Power Panel 2 created"
+
+- name: "POWER_PANEL 5: Delete Power Panel"
+  netbox.netbox.netbox_power_panel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Panel 2
+      site: Test Site
+    state: absent
+  register: test_five
+
+- name: "POWER_PANEL 5: ASSERT - Delete Power Panel"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "power_panel Power Panel 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_power_port.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_power_port.yml
@@ -1,0 +1,124 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_POWER_PORT
+##
+##
+- name: "POWER_PORT 0: Create device for testing power ports"
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Device Power Tests
+      device_type: Cisco Test
+      device_role: Core Switch
+      site: Test Site
+    state: present
+
+- name: "POWER_PORT 1: Necessary info creation"
+  netbox.netbox.netbox_power_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port
+      device: Device Power Tests
+    state: present
+  register: test_one
+
+- name: "POWER_PORT 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['power_port']['name'] == "Power Port"
+      - test_one['msg'] == "power_port Power Port created"
+
+- name: "POWER_PORT 2: Create duplicate"
+  netbox.netbox.netbox_power_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port
+      device: Device Power Tests
+    state: present
+  register: test_two
+
+- name: "POWER_PORT 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['power_port']['name'] == "Power Port"
+      - test_two['power_port']['device'] == test_one['power_port']['device']
+      - test_two['msg'] == "power_port Power Port already exists"
+
+- name: "POWER_FEED 3: Update power_port with other fields"
+  netbox.netbox.netbox_power_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port
+      device: Device Power Tests
+      type: ita-e
+      allocated_draw: 10
+      maximum_draw: 20
+      description: test description
+    state: present
+  register: test_three
+
+- name: "POWER_FEED 3: ASSERT - Update power_port with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "ita-e"
+      - test_three['diff']['after']['allocated_draw'] == 10
+      - test_three['diff']['after']['maximum_draw'] == 20
+      - test_three['diff']['after']['description'] == "test description"
+      - test_three['power_port']['name'] == "Power Port"
+      - test_three['power_port']['device'] == test_one['power_port']['device']
+      - test_three['power_port']['type'] == "ita-e"
+      - test_three['power_port']['allocated_draw'] == 10
+      - test_three['power_port']['maximum_draw'] == 20
+      - test_three['power_port']['description'] == "test description"
+      - test_three['msg'] == "power_port Power Port updated"
+
+- name: "POWER_PORT 4: Create Power Port for Delete Test"
+  netbox.netbox.netbox_power_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port 2
+      device: Device Power Tests
+    state: present
+  register: test_four
+
+- name: "POWER_PORT 4: ASSERT - Create Power Port for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['power_port']['name'] == "Power Port 2"
+      - test_four['power_port']['device'] == test_one['power_port']['device']
+      - test_four['msg'] == "power_port Power Port 2 created"
+
+- name: "POWER_PORT 5: Delete Power Port"
+  netbox.netbox.netbox_power_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port 2
+      device: Device Power Tests
+    state: absent
+  register: test_five
+
+- name: "POWER_PORT 5: ASSERT - Delete Power Port"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "power_port Power Port 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_power_port_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_power_port_template.yml
@@ -1,0 +1,212 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_POWER_PORT_TEMPLATE
+##
+##
+- name: "POWER_PORT_TEMPLATE 0.1: Create device type for testing power ports on device types"
+  netbox.netbox.netbox_device_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Device Type Power Tests
+      manufacturer: Test Manufacturer
+    state: present
+
+- name: "POWER_PORT_TEMPLATE 0.2: Create module type for testing power ports on module types"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Module Type Power Tests
+      manufacturer: Test Manufacturer
+    state: present
+
+- name: "POWER_PORT_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port Template
+      device_type: Device Type Power Tests
+    state: present
+  register: test_one
+
+- name: "POWER_PORT_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['power_port_template']['name'] == "Power Port Template"
+      - test_one['power_port_template']['device_type'] == 8
+      - test_one['msg'] == "power_port_template Power Port Template created"
+
+- name: "POWER_PORT_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port Template
+      device_type: Device Type Power Tests
+    state: present
+  register: test_two
+
+- name: "POWER_PORT_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['power_port_template']['name'] == "Power Port Template"
+      - test_two['power_port_template']['device_type'] == 8
+      - test_two['msg'] == "power_port_template Power Port Template already exists"
+
+- name: "POWER_PORT_TEMPLATE 3: Update power_port_template with other fields"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port Template
+      device_type: Device Type Power Tests
+      type: ita-e
+      allocated_draw: 10
+      maximum_draw: 20
+    state: present
+  register: test_three
+
+- name: "POWER_PORT_TEMPLATE 3: ASSERT - Update power_port_template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['type'] == "ita-e"
+      - test_three['diff']['after']['allocated_draw'] == 10
+      - test_three['diff']['after']['maximum_draw'] == 20
+      - test_three['power_port_template']['name'] == "Power Port Template"
+      - test_three['power_port_template']['device_type'] == 8
+      - test_three['power_port_template']['type'] == "ita-e"
+      - test_three['power_port_template']['allocated_draw'] == 10
+      - test_three['power_port_template']['maximum_draw'] == 20
+      - test_three['msg'] == "power_port_template Power Port Template updated"
+
+- name: "POWER_PORT_TEMPLATE 4: Create Power Port Template for Delete Test"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port Template 2
+      device_type: Device Type Power Tests
+    state: present
+  register: test_four
+
+- name: "POWER_PORT_TEMPLATE 4: ASSERT - Create Power Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['power_port_template']['name'] == "Power Port Template 2"
+      - test_four['power_port_template']['device_type'] == 8
+      - test_four['msg'] == "power_port_template Power Port Template 2 created"
+
+- name: "POWER_PORT_TEMPLATE 5: Delete Power Port Template"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Power Port Template 2
+      device_type: Device Type Power Tests
+    state: absent
+  register: test_five
+
+- name: "POWER_PORT_TEMPLATE 5: ASSERT - Delete Power Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "power_port_template Power Port Template 2 deleted"
+
+- name: "POWER_PORT_TEMPLATE 6: Necessary info creation"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: present
+  register: test_six
+
+- name: "POWER_PORT_TEMPLATE 6: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['power_port_template']['name'] == "Module Power Port Template"
+      - test_six['power_port_template']['module_type'] == 2
+      - test_six['msg'] == "power_port_template Module Power Port Template created"
+
+- name: "POWER_PORT_TEMPLATE 7: Create duplicate"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: present
+  register: test_seven
+
+- name: "POWER_PORT_TEMPLATE 7: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['power_port_template']['name'] == "Module Power Port Template"
+      - test_seven['power_port_template']['module_type'] == 2
+      - test_seven['msg'] == "power_port_template Module Power Port Template already exists"
+
+- name: "POWER_PORT_TEMPLATE 8: Update power_port_template with other fields"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+      type: ita-e
+      allocated_draw: 10
+      maximum_draw: 20
+    state: present
+  register: test_eight
+
+- name: "POWER_PORT_TEMPLATE 8: ASSERT - Update power_port_template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['after']['type'] == "ita-e"
+      - test_eight['diff']['after']['allocated_draw'] == 10
+      - test_eight['diff']['after']['maximum_draw'] == 20
+      - test_eight['power_port_template']['name'] == "Module Power Port Template"
+      - test_eight['power_port_template']['module_type'] == 2
+      - test_eight['power_port_template']['type'] == "ita-e"
+      - test_eight['power_port_template']['allocated_draw'] == 10
+      - test_eight['power_port_template']['maximum_draw'] == 20
+      - test_eight['msg'] == "power_port_template Module Power Port Template updated"
+
+- name: "POWER_PORT_TEMPLATE 9: Delete Power Port Template"
+  netbox.netbox.netbox_power_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Power Port Template
+      module_type: Module Type Power Tests
+    state: absent
+  register: test_nine
+
+- name: "POWER_PORT_TEMPLATE 9: ASSERT - Delete Power Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "present"
+      - test_nine['diff']['after']['state'] == "absent"
+      - test_nine['msg'] == "power_port_template Module Power Port Template deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_prefix.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_prefix.yml
@@ -1,0 +1,254 @@
+---
+##
+##
+### NETBOX_PREFIX
+##
+##
+- name: 1 - Create prefix within NetBox with only required information
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['msg'] == "prefix 10.156.0.0/19 created"
+      - test_one['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: 2 - Duplicate
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "prefix 10.156.0.0/19 already exists"
+      - test_two['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: 3 - Update 10.156.0.0/19
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.156.0.0/19
+      scope_type: "dcim.site"
+      scope: Test Site
+      status: Reserved
+      description: This prefix has been updated
+    state: present
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['scope'] == 1
+      - test_three['diff']['after']['scope_type'] == "dcim.site"
+      - test_three['diff']['after']['status'] == "reserved"
+      - test_three['diff']['after']['description'] == "This prefix has been updated"
+      - test_three['msg'] == "prefix 10.156.0.0/19 updated"
+      - test_three['prefix']['prefix'] == "10.156.0.0/19"
+      - test_three['prefix']['scope'] == 1
+      - test_three['prefix']['scope_type'] == "dcim.site"
+      - test_three['prefix']['status'] == "reserved"
+      - test_three['prefix']['description'] == "This prefix has been updated"
+
+- name: 4 - Delete prefix within netbox
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.156.0.0/19
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "prefix 10.156.0.0/19 deleted"
+
+- name: 5 - Create prefix with several specified options
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      family: 4
+      prefix: 10.156.32.0/19
+      scope_type: "dcim.site"
+      scope: Test Site
+      vrf: Test VRF
+      tenant: Test Tenant
+      vlan:
+        name: Test VLAN
+        site: Test Site
+        tenant: Test Tenant
+        vlan_group: Test Vlan Group
+      status: Reserved
+      prefix_role: Network of care
+      description: Test description
+      is_pool: true
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['msg'] == "prefix 10.156.32.0/19 created"
+      - test_five['prefix']['prefix'] == "10.156.32.0/19"
+      - test_five['prefix']['family'] == 4
+      - test_five['prefix']['scope'] == 1
+      - test_five['prefix']['scope_type'] == "dcim.site"
+      - test_five['prefix']['vrf'] == 1
+      - test_five['prefix']['tenant'] == 1
+      - test_five['prefix']['vlan'] == 4
+      - test_five['prefix']['status'] == "reserved"
+      - test_five['prefix']['role'] == 1
+      - test_five['prefix']['description'] == "Test description"
+      - test_five['prefix']['is_pool'] == true
+      - test_five['prefix']['tags'][0] == 4
+
+- name: 6 - Get a new /24 inside 10.156.0.0/19 within NetBox - Parent doesn't exist
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: true
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_six['changed']
+      - test_six['msg'] == "Parent prefix does not exist - 10.156.0.0/19"
+
+- name: 7 - Create prefix within NetBox with only required information
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.156.0.0/19
+    state: present
+  register: test_seven
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['msg'] == "prefix 10.156.0.0/19 created"
+      - test_seven['prefix']['prefix'] == "10.156.0.0/19"
+
+- name: 8 - Get a new /24 inside 10.156.0.0/19 within NetBox
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: true
+  register: test_eight
+
+- name: 8 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "absent"
+      - test_eight['diff']['after']['state'] == "present"
+      - test_eight['msg'] == "prefix 10.156.0.0/24 created"
+      - test_eight['prefix']['prefix'] == "10.156.0.0/24"
+
+- name: 9 - Create 10.157.0.0/19
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      prefix: 10.157.0.0/19
+      vrf: Test VRF
+      scope_type: "dcim.site"
+      scope: Test Site
+    state: present
+  register: test_nine
+
+- name: 9 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "absent"
+      - test_nine['diff']['after']['state'] == "present"
+      - test_nine['msg'] == "prefix 10.157.0.0/19 created"
+      - test_nine['prefix']['prefix'] == "10.157.0.0/19"
+      - test_nine['prefix']['scope'] == 1
+      - test_nine['prefix']['scope_type'] == "dcim.site"
+      - test_nine['prefix']['vrf'] == 1
+
+- name: 10 - Get a new /24 inside 10.157.0.0/19 within NetBox with additional values
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      parent: 10.157.0.0/19
+      prefix_length: 24
+      vrf: Test VRF
+      scope_type: "dcim.site"
+      scope: Test Site
+    state: present
+    first_available: true
+  register: test_ten
+
+- name: 10 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['msg'] == "prefix 10.157.0.0/24 created"
+      - test_ten['prefix']['prefix'] == "10.157.0.0/24"
+      - test_ten['prefix']['scope'] == 1
+      - test_ten['prefix']['scope_type'] == "dcim.site"
+      - test_ten['prefix']['vrf'] == 1
+
+- name: 11 - Get a new /24 inside 10.156.0.0/19 within NetBox
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      parent: 10.156.0.0/19
+      prefix_length: 24
+    state: present
+    first_available: true
+  register: test_eleven
+
+- name: 11 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "absent"
+      - test_eleven['diff']['after']['state'] == "present"
+      - test_eleven['msg'] == "prefix 10.156.1.0/24 created"
+      - test_eleven['prefix']['prefix'] == "10.156.1.0/24"

--- a/tests/integration/targets/v4.5/tasks/netbox_provider.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_provider.yml
@@ -1,0 +1,79 @@
+---
+##
+##
+### NETBOX_PROVIDER
+##
+##
+- name: "NETBOX_PROVIDER 1: Create provider within NetBox with only required information"
+  netbox.netbox.netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Provider One
+    state: present
+  register: test_one
+
+- name: "NETBOX_PROVIDER 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['provider']['name'] == "Test Provider One"
+      - test_one['provider']['slug'] == "test-provider-one"
+      - test_one['msg'] == "provider Test Provider One created"
+
+- name: "NETBOX_PROVIDER 2: Duplicate"
+  netbox.netbox.netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Provider One
+    state: present
+  register: test_two
+
+- name: "NETBOX_PROVIDER 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['provider']['name'] == "Test Provider One"
+      - test_two['provider']['slug'] == "test-provider-one"
+      - test_two['msg'] == "provider Test Provider One already exists"
+
+- name: "NETBOX_PROVIDER 3: Update provider with other fields"
+  netbox.netbox.netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Provider One
+      comments: BAD PROVIDER
+    state: present
+  register: test_three
+
+- name: "NETBOX_PROVIDER 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['comments'] == "BAD PROVIDER"
+      - test_three['provider']['name'] == "Test Provider One"
+      - test_three['provider']['slug'] == "test-provider-one"
+      - test_three['provider']['comments'] == "BAD PROVIDER"
+      - test_three['msg'] == "provider Test Provider One updated"
+
+- name: "NETBOX_PROVIDER 4: Delete provider within netbox"
+  netbox.netbox.netbox_provider:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Provider One
+    state: absent
+  register: test_four
+
+- name: "NETBOX_PROVIDER 4 : ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['provider']['name'] == "Test Provider One"
+      - test_four['provider']['slug'] == "test-provider-one"
+      - test_four['provider']['comments'] == "BAD PROVIDER"
+      - test_four['msg'] == "provider Test Provider One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_provider_network.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_provider_network.yml
@@ -1,0 +1,83 @@
+---
+##
+##
+### NETBOX_PROVIDER
+##
+##
+- name: "NETBOX_PROVIDER_NETWORK 1: Create provider network within NetBox with only required information"
+  netbox.netbox.netbox_provider_network:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      provider: Test Provider
+      name: Test Provider Network One
+    state: present
+  register: test_one
+
+- name: "NETBOX_PROVIDER_NETWORK 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['provider_network']['name'] == "Test Provider Network One"
+      - test_one['msg'] == "provider_network Test Provider Network One created"
+
+- name: "NETBOX_PROVIDER_NETWORK 2: Duplicate"
+  netbox.netbox.netbox_provider_network:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      provider: Test Provider
+      name: Test Provider Network One
+    state: present
+  register: test_two
+
+- name: "NETBOX_PROVIDER_NETWORK 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['provider_network']['name'] == "Test Provider Network One"
+      - test_two['msg'] == "provider_network Test Provider Network One already exists"
+
+- name: "NETBOX_PROVIDER_NETWORK 3: Update provider network with other fields"
+  netbox.netbox.netbox_provider_network:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      provider: Test Provider
+      name: Test Provider Network One
+      description: Describe a Provider Network
+      comments: A provider network
+    state: present
+  register: test_three
+
+- name: "NETBOX_PROVIDER_NETWORK 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['comments'] == "A provider network"
+      - test_three['diff']['after']['description'] == "Describe a Provider Network"
+      - test_three['provider_network']['name'] == "Test Provider Network One"
+      - test_three['provider_network']['comments'] == "A provider network"
+      - test_three['provider_network']['description'] == "Describe a Provider Network"
+      - test_three['msg'] == "provider_network Test Provider Network One updated"
+
+- name: "NETBOX_PROVIDER_NETWORK 4: Delete provider within netbox"
+  netbox.netbox.netbox_provider_network:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      provider: Test Provider
+      name: Test Provider Network One
+    state: absent
+  register: test_four
+
+- name: "NETBOX_PROVIDER_NETWORK 4 : ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['provider_network']['name'] == "Test Provider Network One"
+      - test_four['provider_network']['comments'] == "A provider network"
+      - test_four['provider_network']['description'] == "Describe a Provider Network"
+      - test_four['msg'] == "provider_network Test Provider Network One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_rack.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_rack.yml
@@ -1,0 +1,226 @@
+---
+##
+##
+### NETBOX_RACK
+##
+##
+- name: 1 - Test rack creation
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack one
+      site: Test Site
+      location: Test Rack Group
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack']['name'] == "Test rack one"
+      - test_one['rack']['site'] == 1
+
+- name: Test duplicate rack
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack one
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack']['name'] == "Test rack one"
+      - test_two['rack']['site'] == 1
+      - test_two['msg'] == "rack Test rack one already exists"
+
+- name: 3 - Create new rack with similar name
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack - Test Site
+      site: Test Site
+    state: present
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['rack']['name'] == "Test rack - Test Site"
+      - test_three['rack']['site'] == 1
+      - test_three['msg'] == "rack Test rack - Test Site created"
+
+- name: 4 - Attempt to create Test rack one again
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack one
+      site: Test Site
+      location: Test Rack Group
+    state: present
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_four['changed']
+      - test_four['rack']['name'] == "Test rack one"
+      - test_four['rack']['site'] == 1
+      - test_four['msg'] == "rack Test rack one already exists"
+
+- name: 5 - Update Test rack one with more options
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack one
+      site: Test Site
+      rack_role: Test Rack Role
+      location: Test Rack Group
+      facility_id: EQUI10291
+      tenant: Test Tenant
+      status: Available
+      serial: FXS10001
+      asset_tag: "1234"
+      width: 23
+      u_height: 48
+      type: 2-post frame
+      outer_width: 32
+      outer_depth: 24
+      outer_unit: Inches
+      comments: Just testing rack module
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['asset_tag'] == "1234"
+      - test_five['diff']['after']['comments'] == "Just testing rack module"
+      - test_five['diff']['after']['facility_id'] == "EQUI10291"
+      - test_five['diff']['after']['outer_depth'] == 24
+      - test_five['diff']['after']['outer_unit'] == "in"
+      - test_five['diff']['after']['outer_width'] == 32
+      - test_five['diff']['after']['role'] == 1
+      - test_five['diff']['after']['serial'] == "FXS10001"
+      - test_five['diff']['after']['status'] == "available"
+      - test_five['diff']['after']['tenant'] == 1
+      - test_five['diff']['after']['tags'][0] == 4
+      - test_five['diff']['after']['form_factor'] == "2-post-frame"
+      - test_five['diff']['after']['u_height'] == 48
+      - test_five['diff']['after']['width'] == 23
+      - test_five['rack']['name'] == "Test rack one"
+      - test_five['rack']['site'] == 1
+      - test_five['rack']['asset_tag'] == "1234"
+      - test_five['rack']['comments'] == "Just testing rack module"
+      - test_five['rack']['facility_id'] == "EQUI10291"
+      - test_five['rack']['location'] == 1
+      - test_five['rack']['outer_depth'] == 24
+      - test_five['rack']['outer_unit'] == "in"
+      - test_five['rack']['outer_width'] == 32
+      - test_five['rack']['role'] == 1
+      - test_five['rack']['serial'] == "FXS10001"
+      - test_five['rack']['status'] == "available"
+      - test_five['rack']['tenant'] == 1
+      - test_five['rack']['tags'][0] == 4
+      - test_five['rack']['form_factor'] == "2-post-frame"
+      - test_five['rack']['u_height'] == 48
+      - test_five['rack']['width'] == 23
+      - test_five['msg'] == "rack Test rack one updated"
+
+- name: 6 - Update Test rack one with same options
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack one
+      site: Test Site
+      rack_role: Test Rack Role
+      location: Test Rack Group
+      facility_id: EQUI10291
+      tenant: Test Tenant
+      status: Available
+      serial: FXS10001
+      asset_tag: "1234"
+      width: 23
+      u_height: 48
+      type: 2-post frame
+      outer_width: 32
+      outer_depth: 24
+      outer_unit: Inches
+      comments: Just testing rack module
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is not changed
+      - test_six['rack']['name'] == "Test rack one"
+      - test_six['rack']['site'] == 1
+      - test_six['rack']['asset_tag'] == "1234"
+      - test_six['rack']['comments'] == "Just testing rack module"
+      - test_six['rack']['facility_id'] == "EQUI10291"
+      - test_six['rack']['location'] == 1
+      - test_six['rack']['outer_depth'] == 24
+      - test_six['rack']['outer_unit'] == "in"
+      - test_six['rack']['outer_width'] == 32
+      - test_six['rack']['role'] == 1
+      - test_six['rack']['serial'] == "FXS10001"
+      - test_six['rack']['status'] == "available"
+      - test_six['rack']['tenant'] == 1
+      - test_six['rack']['tags'][0] == 4
+      - test_six['rack']['form_factor'] == "2-post-frame"
+      - test_six['rack']['u_height'] == 48
+      - test_six['rack']['width'] == 23
+
+- name: 7 - Create rack with same asset tag and serial number
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack two
+      site: Test Site
+      serial: FXS10001
+      asset_tag: "1234"
+    state: present
+  ignore_errors: true
+  register: test_seven
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seven is failed
+      - "'asset tag already exists' in test_seven['msg']"
+
+- name: 8 - Test delete
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test rack one
+    state: absent
+  register: test_eight
+
+- name: 8 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_eight is changed
+      - test_eight['diff']['before']['state'] == "present"
+      - test_eight['diff']['after']['state'] == "absent"
+      - test_eight['msg'] == "rack Test rack one deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_rack_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_rack_group.yml
@@ -1,0 +1,62 @@
+---
+##
+##
+### NETBOX_RACK_GROUP
+##
+##
+- name: "RACK_GROUP 1: Necessary info creation"
+  netbox.netbox.netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack Group
+      site: Test Site
+    state: present
+  register: test_one
+
+- name: "RACK_GROUP 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack_group']['name'] == "Rack Group"
+      - test_one['rack_group']['slug'] == "rack-group"
+      - test_one['rack_group']['site'] == 1
+      - test_one['msg'] == "rack_group Rack Group created"
+
+- name: "RACK_GROUP 2: Create duplicate"
+  netbox.netbox.netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack Group
+      site: Test Site
+    state: present
+  register: test_two
+
+- name: "RACK_GROUP 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack_group']['name'] == "Rack Group"
+      - test_two['rack_group']['slug'] == "rack-group"
+      - test_two['rack_group']['site'] == 1
+      - test_two['msg'] == "rack_group Rack Group already exists"
+
+- name: "RACK_GROUP 3: ASSERT - Delete"
+  netbox.netbox.netbox_rack_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack Group
+    state: absent
+  register: test_three
+
+- name: "RACK_GROUP 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "rack_group Rack Group deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_rack_role.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_rack_role.yml
@@ -1,0 +1,81 @@
+---
+##
+##
+### NETBOX_RACK_ROLE
+##
+##
+- name: "RACK_ROLE 1: Necessary info creation"
+  netbox.netbox.netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack Role
+      color: ffffff
+    state: present
+  register: test_one
+
+- name: "RACK_ROLE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack_role']['name'] == "Rack Role"
+      - test_one['rack_role']['slug'] == "rack-role"
+      - test_one['rack_role']['color'] == "ffffff"
+      - test_one['msg'] == "rack_role Rack Role created"
+
+- name: "RACK_ROLE 2: Create duplicate"
+  netbox.netbox.netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack Role
+    state: present
+  register: test_two
+
+- name: "RACK_ROLE 1: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack_role']['name'] == "Rack Role"
+      - test_two['rack_role']['slug'] == "rack-role"
+      - test_two['rack_role']['color'] == "ffffff"
+      - test_two['msg'] == "rack_role Rack Role already exists"
+
+- name: "RACK_ROLE 3: Update"
+  netbox.netbox.netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack Role
+      color: "003EFF"
+    state: present
+  register: test_three
+
+- name: "RACK_ROLE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "003eff"
+      - test_three['rack_role']['name'] == "Rack Role"
+      - test_three['rack_role']['slug'] == "rack-role"
+      - test_three['rack_role']['color'] == "003eff"
+      - test_three['msg'] == "rack_role Rack Role updated"
+
+- name: "RACK_ROLE 4: Delete"
+  netbox.netbox.netbox_rack_role:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rack Role
+    state: absent
+  register: test_four
+
+- name: "RACK_ROLE 4: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "rack_role Rack Role deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_rear_port.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_rear_port.yml
@@ -1,0 +1,139 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_REAR_PORT
+##
+##
+- name: "REAR_PORT 1: Necessary info creation"
+  netbox.netbox.netbox_rear_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port
+      device: test100
+      type: bnc
+    state: present
+  register: test_one
+
+- name: "REAR_PORT 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rear_port']['name'] == "Rear Port"
+      - test_one['rear_port']['device'] == 1
+      - test_one['rear_port']['type'] == "bnc"
+      - test_one['msg'] == "rear_port Rear Port created"
+
+- name: "REAR_PORT 2: Create duplicate"
+  netbox.netbox.netbox_rear_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port
+      device: test100
+      type: bnc
+    state: present
+  register: test_two
+
+- name: "REAR_PORT 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['rear_port']['name'] == "Rear Port"
+      - test_two['rear_port']['device'] == 1
+      - test_two['rear_port']['type'] == "bnc"
+      - test_two['msg'] == "rear_port Rear Port already exists"
+
+- name: "REAR_PORT 3: Update Rear Port with other fields"
+  netbox.netbox.netbox_rear_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port
+      device: test100
+      type: bnc
+      positions: 5
+      description: test description
+    state: present
+  register: test_three
+
+- name: "REAR_PORT 3: ASSERT - Update Rear Port with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['positions'] == 5
+      - test_three['diff']['after']['description'] == "test description"
+      - test_three['rear_port']['name'] == "Rear Port"
+      - test_three['rear_port']['device'] == 1
+      - test_three['rear_port']['type'] == "bnc"
+      - test_three['rear_port']['positions'] == 5
+      - test_three['rear_port']['description'] == "test description"
+      - test_three['msg'] == "rear_port Rear Port updated"
+
+- name: "REAR_PORT 4: Create Rear Port for Delete Test"
+  netbox.netbox.netbox_rear_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port 2
+      device: test100
+      type: bnc
+    state: present
+  register: test_four
+
+- name: "REAR_PORT 4: ASSERT - Create Rear Port for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['rear_port']['name'] == "Rear Port 2"
+      - test_four['rear_port']['device'] == 1
+      - test_four['rear_port']['type'] == "bnc"
+      - test_four['msg'] == "rear_port Rear Port 2 created"
+
+- name: "REAR_PORT 5: Delete Rear Port"
+  netbox.netbox.netbox_rear_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port 2
+      device: test100
+      type: bnc
+    state: absent
+  register: test_five
+
+- name: "REAR_PORT 5: ASSERT - Delete Rear Port"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "rear_port Rear Port 2 deleted"
+
+- name: "REAR_PORT 6: Create second Rear Port"
+  netbox.netbox.netbox_rear_port:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port
+      device: Test Nexus One
+      type: bnc
+    state: present
+  register: test_six
+
+- name: "REAR_PORT 6: ASSERT - Create second Rear Port"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['rear_port']['name'] == "Rear Port"
+      - test_six['rear_port']['device'] == 4
+      - test_six['rear_port']['type'] == "bnc"
+      - test_six['msg'] == "rear_port Rear Port created"

--- a/tests/integration/targets/v4.5/tasks/netbox_rear_port_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_rear_port_template.yml
@@ -1,0 +1,251 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_REAR_PORT_TEMPLATE
+##
+##
+- name: "NETBOX_REAR_PORT_TEMPLATE 0.1: Create module type for testing power ports on module types"
+  netbox.netbox.netbox_module_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      model: Module Type Front And Rear Port Tests
+      manufacturer: Test Manufacturer
+    state: present
+
+- name: "REAR_PORT_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port Template
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_one
+
+- name: "REAR_PORT_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rear_port_template']['name'] == "Rear Port Template"
+      - test_one['rear_port_template']['device_type'] == 1
+      - test_one['rear_port_template']['type'] == "bnc"
+      - test_one['msg'] == "rear_port_template Rear Port Template created"
+
+- name: "REAR_PORT_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port Template
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_two
+
+- name: "REAR_PORT_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['rear_port_template']['name'] == "Rear Port Template"
+      - test_two['rear_port_template']['device_type'] == 1
+      - test_two['rear_port_template']['type'] == "bnc"
+      - test_two['msg'] == "rear_port_template Rear Port Template already exists"
+
+- name: "REAR_PORT_TEMPLATE 3: Update Rear Port Template with other fields"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port Template
+      device_type: Cisco Test
+      type: bnc
+      positions: 5
+    state: present
+  register: test_three
+
+- name: "REAR_PORT_TEMPLATE 3: ASSERT - Update Rear Port Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['positions'] == 5
+      - test_three['rear_port_template']['name'] == "Rear Port Template"
+      - test_three['rear_port_template']['device_type'] == 1
+      - test_three['rear_port_template']['type'] == "bnc"
+      - test_three['rear_port_template']['positions'] == 5
+      - test_three['msg'] == "rear_port_template Rear Port Template updated"
+
+- name: "REAR_PORT_TEMPLATE 4: Create Rear Port Template for Delete Test"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port Template 2
+      device_type: Cisco Test
+      type: bnc
+    state: present
+  register: test_four
+
+- name: "REAR_PORT_TEMPLATE 4: ASSERT - Create Rear Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['rear_port_template']['name'] == "Rear Port Template 2"
+      - test_four['rear_port_template']['device_type'] == 1
+      - test_four['rear_port_template']['type'] == "bnc"
+      - test_four['msg'] == "rear_port_template Rear Port Template 2 created"
+
+- name: "REAR_PORT_TEMPLATE 5: Delete Rear Port Template"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port Template 2
+      device_type: Cisco Test
+      type: bnc
+    state: absent
+  register: test_five
+
+- name: "REAR_PORT_TEMPLATE 5: ASSERT - Delete Rear Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "rear_port_template Rear Port Template 2 deleted"
+
+- name: "REAR_PORT_TEMPLATE 6: Create second Rear Port Template"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Rear Port Template 2
+      device_type: Arista Test
+      type: bnc
+    state: present
+  register: test_six
+
+- name: "REAR_PORT_TEMPLATE 6: ASSERT - Create second Rear Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "absent"
+      - test_six['diff']['after']['state'] == "present"
+      - test_six['rear_port_template']['name'] == "Rear Port Template 2"
+      - test_six['rear_port_template']['device_type'] == 2
+      - test_six['rear_port_template']['type'] == "bnc"
+      - test_six['msg'] == "rear_port_template Rear Port Template 2 created"
+
+- name: "REAR_PORT_TEMPLATE 7: Necessary info creation"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_seven
+
+- name: "REAR_PORT_TEMPLATE 7: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['rear_port_template']['name'] == "Module Type Rear Port Template"
+      - test_seven['rear_port_template']['module_type'] == 1
+      - test_seven['rear_port_template']['type'] == "bnc"
+      - test_seven['msg'] == "rear_port_template Module Type Rear Port Template created"
+
+- name: "REAR_PORT_TEMPLATE 8: Create duplicate"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_eight
+
+- name: "REAR_PORT_TEMPLATE 8: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_eight['changed']
+      - test_eight['rear_port_template']['name'] == "Module Type Rear Port Template"
+      - test_eight['rear_port_template']['module_type'] == 1
+      - test_eight['rear_port_template']['type'] == "bnc"
+      - test_eight['msg'] == "rear_port_template Module Type Rear Port Template already exists"
+
+- name: "REAR_PORT_TEMPLATE 9: Update Rear Port Template with other fields"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+      positions: 5
+    state: present
+  register: test_nine
+
+- name: "REAR_PORT_TEMPLATE 9: ASSERT - Update Rear Port Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['after']['positions'] == 5
+      - test_nine['rear_port_template']['name'] == "Module Type Rear Port Template"
+      - test_nine['rear_port_template']['module_type'] == 1
+      - test_nine['rear_port_template']['type'] == "bnc"
+      - test_nine['rear_port_template']['positions'] == 5
+      - test_nine['msg'] == "rear_port_template Module Type Rear Port Template updated"
+
+- name: "REAR_PORT_TEMPLATE 10: Create Rear Port Template for Delete Test"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: present
+  register: test_ten
+
+- name: "REAR_PORT_TEMPLATE 10: ASSERT - Create Rear Port Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == "absent"
+      - test_ten['diff']['after']['state'] == "present"
+      - test_ten['rear_port_template']['name'] == "Module Type Rear Port Template 2"
+      - test_ten['rear_port_template']['module_type'] == 1
+      - test_ten['rear_port_template']['type'] == "bnc"
+      - test_ten['msg'] == "rear_port_template Module Type Rear Port Template 2 created"
+
+- name: "REAR_PORT_TEMPLATE 11: Delete Rear Port Template"
+  netbox.netbox.netbox_rear_port_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Module Type Rear Port Template 2
+      module_type: Module Type Front And Rear Port Tests
+      type: bnc
+    state: absent
+  register: test_eleven
+
+- name: "REAR_PORT_TEMPLATE 11: ASSERT - Delete Rear Port Template"
+  ansible.builtin.assert:
+    that:
+      - test_eleven is changed
+      - test_eleven['diff']['before']['state'] == "present"
+      - test_eleven['diff']['after']['state'] == "absent"
+      - test_eleven['msg'] == "rear_port_template Module Type Rear Port Template 2 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_region.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_region.yml
@@ -1,0 +1,79 @@
+---
+##
+##
+### NETBOX_REGION
+##
+##
+- name: "REGION 1: Necessary info creation"
+  netbox.netbox.netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Region One
+    state: present
+  register: test_one
+
+- name: "REGION 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['region']['name'] == "Test Region One"
+      - test_one['region']['slug'] == "test-region-one"
+      - test_one['msg'] == "region Test Region One created"
+
+- name: "REGION 2: Create duplicate"
+  netbox.netbox.netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Region One
+    state: present
+  register: test_two
+
+- name: "REGION 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['region']['name'] == "Test Region One"
+      - test_two['region']['slug'] == "test-region-one"
+      - test_two['msg'] == "region Test Region One already exists"
+
+- name: "REGION 3: ASSERT - Update"
+  netbox.netbox.netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Region One
+      parent_region: Test Region
+    state: present
+  register: test_three
+
+- name: "REGION 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['parent'] == 1
+      - test_three['region']['name'] == "Test Region One"
+      - test_three['region']['slug'] == "test-region-one"
+      - test_three['region']['parent'] == 1
+      - test_three['msg'] == "region Test Region One updated"
+
+- name: "REGION 4: ASSERT - Delete"
+  netbox.netbox.netbox_region:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Region One
+    state: absent
+  register: test_four
+
+- name: "REGION 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['region']['name'] == "Test Region One"
+      - test_four['region']['slug'] == "test-region-one"
+      - test_four['region']['parent'] == 1
+      - test_four['msg'] == "region Test Region One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_rir.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_rir.yml
@@ -1,0 +1,79 @@
+---
+##
+##
+### NETBOX_RIR
+##
+##
+- name: "RIR 1: Necessary info creation"
+  netbox.netbox.netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test RIR One
+    state: present
+  register: test_one
+
+- name: "RIR 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rir']['name'] == "Test RIR One"
+      - test_one['rir']['slug'] == "test-rir-one"
+      - test_one['msg'] == "rir Test RIR One created"
+
+- name: "RIR 2: Create duplicate"
+  netbox.netbox.netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test RIR One
+    state: present
+  register: test_two
+
+- name: "RIR 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['rir']['name'] == "Test RIR One"
+      - test_two['rir']['slug'] == "test-rir-one"
+      - test_two['msg'] == "rir Test RIR One already exists"
+
+- name: "RIR 3: ASSERT - Update"
+  netbox.netbox.netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test RIR One
+      is_private: true
+    state: present
+  register: test_three
+
+- name: "RIR 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['is_private'] == true
+      - test_three['rir']['name'] == "Test RIR One"
+      - test_three['rir']['slug'] == "test-rir-one"
+      - test_three['rir']['is_private'] == true
+      - test_three['msg'] == "rir Test RIR One updated"
+
+- name: "RIR 4: ASSERT - Delete"
+  netbox.netbox.netbox_rir:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test RIR One
+    state: absent
+  register: test_four
+
+- name: "RIR 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['rir']['name'] == "Test RIR One"
+      - test_four['rir']['slug'] == "test-rir-one"
+      - test_four['rir']['is_private'] == true
+      - test_four['msg'] == "rir Test RIR One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_route_target.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_route_target.yml
@@ -1,0 +1,204 @@
+---
+#
+# ADD (CHECK MODE)
+- name: "NETBOX_ROUTE_TARGET_ADD: Check Mode - Add all fields except description"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+      tenant: Test Tenant
+      tags:
+        - first
+        - second
+  check_mode: true
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_ADD: (ASSERT) Check Mode - Add all fields except description"
+  ansible.builtin.assert:
+    that:
+      - test_results is changed
+      - test_results['route_target']['name'] == "65000:65001"
+      - test_results['route_target']['tenant'] == 1
+      - test_results['route_target']['tags'] | length == 2
+      - test_results['diff']['after']['state'] == "present"
+      - test_results['diff']['before']['state'] == "absent"
+      - test_results['msg'] == "route_target 65000:65001 created"
+
+# ADD
+- name: "NETBOX_ROUTE_TARGET_ADD: Add all fields except description"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+      tenant: Test Tenant
+      tags:
+        - first
+        - second
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_ADD: (ASSERT) Add all fields except description"
+  ansible.builtin.assert:
+    that:
+      - test_results is changed
+      - test_results['route_target']['name'] == "65000:65001"
+      - test_results['route_target']['tenant'] == 1
+      - test_results['route_target']['tags'] | length == 2
+      - test_results['diff']['after']['state'] == "present"
+      - test_results['diff']['before']['state'] == "absent"
+      - test_results['msg'] == "route_target 65000:65001 created"
+
+# ADD (IDEMPOTENT)
+- name: "NETBOX_ROUTE_TARGET_ADD_IDEM: (IDEMPOTENT) Add all fields except description"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+      tenant: Test Tenant
+      tags:
+        - first
+        - second
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_ADD_IDEM: (IDEMPOTENT) Add all fields except description"
+  ansible.builtin.assert:
+    that:
+      - test_results is not changed
+      - test_results['route_target']['name'] == "65000:65001"
+      - test_results['route_target']['tenant'] == 1
+      - test_results['route_target']['tags'] | length == 2
+      - test_results['msg'] == "route_target 65000:65001 already exists"
+
+#
+# UPDATE (CHECK MODE)
+- name: "NETBOX_ROUTE_TARGET_UPDATE: Check Mode - Update description"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+      description: NEW DESCRIPTION
+      tenant: Test Tenant
+      tags:
+        - first
+        - second
+  check_mode: true
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_UPDATE: (ASSERT) Check Mode - Update description"
+  ansible.builtin.assert:
+    that:
+      - test_results is changed
+      - test_results['route_target']['name'] == "65000:65001"
+      - test_results['route_target']['tenant'] == 1
+      - test_results['route_target']['tags'] | length == 2
+      - test_results['route_target']['description'] == "NEW DESCRIPTION"
+      - test_results['diff']['after']['description'] == "NEW DESCRIPTION"
+      - test_results['diff']['before']['description'] == ""
+      - test_results['msg'] == "route_target 65000:65001 updated"
+
+# UPDATE
+- name: "NETBOX_ROUTE_TARGET_UPDATE: Update description"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+      tenant: Test Tenant
+      description: NEW DESCRIPTION
+      tags:
+        - first
+        - second
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_UPDATE: (ASSERT) Update description"
+  ansible.builtin.assert:
+    that:
+      - test_results is changed
+      - test_results['route_target']['name'] == "65000:65001"
+      - test_results['route_target']['tenant'] == 1
+      - test_results['route_target']['tags'] | length == 2
+      - test_results['route_target']['description'] == "NEW DESCRIPTION"
+      - test_results['diff']['after']['description'] == "NEW DESCRIPTION"
+      - test_results['diff']['before']['description'] == ""
+      - test_results['msg'] == "route_target 65000:65001 updated"
+
+# UPDATE (IDEMPOTENT)
+- name: "NETBOX_ROUTE_TARGET_UPDATE_IDEM: (IDEMPOTENT) Update description"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+      tenant: Test Tenant
+      description: NEW DESCRIPTION
+      tags:
+        - first
+        - second
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_UPDATE_IDEM: (IDEMPOTENT) Update description"
+  ansible.builtin.assert:
+    that:
+      - test_results is not changed
+      - test_results['route_target']['name'] == "65000:65001"
+      - test_results['route_target']['tenant'] == 1
+      - test_results['route_target']['tags'] | length == 2
+      - test_results['route_target']['description'] == "NEW DESCRIPTION"
+      - test_results['msg'] == "route_target 65000:65001 already exists"
+
+#
+# DELETE (CHECK MODE)
+- name: "NETBOX_ROUTE_TARGET_DELETE: Check Mode - Delete route target"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+    state: absent
+  check_mode: true
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_DELETE: (ASSERT) Check Mode - Delete route target"
+  ansible.builtin.assert:
+    that:
+      - test_results is changed
+      - test_results['diff']['after']['state'] == "absent"
+      - test_results['diff']['before']['state'] == "present"
+      - test_results['msg'] == "route_target 65000:65001 deleted"
+
+# DELETE
+- name: "NETBOX_ROUTE_TARGET_DELETE: Delete route target"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+    state: absent
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_DELETE: (ASSERT) Delete route target"
+  ansible.builtin.assert:
+    that:
+      - test_results is changed
+      - test_results['diff']['after']['state'] == "absent"
+      - test_results['diff']['before']['state'] == "present"
+      - test_results['msg'] == "route_target 65000:65001 deleted"
+
+# DELETE (IDEMPOTENT)
+- name: "NETBOX_ROUTE_TARGET_DELETE_IDEM: (IDEMPOTENT) Delete route target"
+  netbox.netbox.netbox_route_target:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: 65000:65001
+    state: absent
+  register: test_results
+
+- name: "NETBOX_ROUTE_TARGET_DELETE_IDEM: (IDEMPOTENT) Delete route target"
+  ansible.builtin.assert:
+    that:
+      - test_results is not changed
+      - test_results['msg'] == "route_target 65000:65001 already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_service.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_service.yml
@@ -1,0 +1,196 @@
+---
+##
+##
+### NETBOX_SERVICE
+##
+##
+- name: 1 - Device with required information needs to add new service
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: FOR_SERVICE
+      device_type: Cisco Test
+      device_role: Core Switch
+      site: Test Site
+      status: Staged
+    state: present
+
+- name: "NETBOX_SERVICE: Create new service"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: FOR_SERVICE
+      name: node-exporter
+      port: 9100
+      protocol: TCP
+    state: present
+  register: test_service_create
+
+- name: NETBOX_SERVICE ASSERT - Create
+  ansible.builtin.assert:
+    that:
+      - test_service_create is changed
+      - test_service_create['services']['name'] == "node-exporter"
+      - test_service_create['services']['ports'] == [9100]
+      - test_service_create['services']['protocol'] == "tcp"
+      - test_service_create['diff']['after']['state'] == "present"
+      - test_service_create['diff']['before']['state'] == "absent"
+      - test_service_create['msg'] == "services node-exporter created"
+
+- name: "NETBOX_SERVICE: Test idempotence"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: FOR_SERVICE
+      name: node-exporter
+      port: 9100
+      protocol: TCP
+    state: present
+  register: test_service_idempotence
+
+- name: NETBOX_SERVICE ASSERT - Not changed
+  ansible.builtin.assert:
+    that:
+      - test_service_idempotence['services']['name'] == "node-exporter"
+      - test_service_idempotence['services']['ports'] == [9100]
+      - test_service_idempotence['services']['protocol'] == "tcp"
+      - test_service_idempotence['msg'] == "services node-exporter already exists"
+
+- name: "NETBOX_SERVICE: Test update"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: FOR_SERVICE
+      name: node-exporter
+      ports:
+        - 9100
+        - 9200
+      protocol: TCP
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_service_update
+
+- name: NETBOX_SERVICE ASSERT - Service has been updated
+  ansible.builtin.assert:
+    that:
+      - test_service_update is changed
+      - test_service_update['diff']['after']['tags'][0] == 4
+      - test_service_update['diff']['after']['ports'] == [9100, 9200]
+      - test_service_update['msg'] == "services node-exporter updated"
+
+- name: "NETBOX_SERVICE: Test same details, but different protocol - Create"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: FOR_SERVICE
+      name: node-exporter
+      port: 9100
+      protocol: UDP
+    state: present
+  register: test_service_protocol
+
+- name: NETBOX_SERVICE ASSERT - Different protocol - Create
+  ansible.builtin.assert:
+    that:
+      - test_service_protocol is changed
+      - test_service_protocol['diff']['after']['state'] == "present"
+      - test_service_protocol['diff']['before']['state'] == "absent"
+      - test_service_protocol['services']['name'] == "node-exporter"
+      - test_service_protocol['services']['ports'] == [9100]
+      - test_service_protocol['services']['protocol'] == "udp"
+      - test_service_protocol['msg'] == "services node-exporter created"
+
+- name: "NETBOX_SERVICE: Test service deletion"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: FOR_SERVICE
+      name: node-exporter
+      port: 9100
+      protocol: UDP
+    state: absent
+  register: test_service_delete
+
+- name: NETBOX_SERVICE ASSERT - Service has been deleted
+  ansible.builtin.assert:
+    that:
+      - test_service_delete is changed
+      - test_service_delete['diff']['after']['state'] == "absent"
+      - test_service_delete['diff']['before']['state'] == "present"
+      - test_service_delete['msg'] == "services node-exporter deleted"
+
+- name: "NETBOX_SERVICE: Test service IP addresses"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: node-exporter
+      port: 9100
+      protocol: UDP
+      ipaddresses:
+        - address: 172.16.180.1/24
+    state: present
+  register: test_service_ip_addresses
+
+- name: NETBOX_SERVICE ASSERT - Service has been created with IP address
+  ansible.builtin.assert:
+    that:
+      - test_service_ip_addresses is changed
+      - test_service_ip_addresses['diff']['after']['state'] == "present"
+      - test_service_ip_addresses['diff']['before']['state'] == "absent"
+      - test_service_ip_addresses['services']['name'] == "node-exporter"
+      - test_service_ip_addresses['services']['ports'] == [9100]
+      - test_service_ip_addresses['services']['protocol'] == "udp"
+      - test_service_ip_addresses['services']['ipaddresses'] is defined
+      - test_service_ip_addresses['msg'] == "services node-exporter created"
+
+- name: "NETBOX_SERVICE: Missing both device & virtual_machine options - Tests required_one_of"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: node-exporter
+      port: 9100
+      protocol: UDP
+      ipaddresses:
+        - address: 172.16.180.1/24
+    state: present
+  ignore_errors: true
+  register: test_service_required_one_of
+
+- name: NETBOX_SERVICE ASSERT - Failed due to missing arguments
+  ansible.builtin.assert:
+    that:
+      - test_service_required_one_of is failed
+      - 'test_service_required_one_of["msg"] == "one of the following is required: device, virtual_machine"'
+
+- name: "NETBOX_SERVICE: Create new service on virtual_machine"
+  netbox.netbox.netbox_service:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: node-exporter-vm
+      port: 9100
+      protocol: TCP
+    state: present
+  register: test_service_create_vm
+
+- name: NETBOX_SERVICE ASSERT - Create
+  ansible.builtin.assert:
+    that:
+      - test_service_create_vm is changed
+      - test_service_create_vm['services']['name'] == "node-exporter-vm"
+      - test_service_create_vm['services']['ports'] == [9100]
+      - test_service_create_vm['services']['protocol'] == "tcp"
+      - test_service_create_vm['diff']['after']['state'] == "present"
+      - test_service_create_vm['diff']['before']['state'] == "absent"
+      - test_service_create_vm['msg'] == "services node-exporter-vm created"

--- a/tests/integration/targets/v4.5/tasks/netbox_service_template.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_service_template.yml
@@ -1,0 +1,115 @@
+---
+##
+##
+### NETBOX_SERVICE_TEMPLATE
+##
+##
+- name: "SERVICE_TEMPLATE 1: Necessary info creation"
+  netbox.netbox.netbox_service_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Service Template for SSH
+      ports:
+        - 22
+      protocol: tcp
+    state: present
+  register: test_one
+
+- name: "SERVICE_TEMPLATE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['service_template']['name'] == "Service Template for SSH"
+      - test_one['service_template']['ports'] == [22]
+      - test_one['service_template']['protocol'] == "tcp"
+      - test_one['msg'] == "service_template Service Template for SSH created"
+
+- name: "SERVICE_TEMPLATE 2: Create duplicate"
+  netbox.netbox.netbox_service_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Service Template for SSH
+      ports:
+        - 22
+      protocol: tcp
+    state: present
+  register: test_two
+
+- name: "SERVICE_TEMPLATE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['service_template']['name'] == "Service Template for SSH"
+      - test_two['service_template']['ports'] == [22]
+      - test_two['service_template']['protocol'] == "tcp"
+      - test_two['msg'] == "service_template Service Template for SSH already exists"
+
+- name: "SERVICE_TEMPLATE 3: Update Service Template with other fields"
+  netbox.netbox.netbox_service_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Service Template for SSH
+      ports:
+        - 22
+      protocol: tcp
+      comments: For SSH service
+    state: present
+  register: test_three
+
+- name: "SERVICE_TEMPLATE 3: ASSERT - Update Service Template with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['comments'] == "For SSH service"
+      - test_three['service_template']['name'] == "Service Template for SSH"
+      - test_three['service_template']['ports'] == [22]
+      - test_three['service_template']['protocol'] == "tcp"
+      - test_three['service_template']['comments'] == "For SSH service"
+      - test_three['msg'] == "service_template Service Template for SSH updated"
+
+- name: "SERVICE_TEMPLATE 4: Create Service Template for Delete Test"
+  netbox.netbox.netbox_service_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Service Template for DNS
+      ports:
+        - 53
+      protocol: udp
+      comments: Domain Name System
+    state: present
+  register: test_four
+
+- name: "SERVICE_TEMPLATE 4: ASSERT - Create Service Template for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['service_template']['name'] == "Service Template for DNS"
+      - test_four['service_template']['ports'] == [53]
+      - test_four['service_template']['protocol'] == "udp"
+      - test_four['service_template']['comments'] == "Domain Name System"
+      - test_four['msg'] == "service_template Service Template for DNS created"
+
+- name: "SERVICE_TEMPLATE 5: Delete Service Template"
+  netbox.netbox.netbox_service_template:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Service Template for DNS
+    state: absent
+  register: test_five
+
+- name: "SERVICE_TEMPLATE 5: ASSERT - Delete Service Template"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "service_template Service Template for DNS deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_site.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_site.yml
@@ -1,0 +1,165 @@
+---
+##
+##
+### NETBOX_SITE
+##
+##
+- name: 1 - Create site within NetBox with only required information
+  netbox.netbox.netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test - Colorado
+    state: present
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['site']['name'] == "Test - Colorado"
+      - test_one['msg'] == "site Test - Colorado created"
+
+- name: 2 - Duplicate
+  netbox.netbox.netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test - Colorado
+    state: present
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "site Test - Colorado already exists"
+      - test_two['site']['name'] == "Test - Colorado"
+
+- name: 3 - Update Test - Colorado
+  netbox.netbox.netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test - Colorado
+      status: Planned
+      region: Test Region
+    state: present
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['diff']['after']['region'] == 1
+      - test_three['msg'] == "site Test - Colorado updated"
+      - test_three['site']['name'] == "Test - Colorado"
+      - test_three['site']['status'] == "planned"
+      - test_three['site']['region'] == 1
+
+- name: 4 - Create site with all parameters
+  netbox.netbox.netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test - California
+      status: Planned
+      region: Test Region
+      site_group: Test Site Group
+      tenant: Test Tenant
+      facility: EquinoxCA7
+      time_zone: America/Los Angeles
+      description: This is a test description
+      physical_address: Hollywood, CA, 90210
+      shipping_address: Hollywood, CA, 90210
+      latitude: "22.169141"
+      longitude: "-100.994041"
+      comments: "### Placeholder"
+      slug: test_california
+    state: present
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['site']['name'] == "Test - California"
+      - test_four['msg'] == "site Test - California created"
+      - test_four['site']['status'] == "planned"
+      - test_four['site']['region'] == 1
+      - test_four['site']['group'] == 4
+      - test_four['site']['tenant'] == 1
+      - test_four['site']['facility'] == "EquinoxCA7"
+      - test_four['site']['time_zone'] == "America/Los_Angeles"
+      - test_four['site']['description'] == "This is a test description"
+      - test_four['site']['physical_address'] == "Hollywood, CA, 90210"
+      - test_four['site']['shipping_address'] == "Hollywood, CA, 90210"
+      - test_four['site']['latitude'] == 22.169141
+      - test_four['site']['longitude'] == -100.994041
+      - test_four['site']['comments'] == "### Placeholder"
+      - test_four['site']['slug'] == "test_california"
+
+- name: "NETBOX_SITE_IDEM: Idempotency - Create duplicate site with all parameters"
+  netbox.netbox.netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test - California
+      status: Planned
+      region: Test Region
+      site_group: Test Site Group
+      tenant: Test Tenant
+      facility: EquinoxCA7
+      time_zone: America/Los Angeles
+      description: This is a test description
+      physical_address: Hollywood, CA, 90210
+      shipping_address: Hollywood, CA, 90210
+      latitude: "22.169141"
+      longitude: "-100.994041"
+      comments: "### Placeholder"
+      slug: test_california
+    state: present
+  register: test_results
+
+- name: "NETBOX_SITE_IDEM: (ASSERT) Idempotency - Duplicate device site with all parameters"
+  ansible.builtin.assert:
+    that:
+      - test_results is not changed
+      - test_results['site']['name'] == "Test - California"
+      - test_results['msg'] == "site Test - California already exists"
+      - test_results['site']['status'] == "planned"
+      - test_results['site']['region'] == 1
+      - test_results['site']['group'] == 4
+      - test_results['site']['tenant'] == 1
+      - test_results['site']['facility'] == "EquinoxCA7"
+      - test_results['site']['time_zone'] == "America/Los_Angeles"
+      - test_results['site']['description'] == "This is a test description"
+      - test_results['site']['physical_address'] == "Hollywood, CA, 90210"
+      - test_results['site']['shipping_address'] == "Hollywood, CA, 90210"
+      - test_results['site']['latitude'] == 22.169141
+      - test_results['site']['longitude'] == -100.994041
+      - test_results['site']['comments'] == "### Placeholder"
+      - test_results['site']['slug'] == "test_california"
+
+- name: 5 - Delete site within netbox
+  netbox.netbox.netbox_site:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test - Colorado
+    state: absent
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['site']['name'] == "Test - Colorado"
+      - test_five['msg'] == "site Test - Colorado deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_site_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_site_group.yml
@@ -1,0 +1,81 @@
+---
+##
+##
+### NETBOX_SITE_GROUP
+##
+##
+- name: "SITE_GROUP 1: Necessary info creation"
+  netbox.netbox.netbox_site_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Site Group
+    state: present
+  register: test_one
+
+- name: "SITE_GROUP 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['site_group']['name'] == "Site Group"
+      - test_one['site_group']['slug'] == "site-group"
+      - test_one['msg'] == "site_group Site Group created"
+
+- name: "SITE_GROUP 2: Create duplicate"
+  netbox.netbox.netbox_site_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Site Group
+    state: present
+  register: test_two
+
+- name: "SITE_GROUP 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['site_group']['name'] == "Site Group"
+      - test_two['site_group']['slug'] == "site-group"
+      - test_two['msg'] == "site_group Site Group already exists"
+
+- name: "SITE_GROUP 3: Update"
+  netbox.netbox.netbox_site_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Site Group
+      parent_site_group: Test Site Group
+      description: This is a site group
+    state: present
+  register: test_three
+
+- name: "SITE_GROUP 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['parent'] == 4
+      - test_three['diff']['after']['description'] == "This is a site group"
+      - test_three['site_group']['name'] == "Site Group"
+      - test_three['site_group']['slug'] == "site-group"
+      - test_three['site_group']['parent'] == 4
+      - test_three['site_group']['description'] == "This is a site group"
+      - test_three['msg'] == "site_group Site Group updated"
+
+- name: "SITE_GROUP 4: Delete"
+  netbox.netbox.netbox_site_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Site Group
+    state: absent
+  register: test_four
+
+- name: "SITE_GROUP 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "site_group Site Group deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_tag.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_tag.yml
@@ -1,0 +1,110 @@
+---
+##
+##
+### NETBOX_TAGS
+##
+##
+- name: "TAG 1: ASSERT - Necessary info creation"
+  netbox.netbox.netbox_tag:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tag 1
+      description: Tag 1 test
+      color: "0000ff"
+    state: present
+  register: test_one
+
+- name: "TAG 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tags']['color'] == "0000ff"
+      - test_one['tags']['description'] == "Tag 1 test"
+      - test_one['tags']['name'] == "Test Tag 1"
+      - test_one['tags']['slug'] == "test-tag-1"
+      - test_one['msg'] == "tags Test Tag 1 created"
+
+- name: "TAG 2: Create duplicate"
+  netbox.netbox.netbox_tag:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tag 1
+      description: Tag 1 test
+      color: "0000ff"
+    state: present
+  register: test_two
+
+- name: "TAG 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['tags']['name'] == "Test Tag 1"
+      - test_two['msg'] == "tags Test Tag 1 already exists"
+
+- name: "TAG 3: ASSERT - Update"
+  netbox.netbox.netbox_tag:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tag 1
+      description: Tag 1 update test
+      color: "00ff00"
+    state: present
+  register: test_three
+
+- name: "TAG 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['color'] == "00ff00"
+      - test_three['diff']['after']['description'] == "Tag 1 update test"
+      - test_three['tags']['name'] == "Test Tag 1"
+      - test_three['tags']['description'] == "Tag 1 update test"
+      - test_three['tags']['color'] == "00ff00"
+      - test_three['msg'] == "tags Test Tag 1 updated"
+
+- name: "TAG 4: ASSERT - Delete"
+  netbox.netbox.netbox_tag:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tag 1
+    state: absent
+  register: test_four
+
+- name: "TAG 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['tags']['name'] == "Test Tag 1"
+      - test_four['tags']['slug'] == "test-tag-1"
+      - test_four['msg'] == "tags Test Tag 1 deleted"
+
+- name: "TAG 5: ASSERT - Necessary info creation"
+  netbox.netbox.netbox_tag:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tag 5
+      slug: test-tag-five
+      description: Tag 5 test
+      color: "0000ff"
+    state: present
+  register: test_five
+
+- name: "TAG 5: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['tags']['color'] == "0000ff"
+      - test_five['tags']['description'] == "Tag 5 test"
+      - test_five['tags']['name'] == "Test Tag 5"
+      - test_five['tags']['slug'] == "test-tag-five"
+      - test_five['msg'] == "tags Test Tag 5 created"

--- a/tests/integration/targets/v4.5/tasks/netbox_tenant.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_tenant.yml
@@ -1,0 +1,106 @@
+---
+##
+##
+### NETBOX_TENANT
+##
+##
+- name: 1 - Test tenant creation
+  netbox.netbox.netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Tenant ABC
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tenant']['name'] == "Tenant ABC"
+      - test_one['tenant']['slug'] == "tenant-abc"
+      - test_one['msg'] == "tenant Tenant ABC created"
+
+- name: Test duplicate tenant
+  netbox.netbox.netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Tenant ABC
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['tenant']['name'] == "Tenant ABC"
+      - test_two['tenant']['slug'] == "tenant-abc"
+      - test_two['msg'] == "tenant Tenant ABC already exists"
+
+- name: 3 - Test update
+  netbox.netbox.netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Tenant ABC
+      description: Updated description
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Updated description"
+      - test_three['tenant']['name'] == "Tenant ABC"
+      - test_three['tenant']['slug'] == "tenant-abc"
+      - test_three['tenant']['description'] == "Updated description"
+      - test_three['msg'] == "tenant Tenant ABC updated"
+
+- name: 4 - Test delete
+  netbox.netbox.netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Tenant ABC
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "tenant Tenant ABC deleted"
+
+- name: 5 - Create tenant with all parameters
+  netbox.netbox.netbox_tenant:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Tenant ABC
+      description: ABC Incorporated
+      comments: "### This tenant is super cool"
+      tenant_group: Test Tenant Group
+      slug: tenant_abc
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['tenant']['name'] == "Tenant ABC"
+      - test_five['tenant']['slug'] == "tenant_abc"
+      - test_five['tenant']['description'] == "ABC Incorporated"
+      - test_five['tenant']['comments'] == "### This tenant is super cool"
+      - test_five['tenant']['group'] == 1
+      - test_five['tenant']['tags'] | length == 3
+      - test_five['msg'] == "tenant Tenant ABC created"

--- a/tests/integration/targets/v4.5/tasks/netbox_tenant_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_tenant_group.yml
@@ -1,0 +1,129 @@
+---
+##
+##
+### NETBOX_TENANT_GROUP
+##
+##
+- name: 1 - Test tenant group creation
+  netbox.netbox.netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tenant Group Two
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tenant_group']['name'] == "Test Tenant Group Two"
+      - test_one['tenant_group']['slug'] == "test-tenant-group-two"
+      - test_one['msg'] == "tenant_group Test Tenant Group Two created"
+
+- name: Test duplicate tenant group
+  netbox.netbox.netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tenant Group Two
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['tenant_group']['name'] == "Test Tenant Group Two"
+      - test_two['tenant_group']['slug'] == "test-tenant-group-two"
+      - test_two['msg'] == "tenant_group Test Tenant Group Two already exists"
+
+- name: 3 - Test delete
+  netbox.netbox.netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tenant Group Two
+    state: absent
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "present"
+      - test_three['diff']['after']['state'] == "absent"
+      - test_three['msg'] == "tenant_group Test Tenant Group Two deleted"
+
+- name: 4 - Test tenant group creation with custom slug
+  netbox.netbox.netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tenant Group ABC
+      slug: test_tenant_group_four
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['tenant_group']['name'] == "Test Tenant Group ABC"
+      - test_four['tenant_group']['slug'] == "test_tenant_group_four"
+      - test_four['msg'] == "tenant_group Test Tenant Group ABC created"
+
+- name: 5 - Test child tenant group creation
+  netbox.netbox.netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Child Test Tenant Group
+      parent_tenant_group: "{{ test_four.tenant_group.slug }}"
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['tenant_group']['name'] == "Child Test Tenant Group"
+      - test_five['tenant_group']['parent'] == test_four.tenant_group.id
+      - test_five['msg'] == "tenant_group Child Test Tenant Group created"
+
+- name: 6 - Test child tenant group deletion
+  netbox.netbox.netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Child Test Tenant Group
+    state: absent
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "present"
+      - test_six['diff']['after']['state'] == "absent"
+      - test_six['msg'] == "tenant_group Child Test Tenant Group deleted"
+
+- name: 7 - Test deletion of the tenant group with custom slug
+  netbox.netbox.netbox_tenant_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tenant Group ABC
+      slug: test_tenant_group_four
+    state: absent
+  register: test_seven
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "present"
+      - test_seven['diff']['after']['state'] == "absent"
+      - test_seven['msg'] == "tenant_group Test Tenant Group ABC deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_token.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_token.yml
@@ -1,0 +1,105 @@
+---
+##
+##
+### NETBOX_PERMISSION
+##
+##
+- name: "TOKEN: Set up user"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+      password: TestPassword2
+    state: present
+  register: test_user
+
+- name: "TOKEN 1: Necessary info creation"
+  netbox.netbox.netbox_token:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      user: TestUser
+      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    state: present
+  register: test_one
+
+- name: "TOKEN 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['token']['user'] == test_user['user']['id']
+      - test_one['msg'] == "token ******** created"
+
+- name: "TOKEN 2: Create duplicate"
+  netbox.netbox.netbox_token:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      user: TestUser
+      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    state: present
+  register: test_two
+
+- name: "TOKEN 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "token ******** already exists"
+
+- name: "TOKEN 3: Update"
+  netbox.netbox.netbox_token:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      user: TestUser
+      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      description: The test token
+      write_enabled: false
+      expires: 2024-08-26T14:49:01.345000+00:00
+    state: present
+  register: test_three
+
+- name: "TOKEN 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['token']['description'] == "The test token"
+      - test_three['token']['write_enabled'] == false
+      - test_three['token']['expires'] == "2024-08-26T14:49:01.345000+00:00"
+      - test_three['msg'] == "token ******** updated"
+
+- name: "TOKEN 4: Delete"
+  netbox.netbox.netbox_token:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    state: absent
+  register: test_four
+
+- name: "TOKEN 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "token ******** deleted"
+
+- name: "TOKEN 5: ASSERT - Delete non existing"
+  netbox.netbox.netbox_token:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    state: absent
+  register: test_five
+
+- name: "TOKEN 5: ASSERT - Delete non existing"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['token'] == None
+      - test_five['msg'] == "token ******** already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_token.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_token.yml
@@ -1,8 +1,10 @@
 ---
 ##
 ##
-### NETBOX_PERMISSION
+### NETBOX_TOKEN (v4.5 - v2 tokens)
 ##
+## v4.5 uses v2 tokens by default. Keys are auto-generated and cannot be
+## used for lookup. Use description + user for idempotent operations.
 ##
 - name: "TOKEN: Set up user"
   netbox.netbox.netbox_user:
@@ -14,51 +16,50 @@
     state: present
   register: test_user
 
-- name: "TOKEN 1: Necessary info creation"
+- name: "TOKEN 1: Create v2 token with description"
   netbox.netbox.netbox_token:
     netbox_url: http://localhost:32768
     netbox_token: "0123456789abcdef0123456789abcdef01234567"
     data:
       user: TestUser
-      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      description: The test token
     state: present
   register: test_one
 
-- name: "TOKEN 1: ASSERT - Necessary info creation"
+- name: "TOKEN 1: ASSERT - Creation"
   ansible.builtin.assert:
     that:
       - test_one is changed
       - test_one['diff']['before']['state'] == "absent"
       - test_one['diff']['after']['state'] == "present"
       - test_one['token']['user'] == test_user['user']['id']
-      - test_one['msg'] == "token ******** created"
+      - test_one['token']['description'] == "The test token"
+      - test_one['msg'] == "token The test token created"
 
-- name: "TOKEN 2: Create duplicate"
+- name: "TOKEN 2: Create duplicate (idempotency)"
   netbox.netbox.netbox_token:
     netbox_url: http://localhost:32768
     netbox_token: "0123456789abcdef0123456789abcdef01234567"
     data:
       user: TestUser
-      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      description: The test token
     state: present
   register: test_two
 
-- name: "TOKEN 2: ASSERT - Create duplicate"
+- name: "TOKEN 2: ASSERT - Idempotency"
   ansible.builtin.assert:
     that:
       - not test_two['changed']
-      - test_two['msg'] == "token ******** already exists"
+      - test_two['msg'] == "token The test token already exists"
 
-- name: "TOKEN 3: Update"
+- name: "TOKEN 3: Update token"
   netbox.netbox.netbox_token:
     netbox_url: http://localhost:32768
     netbox_token: "0123456789abcdef0123456789abcdef01234567"
     data:
       user: TestUser
-      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       description: The test token
       write_enabled: false
-      expires: 2024-08-26T14:49:01.345000+00:00
     state: present
   register: test_three
 
@@ -68,15 +69,15 @@
       - test_three is changed
       - test_three['token']['description'] == "The test token"
       - test_three['token']['write_enabled'] == false
-      - test_three['token']['expires'] == "2024-08-26T14:49:01.345000+00:00"
-      - test_three['msg'] == "token ******** updated"
+      - test_three['msg'] == "token The test token updated"
 
-- name: "TOKEN 4: Delete"
+- name: "TOKEN 4: Delete token"
   netbox.netbox.netbox_token:
     netbox_url: http://localhost:32768
     netbox_token: "0123456789abcdef0123456789abcdef01234567"
     data:
-      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      user: TestUser
+      description: The test token
     state: absent
   register: test_four
 
@@ -86,14 +87,15 @@
       - test_four is changed
       - test_four['diff']['before']['state'] == "present"
       - test_four['diff']['after']['state'] == "absent"
-      - test_four['msg'] == "token ******** deleted"
+      - test_four['msg'] == "token The test token deleted"
 
-- name: "TOKEN 5: ASSERT - Delete non existing"
+- name: "TOKEN 5: Delete non existing"
   netbox.netbox.netbox_token:
     netbox_url: http://localhost:32768
     netbox_token: "0123456789abcdef0123456789abcdef01234567"
     data:
-      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      user: TestUser
+      description: The test token
     state: absent
   register: test_five
 
@@ -102,4 +104,4 @@
     that:
       - not test_five['changed']
       - test_five['token'] == None
-      - test_five['msg'] == "token ******** already absent"
+      - test_five['msg'] == "token The test token already absent"

--- a/tests/integration/targets/v4.5/tasks/netbox_tunnel.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_tunnel.yml
@@ -1,0 +1,96 @@
+---
+##
+##
+### NETBOX_TUNNEL
+##
+##
+- name: "TUNNEL 1: Necessary info creation"
+  netbox.netbox.netbox_tunnel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel
+      status: active
+      encapsulation: ipsec-tunnel
+    state: present
+  register: test_one
+
+- name: "TUNNEL 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tunnel']['name'] == "Test Tunnel"
+      - test_one['tunnel']['status'] == "active"
+      - test_one['tunnel']['encapsulation'] == "ipsec-tunnel"
+      - test_one['msg'] == "tunnel Test Tunnel created"
+
+- name: "TUNNEL 2: Create duplicate"
+  netbox.netbox.netbox_tunnel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel
+      status: active
+      encapsulation: ipsec-tunnel
+    state: present
+  register: test_two
+
+- name: "TUNNEL 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['tunnel']['name'] == "Test Tunnel"
+      - test_two['tunnel']['status'] == "active"
+      - test_two['tunnel']['encapsulation'] == "ipsec-tunnel"
+      - test_two['msg'] == "tunnel Test Tunnel already exists"
+
+- name: "TUNNEL 3: Update Existing"
+  netbox.netbox.netbox_tunnel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel
+      encapsulation: ipsec-tunnel
+      description: Test Description
+      tenant: Test Tenant
+      tunnel_id: 200
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "TUNNEL: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Test Description"
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['diff']['after']['tunnel_id'] == 200
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['tunnel']['name'] == "Test Tunnel"
+      - test_three['tunnel']['tenant'] == 1
+      - test_three['tunnel']['tunnel_id'] == 200
+      - test_three['tunnel']['description'] == "Test Description"
+      - test_three['tunnel']['tags'][0] == 4
+      - test_three['tunnel']['encapsulation'] == "ipsec-tunnel"
+      - test_three['msg'] == "tunnel Test Tunnel updated"
+
+- name: "TUNNEL 4: Delete"
+  netbox.netbox.netbox_tunnel:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel
+      encapsulation: ipsec-tunnel
+    state: absent
+  register: test_four
+
+- name: "TUNNEL 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "tunnel Test Tunnel deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_tunnel_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_tunnel_group.yml
@@ -1,0 +1,81 @@
+---
+##
+##
+### NETBOX_TUNNEL GROUP
+##
+##
+- name: "TUNNEL_GROUP 1: Necessary info creation"
+  netbox.netbox.netbox_tunnel_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel Group
+    state: present
+  register: test_one
+
+- name: "TUNNEL_GROUP 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['tunnel_group']['name'] == "Test Tunnel Group"
+      - test_one['tunnel_group']['slug'] == "test-tunnel-group"
+      - test_one['msg'] == "tunnel_group Test Tunnel Group created"
+
+- name: "TUNNEL_GROUP 2: Create duplicate"
+  netbox.netbox.netbox_tunnel_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel Group
+    state: present
+  register: test_two
+
+- name: "TUNNEL_GROUP 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['tunnel_group']['name'] == "Test Tunnel Group"
+      - test_two['tunnel_group']['slug'] == "test-tunnel-group"
+      - test_two['msg'] == "tunnel_group Test Tunnel Group already exists"
+
+- name: "TUNNEL_GROUP 3: Update Existing"
+  netbox.netbox.netbox_tunnel_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel Group
+      description: Test Description
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "TUNNEL_GROUP 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Test Description"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['tunnel_group']['name'] == "Test Tunnel Group"
+      - test_three['tunnel_group']['description'] == "Test Description"
+      - test_three['tunnel_group']['tags'][0] == 4
+      - test_three['msg'] == "tunnel_group Test Tunnel Group updated"
+
+- name: "TUNNEL_GROUP 4: Delete"
+  netbox.netbox.netbox_tunnel_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Tunnel Group
+    state: absent
+  register: test_four
+
+- name: "TUNNEL_GROUP 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "tunnel_group Test Tunnel Group deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_user.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_user.yml
@@ -1,0 +1,200 @@
+---
+##
+##
+### NETBOX_USER
+##
+##
+- name: "USER 1: Necessary info creation"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+      password: TestPassword1
+    state: present
+  register: test_one
+
+- name: "USER 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['user']['username'] == "TestUser"
+      - test_one['user']['display'] == "TestUser"
+      - test_one['msg'] == "user TestUser created"
+
+- name: "USER 2: Update password"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+      password: TestPassword2
+      email: my@user.com
+    state: present
+  register: test_two
+
+- name: "USER 2: ASSERT - Update password"
+  ansible.builtin.assert:
+    that:
+      - test_two['changed']
+      - test_two['user']['username'] == "TestUser"
+      - test_two['msg'] == "user TestUser updated"
+
+- name: "USER 3: Update"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+      password: TestPassword3
+      email: test@user.com
+      first_name: Test
+      last_name: User
+      is_active: false
+    state: present
+  register: test_three
+
+- name: "USER 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['first_name'] == "Test"
+      - test_three['diff']['after']['last_name'] == "User"
+      - test_three['user']['username'] == "TestUser"
+      - test_three['user']['email'] == "test@user.com"
+      - test_three['user']['first_name'] == "Test"
+      - test_three['user']['last_name'] == "User"
+      - test_three['user']['is_active'] == False
+      - test_three['msg'] == "user TestUser updated"
+
+- name: "USER 4: Delete"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+    state: absent
+  register: test_four
+
+- name: "USER 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "user TestUser deleted"
+
+- name: "USER 5: Delete non existing"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+    state: absent
+  register: test_five
+
+- name: "USER 5: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_five['changed']
+      - test_five['user'] == None
+      - test_five['msg'] == "user TestUser already absent"
+
+- name: "USER 6: Necessary group 1"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group Alpha
+    state: present
+  register: user_group_alpha
+
+- name: "USER 6: Necessary group 2"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group Beta
+    state: present
+  register: user_group_beta
+
+- name: "User 6: Necessary permission 1"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission Foo
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: permission_foo
+
+- name: "User 6: Necessary permission 2"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission Bar
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: permission_bar
+
+- name: "User 6: Necessary permission 3"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission Baz
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: permission_baz
+
+- name: "USER 6: Set up user with multiple groups and permissions"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser2
+      password: TestPassword2
+      permissions:
+        - Test Permission Foo
+        - Test Permission Bar
+        - Test Permission Baz
+      groups:
+        - Test User Group Alpha
+        - Test User Group Beta
+    state: present
+
+- name: "USER 6: Re-create user with lists in wrong order"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser2
+      permissions:
+        - Test Permission Bar
+        - Test Permission Baz
+        - Test Permission Foo
+      groups:
+        - Test User Group Beta
+        - Test User Group Alpha
+    state: present
+  register: test_six
+
+- name: "USER 6: ASSERT - The same lists in a new order do not update the user"
+  ansible.builtin.assert:
+    that:
+      - not test_six['changed']
+      - test_six['msg'] == "user TestUser2 already exists"
+      - test_six['user']['groups'][0] == user_group_alpha['user_group']['id']
+      - test_six['user']['groups'][1] == user_group_beta['user_group']['id']
+      - test_six['user']['permissions'][0] == permission_foo['permission']['id']
+      - test_six['user']['permissions'][1] == permission_bar['permission']['id']
+      - test_six['user']['permissions'][2] == permission_baz['permission']['id']

--- a/tests/integration/targets/v4.5/tasks/netbox_user_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_user_group.yml
@@ -1,0 +1,181 @@
+---
+##
+##
+### NETBOX_USER_GROUP
+##
+##
+- name: "USER_GROUP 1: Necessary info creation"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+    state: present
+  register: test_one
+
+- name: "USER_GROUP 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['user_group']['name'] == "Test User Group"
+      - test_one['msg'] == "user_group Test User Group created"
+
+- name: "USER_GROUP 2: Create duplicate"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+    state: present
+  register: test_two
+
+- name: "USER_GROUP 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['user_group']['name'] == "Test User Group"
+      - test_two['msg'] == "user_group Test User Group already exists"
+
+- name: "USER_GROUP 3: Update"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+      description: The test group
+    state: present
+  register: test_three
+
+- name: "USER_GROUP 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "The test group"
+      - test_three['user_group']['name'] == "Test User Group"
+      - test_three['user_group']['description'] == "The test group"
+      - test_three['msg'] == "user_group Test User Group updated"
+
+- name: "USER_GROUP 4: Create second group"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group 2
+    state: present
+  register: test_four
+
+- name: "USER_GROUP 4: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['user_group']['name'] == "Test User Group 2"
+      - test_four['msg'] == "user_group Test User Group 2 created"
+
+- name: "USER_GROUP 5: Add user to group"
+  netbox.netbox.netbox_user:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      username: TestUser
+      password: TestPassword5
+      groups:
+        - Test User Group
+    state: present
+  register: test_five
+
+- name: "USER_GROUP 5: ASSERT - Add user to group"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['user']['groups'] == [test_one['user_group']['id']]
+
+- name: "USER_GROUP 6: Delete"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+    state: absent
+  register: test_six
+
+- name: "USER_GROUP 6: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['diff']['before']['state'] == "present"
+      - test_six['diff']['after']['state'] == "absent"
+      - test_six['msg'] == "user_group Test User Group deleted"
+
+- name: "USER_GROUP 6: ASSERT - Delete non existing"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+    state: absent
+  register: test_seven
+
+- name: "USER_GROUP 7: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['user_group'] == None
+      - test_seven['msg'] == "user_group Test User Group already absent"
+
+- name: "USER_GROUP 8: Necessary permission 1"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission Foo
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: permission_foo
+
+- name: "USER_GROUP 8: Necessary permission 2"
+  netbox.netbox.netbox_permission:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test Permission Bar
+      actions:
+        - view
+      object_types: []
+    state: present
+  register: permission_bar
+
+- name: "USER_GROUP 8: Necessary info creation"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+      permissions:
+        - Test Permission Foo
+        - Test Permission Bar
+    state: present
+
+- name: "USER_GROUP 8: Re-create user group with permissions in wrong order"
+  netbox.netbox.netbox_user_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test User Group
+      permissions:
+        - Test Permission Bar
+        - Test Permission Foo
+    state: present
+  register: test_eight
+
+- name: "USER_GROUP 8: ASSERT - The same permissions in a new order do not update the group"
+  ansible.builtin.assert:
+    that:
+      - not test_eight is changed
+      - test_eight['user_group']['permissions'][0] == permission_foo['permission']['id']
+      - test_eight['user_group']['permissions'][1] == permission_bar['permission']['id']

--- a/tests/integration/targets/v4.5/tasks/netbox_virtual_chassis.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_virtual_chassis.yml
@@ -1,0 +1,130 @@
+---
+# © 2020 Nokia
+# Licensed under the GNU General Public License v3.0 only
+# SPDX-License-Identifier: GPL-3.0-only
+##
+##
+### NETBOX_VIRTUAL_CHASSIS
+##
+##
+- name: "VIRTUAL_CHASSIS 0: Create device for testing virtual chassis"
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Device Virtual Chassis Tests
+      device_type: Cisco Test
+      device_role: Core Switch
+      site: Test Site
+      vc_position: 1
+      vc_priority: 1
+    state: present
+
+- name: "VIRTUAL_CHASSIS 1: Necessary info creation"
+  netbox.netbox.netbox_virtual_chassis:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: First VC
+      master: Device Virtual Chassis Tests
+    state: present
+  register: test_one
+
+- name: "VIRTUAL_CHASSIS 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['virtual_chassis']['name'] == "First VC"
+      - test_one['msg'] == "virtual_chassis First VC created"
+
+- name: "VIRTUAL_CHASSIS 2: Create duplicate"
+  netbox.netbox.netbox_virtual_chassis:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: First VC
+      master: Device Virtual Chassis Tests
+    state: present
+  register: test_two
+
+- name: "VIRTUAL_CHASSIS 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['virtual_chassis']['master'] == test_one['virtual_chassis']['master']
+      - test_two['virtual_chassis']['name'] == "First VC"
+      - test_two['msg'] == "virtual_chassis First VC already exists"
+
+- name: "POWER_FEED 3: Update virtual_chassis with other fields"
+  netbox.netbox.netbox_virtual_chassis:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: First VC
+      master: Device Virtual Chassis Tests
+      domain: Domain Text
+    state: present
+  register: test_three
+
+- name: "POWER_FEED 3: ASSERT - Update virtual_chassis with other fields"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['domain'] == "Domain Text"
+      - test_three['virtual_chassis']['master'] == test_one['virtual_chassis']['master']
+      - test_three['virtual_chassis']['domain'] == "Domain Text"
+      - test_three['virtual_chassis']['name'] == "First VC"
+      - test_three['msg'] == "virtual_chassis First VC updated"
+
+- name: "VIRTUAL_CHASSIS 4: Create device for testing virtual chassis deletion"
+  netbox.netbox.netbox_device:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Device Virtual Chassis Tests 2
+      device_type: Cisco Test
+      device_role: Core Switch
+      site: Test Site
+      vc_position: 1
+      vc_priority: 15
+    state: present
+
+- name: "VIRTUAL_CHASSIS 4: Create Virtual Chassis for Delete Test"
+  netbox.netbox.netbox_virtual_chassis:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Second VC
+      master: Device Virtual Chassis Tests 2
+    state: present
+  register: test_four
+
+- name: "VIRTUAL_CHASSIS 4: ASSERT - Create Virtual Chassis for Delete Test"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['virtual_chassis']['master'] != test_one['virtual_chassis']['master']
+      - test_four['virtual_chassis']['name'] == "Second VC"
+      - test_four['msg'] == "virtual_chassis Second VC created"
+
+- name: "VIRTUAL_CHASSIS 5: Delete Virtual Chassis"
+  netbox.netbox.netbox_virtual_chassis:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Second VC
+      master: Device Virtual Chassis Tests 2
+    state: absent
+  register: test_five
+
+- name: "VIRTUAL_CHASSIS 5: ASSERT - Delete Virtual Chassis"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "virtual_chassis Second VC deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_virtual_disk.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_virtual_disk.yml
@@ -1,0 +1,87 @@
+---
+##
+##
+### NETBOX_VIRTUAL_DISK
+##
+##
+- name: "NETBOX_VIRTUAL_DISK 1: Necessary info creation"
+  netbox.netbox.netbox_virtual_disk:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: disk0
+      size: 50
+    state: present
+  register: test_one
+
+- name: "NETBOX_VIRTUAL_DISK 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['virtual_disk']['name'] == "disk0"
+      - test_one['virtual_disk']['virtual_machine'] == 1
+      - test_one['msg'] == "virtual_disk disk0 created"
+
+- name: "NETBOX_VIRTUAL_DISK 2: Create duplicate"
+  netbox.netbox.netbox_virtual_disk:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: disk0
+      size: 50
+    state: present
+  register: test_two
+
+- name: "NETBOX_VIRTUAL_DISK 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['virtual_disk']['name'] == "disk0"
+      - test_two['virtual_disk']['virtual_machine'] == 1
+      - test_two['msg'] == "virtual_disk disk0 already exists"
+
+- name: "NETBOX_VIRTUAL_DISK 3: Update"
+  netbox.netbox.netbox_virtual_disk:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: disk0
+      size: 60
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "NETBOX_VIRTUAL_DISK 4: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['size'] == 60
+      - test_three['virtual_disk']['name'] == "disk0"
+      - test_three['virtual_disk']['virtual_machine'] == 1
+      - test_three['virtual_disk']['size'] == 60
+      - test_three['virtual_disk']['tags'][0] == 4
+      - test_three['msg'] == "virtual_disk disk0 updated"
+
+- name: "NETBOX_VIRTUAL_DISK 4: ASSERT - Delete"
+  netbox.netbox.netbox_virtual_disk:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: disk0
+      virtual_machine: test100-vm
+    state: absent
+  register: test_four
+
+- name: "NETBOX_VIRTUAL_DISK 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['virtual_disk']['name'] == "disk0"
+      - test_four['virtual_disk']['virtual_machine'] == 1
+      - test_four['msg'] == "virtual_disk disk0 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_virtual_machine.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_virtual_machine.yml
@@ -1,0 +1,131 @@
+---
+##
+##
+### NETBOX_VIRTUAL_MACHINES
+##
+##
+- name: "VIRTUAL_MACHINE 1: Necessary info creation"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VM One
+      cluster: Test Cluster
+    state: present
+  register: test_one
+
+- name: "VIRTUAL_MACHINE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['virtual_machine']['name'] == "Test VM One"
+      - test_one['virtual_machine']['cluster'] == 1
+      - test_one['msg'] == "virtual_machine Test VM One created"
+
+- name: "VIRTUAL_MACHINE 2: Create duplicate"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VM One
+      cluster: Test Cluster
+    state: present
+  register: test_two
+
+- name: "VIRTUAL_MACHINE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['virtual_machine']['name'] == "Test VM One"
+      - test_two['virtual_machine']['cluster'] == 1
+      - test_two['msg'] == "virtual_machine Test VM One already exists"
+
+- name: "VIRTUAL_MACHINE 3: Update"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VM One
+      cluster: Test Cluster
+      serial: 12345678
+      vcpus: 8.5
+      memory: 8
+      status: Planned
+      virtual_machine_role: Test VM Role
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "VIRTUAL_MACHINE 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['vcpus'] == 8.5
+      - test_three['diff']['after']['memory'] == 8
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['diff']['after']['role'] == 2
+      - test_three['diff']['after']['serial'] == "12345678"
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['virtual_machine']['name'] == "Test VM One"
+      - test_three['virtual_machine']['cluster'] == 1
+      - test_three['virtual_machine']['vcpus'] == 8.5
+      - test_three['virtual_machine']['memory'] == 8
+      - test_three['virtual_machine']['status'] == "planned"
+      - test_three['virtual_machine']['role'] == 2
+      - test_three['virtual_machine']['serial'] == "12345678"
+      - test_three['virtual_machine']['tags'][0] == 4
+      - test_three['msg'] == "virtual_machine Test VM One updated"
+
+- name: "VIRTUAL_MACHINE 4: Test idempotence"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VM One
+      cluster: Test Cluster
+      vcpus: 8.5
+      memory: 8
+      status: Planned
+      virtual_machine_role: Test VM Role
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four_idempotence
+
+- name: "VIRTUAL_MACHINE 4: ASSERT - Not changed"
+  ansible.builtin.assert:
+    that:
+      - test_four_idempotence is not changed
+      - test_four_idempotence['virtual_machine']['name'] == "Test VM One"
+      - test_four_idempotence['virtual_machine']['cluster'] == 1
+      - test_four_idempotence['virtual_machine']['vcpus'] == 8.5
+      - test_four_idempotence['virtual_machine']['memory'] == 8
+      - test_four_idempotence['virtual_machine']['status'] == "planned"
+      - test_four_idempotence['virtual_machine']['role'] == 2
+      - test_four_idempotence['virtual_machine']['tags'][0] == 4
+      - test_four_idempotence['msg'] == "virtual_machine Test VM One already exists"
+
+- name: "VIRTUAL_MACHINE 5: Delete"
+  netbox.netbox.netbox_virtual_machine:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VM One
+    state: absent
+  register: test_five
+
+- name: "VIRTUAL_MACHINE 5: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['virtual_machine']['name'] == "Test VM One"
+      - test_five['virtual_machine']['cluster'] == 1
+      - test_five['virtual_machine']['vcpus'] == 8.5
+      - test_five['virtual_machine']['memory'] == 8
+      - test_five['virtual_machine']['status'] == "planned"
+      - test_five['virtual_machine']['role'] == 2
+      - test_five['virtual_machine']['tags'][0] == 4
+      - test_five['msg'] == "virtual_machine Test VM One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_vlan.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_vlan.yml
@@ -1,0 +1,193 @@
+---
+##
+##
+### NETBOX_VLAN
+##
+##
+- name: "VLAN 1: Necessary info creation"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+      vid: 500
+    state: present
+  register: test_one
+
+- name: "VLAN 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vlan']['name'] == "Test VLAN 500"
+      - test_one['vlan']['vid'] == 500
+      - test_one['msg'] == "vlan Test VLAN 500 created"
+
+- name: "VLAN 2: Create duplicate"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+      vid: 500
+    state: present
+  register: test_two
+
+- name: "VLAN 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['vlan']['name'] == "Test VLAN 500"
+      - test_two['vlan']['vid'] == 500
+      - test_two['msg'] == "vlan Test VLAN 500 already exists"
+
+- name: "VLAN 3: Create VLAN with same name, but different site"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+      vid: 500
+      site: Test Site
+      tenant: Test Tenant
+      vlan_group: Test VLAN Group
+    state: present
+  register: test_three
+
+- name: "VLAN 3: ASSERT - Create VLAN with same name, but different site"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['vlan']['name'] == "Test VLAN 500"
+      - test_three['vlan']['vid'] == 500
+      - test_three['vlan']['site'] == 1
+      - test_three['vlan']['group'] == 1
+      - test_three['msg'] == "vlan Test VLAN 500 created"
+
+- name: "VLAN 4: ASSERT - Update"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+      vid: 500
+      tenant: Test Tenant
+      vlan_group: Test VLAN Group
+      status: Reserved
+      vlan_role: Network of care
+      description: Updated description
+      site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four
+
+- name: "VLAN 4: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['status'] == "reserved"
+      - test_four['diff']['after']['role'] == 1
+      - test_four['diff']['after']['description'] == "Updated description"
+      - test_four['diff']['after']['tags'][0] == 4
+      - test_four['vlan']['name'] == "Test VLAN 500"
+      - test_four['vlan']['tenant'] == 1
+      - test_four['vlan']['site'] == 1
+      - test_four['vlan']['group'] == 1
+      - test_four['vlan']['status'] == "reserved"
+      - test_four['vlan']['role'] == 1
+      - test_four['vlan']['description'] == "Updated description"
+      - test_four['vlan']['tags'][0] == 4
+      - test_four['msg'] == "vlan Test VLAN 500 updated"
+
+- name: "VLAN: ASSERT - IDEMPOTENT WITH VLAN_GROUP"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+      vid: 500
+      tenant: Test Tenant
+      vlan_group: Test VLAN Group
+      status: Reserved
+      vlan_role: Network of care
+      description: Updated description
+      site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: idempotent_vlan_group
+
+- name: "VLAN: ASSERT - IDEMPOTENT WITH VLAN_GROUP"
+  ansible.builtin.assert:
+    that:
+      - idempotent_vlan_group is not changed
+
+- name: "VLAN: Create VLAN with same name, but different vlan_group"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+      vid: 500
+      site: Test Site
+      tenant: Test Tenant
+      vlan_group: Test VLAN Group 2
+    state: present
+  register: new_vlan_group
+
+- name: "VLAN: ASSERT - Create VLAN with same name, but different vlan_group"
+  ansible.builtin.assert:
+    that:
+      - new_vlan_group is changed
+      - new_vlan_group['diff']['before']['state'] == "absent"
+      - new_vlan_group['diff']['after']['state'] == "present"
+      - new_vlan_group['vlan']['name'] == "Test VLAN 500"
+      - new_vlan_group['vlan']['vid'] == 500
+      - new_vlan_group['vlan']['site'] == 1
+      - new_vlan_group['vlan']['group'] == 2
+      - new_vlan_group['msg'] == "vlan Test VLAN 500 created"
+
+- name: "VLAN 5: ASSERT - Delete more than one result"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+    state: absent
+  ignore_errors: true
+  register: test_five
+
+- name: "VLAN 5: ASSERT - Delete more than one result"
+  ansible.builtin.assert:
+    that:
+      - test_five is failed
+      - test_five['msg'] == "More than one result returned for Test VLAN 500"
+
+- name: "VLAN 6: ASSERT - Delete"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VLAN 500
+      site: Test Site
+      vlan_group: Test VLAN Group
+    state: absent
+  register: test_six
+
+- name: "VLAN 6: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['vlan']['name'] == "Test VLAN 500"
+      - test_six['vlan']['tenant'] == 1
+      - test_six['vlan']['site'] == 1
+      - test_six['vlan']['group'] == 1
+      - test_six['vlan']['status'] == "reserved"
+      - test_six['vlan']['role'] == 1
+      - test_six['vlan']['description'] == "Updated description"
+      - test_six['vlan']['tags'][0] == 4
+      - test_six['msg'] == "vlan Test VLAN 500 deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_vlan_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_vlan_group.yml
@@ -1,0 +1,400 @@
+---
+##
+##
+### NETBOX_VLAN_GROUP
+##
+##
+- name: "VLAN_GROUP 1: Necessary info creation"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group One
+      scope_type: dcim.site
+      scope: Test Site
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "absent"
+      - results['diff']['after']['state'] == "present"
+      - results['vlan_group']['name'] == "VLAN Group One"
+      - results['vlan_group']['slug'] == "vlan-group-one"
+      - results['vlan_group']['scope_type'] == "dcim.site"
+      - results['vlan_group']['scope_id'] == 1
+      - results['msg'] == "vlan_group VLAN Group One created"
+
+- name: "VLAN_GROUP 2: Create duplicate"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group One
+      scope_type: dcim.site
+      scope: Test Site
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not results['changed']
+      - results['vlan_group']['name'] == "VLAN Group One"
+      - results['vlan_group']['slug'] == "vlan-group-one"
+      - results['vlan_group']['scope_type'] == "dcim.site"
+      - results['vlan_group']['scope_id'] == 1
+      - results['msg'] == "vlan_group VLAN Group One already exists"
+
+- name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group One
+      scope_type: dcim.site
+      scope: Test Site2
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 3: ASSERT - Create with same name, different site"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['vlan_group']['name'] == "VLAN Group One"
+      - results['vlan_group']['slug'] == "vlan-group-one"
+      - results['vlan_group']['scope_type'] == "dcim.site"
+      - results['vlan_group']['scope_id'] == 2
+      - results['msg'] == "vlan_group VLAN Group One created"
+
+- name: "VLAN_GROUP 4: ASSERT - Create vlan group, no site"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group One
+    state: present
+  ignore_errors: true
+  register: results
+
+- name: "VLAN_GROUP 4: ASSERT - Create with same name, different site"
+  ansible.builtin.assert:
+    that:
+      - results is failed
+      - results['msg'] == "More than one result returned for VLAN Group One"
+
+- name: "VLAN_GROUP 5: ASSERT - Delete"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group One
+      scope_type: dcim.site
+      scope: Test Site2
+    state: absent
+  register: results
+
+- name: "VLAN_GROUP 5: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "present"
+      - results['diff']['after']['state'] == "absent"
+      - results['vlan_group']['name'] == "VLAN Group One"
+      - results['vlan_group']['slug'] == "vlan-group-one"
+      - results['vlan_group']['scope_type'] == "dcim.site"
+      - results['vlan_group']['scope_id'] == 2
+      - results['msg'] == "vlan_group VLAN Group One deleted"
+
+- name: "VLAN_GROUP 6: ASSERT - Delete non existing"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group One
+      scope_type: dcim.site
+      scope: Test Site2
+    state: absent
+  register: results
+
+- name: "VLAN_GROUP 6: ASSERT - Delete non existing`"
+  ansible.builtin.assert:
+    that:
+      - not results['changed']
+      - results['vlan_group'] == None
+      - results['msg'] == "vlan_group VLAN Group One already absent"
+
+- name: "VLAN_GROUP 7: Necessary info creation - scope_type: dcim.location"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Location
+      scope_type: dcim.location
+      scope: Test Rack Group
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 7: ASSERT - Necessary info creation - scope_type: dcim.location"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "absent"
+      - results['diff']['after']['state'] == "present"
+      - results['vlan_group']['name'] == "VLAN Group Location"
+      - results['vlan_group']['slug'] == "vlan-group-location"
+      - results['vlan_group']['scope_type'] == "dcim.location"
+      - results['vlan_group']['scope_id'] == 1
+      - results['msg'] == "vlan_group VLAN Group Location created"
+
+- name: "VLAN_GROUP 8: Necessary info creation - scope_type: dcim.rack"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Rack
+      scope_type: dcim.rack
+      scope: Test Rack
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 8: ASSERT - Necessary info creation - scope_type: dcim.rack"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "absent"
+      - results['diff']['after']['state'] == "present"
+      - results['vlan_group']['name'] == "VLAN Group Rack"
+      - results['vlan_group']['slug'] == "vlan-group-rack"
+      - results['vlan_group']['scope_type'] == "dcim.rack"
+      - results['vlan_group']['scope_id'] == 2
+      - results['msg'] == "vlan_group VLAN Group Rack created"
+
+- name: "VLAN_GROUP 9: Necessary info creation - scope_type: dcim.region"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Region
+      scope_type: dcim.region
+      scope: Test Region
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 9: ASSERT - Necessary info creation - scope_type: dcim.region"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "absent"
+      - results['diff']['after']['state'] == "present"
+      - results['vlan_group']['name'] == "VLAN Group Region"
+      - results['vlan_group']['slug'] == "vlan-group-region"
+      - results['vlan_group']['scope_type'] == "dcim.region"
+      - results['vlan_group']['scope_id'] == 1
+      - results['msg'] == "vlan_group VLAN Group Region created"
+
+- name: "VLAN_GROUP 10: Necessary info creation - scope_type: dcim.sitegroup"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Site Group
+      scope_type: dcim.sitegroup
+      scope: Test Site Group
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 10: ASSERT - Necessary info creation - scope_type: dcim.sitegroup"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "absent"
+      - results['diff']['after']['state'] == "present"
+      - results['vlan_group']['name'] == "VLAN Group Site Group"
+      - results['vlan_group']['slug'] == "vlan-group-site-group"
+      - results['vlan_group']['scope_type'] == "dcim.sitegroup"
+      - results['vlan_group']['scope_id'] == 4
+      - results['msg'] == "vlan_group VLAN Group Site Group created"
+
+# Commented out due to invalid content type being reported back by API
+# - name: "VLAN_GROUP 11: Necessary info creation - scope_type: virtualization.cluster"
+#  netbox.netbox.netbox_vlan_group:
+#    netbox_url: http://localhost:32768
+#    netbox_token: 0123456789abcdef0123456789abcdef01234567
+#    data:
+#      name: "VLAN Group Cluster"
+#      scope_type: "virtualization.cluster"
+#      scope: Test Cluster
+#    state: present
+#  register: results
+
+# - name: "VLAN_GROUP 11: ASSERT - Necessary info creation - scope_type: virtualization.cluster"
+#  assert:
+#    that:
+#      - results is changed
+#      - results['diff']['before']['state'] == "absent"
+#      - results['diff']['after']['state'] == "present"
+#      - results['vlan_group']['name'] == "VLAN Group Cluster"
+#      - results['vlan_group']['slug'] == "vlan-group-cluster"
+#      - results['vlan_group']['scope_type'] == "virtualization.cluster"
+#      - results['vlan_group']['scope_id'] == 1
+#      - results['msg'] == "vlan_group VLAN Group Cluster created"
+
+# - name: "VLAN_GROUP 12: Necessary info creation - scope_type: virtualization.clustergroup"
+#  netbox.netbox.netbox_vlan_group:
+#    netbox_url: http://localhost:32768
+#    netbox_token: 0123456789abcdef0123456789abcdef01234567
+#    data:
+#      name: "VLAN Group Cluster Group"
+#      scope_type: "virtualization.clustergroup"
+#      scope: Test Cluster Group
+#    state: present
+#  register: results
+
+# - name: "VLAN_GROUP 12: ASSERT - Necessary info creation - scope_type: virtualization.clustergroup"
+#  assert:
+#    that:
+#      - results is changed
+#      - results['diff']['before']['state'] == "absent"
+#      - results['diff']['after']['state'] == "present"
+#      - results['vlan_group']['name'] == "VLAN Group Cluster Group"
+#      - results['vlan_group']['slug'] == "vlan-group-cluster-group"
+#      - results['vlan_group']['scope_type'] == "virtualization.clustergroup"
+#      - results['vlan_group']['scope_id'] == 1
+#      - results['msg'] == "vlan_group VLAN Group Cluster Group created"
+
+- name: "VLAN_GROUP 12: Update Description - scope_type: dcim.location"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Location
+      scope_type: dcim.location
+      scope: Test Rack Group
+      description: Ansible updated description
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 12: ASSERT - Update Description - scope_type: dcim.location"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['description'] == ""
+      - results['diff']['after']['description'] == "Ansible updated description"
+      - results['vlan_group']['name'] == "VLAN Group Location"
+      - results['vlan_group']['slug'] == "vlan-group-location"
+      - results['vlan_group']['scope_type'] == "dcim.location"
+      - results['vlan_group']['scope_id'] == 1
+      - results['vlan_group']['description'] == "Ansible updated description"
+      - results['msg'] == "vlan_group VLAN Group Location updated"
+
+- name: "VLAN_GROUP 12: Update Description (IDEM) - scope_type: dcim.location"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Location
+      scope_type: dcim.location
+      scope: Test Rack Group
+      description: Ansible updated description
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 12: ASSERT - Update Description (IDEM) - scope_type: dcim.location"
+  ansible.builtin.assert:
+    that:
+      - results is not changed
+      - results['vlan_group']['name'] == "VLAN Group Location"
+      - results['vlan_group']['slug'] == "vlan-group-location"
+      - results['vlan_group']['scope_type'] == "dcim.location"
+      - results['vlan_group']['scope_id'] == 1
+      - results['vlan_group']['description'] == "Ansible updated description"
+      - results['msg'] == "vlan_group VLAN Group Location already exists"
+
+- name: "VLAN_GROUP 13: Create VLAN group with tenant"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+      tenant: Test Tenant
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 13: ASSERT - Create VLAN group with tenant"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "absent"
+      - results['diff']['after']['state'] == "present"
+      - results['vlan_group']['name'] == "VLAN Group Tenant Test"
+      - results['vlan_group']['slug'] == "vlan-group-tenant-test"
+      - results['vlan_group']['scope_type'] == "dcim.site"
+      - results['vlan_group']['scope_id'] == 1
+      - results['vlan_group']['tenant'] == 1
+      - results['msg'] == "vlan_group VLAN Group Tenant Test created"
+
+- name: "VLAN_GROUP 14: Create duplicate VLAN group with tenant (idempotency)"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+      tenant: Test Tenant
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 14: ASSERT - Create duplicate VLAN group with tenant (idempotency)"
+  ansible.builtin.assert:
+    that:
+      - results is not changed
+      - results['vlan_group']['name'] == "VLAN Group Tenant Test"
+      - results['vlan_group']['tenant'] == 1
+      - results['msg'] == "vlan_group VLAN Group Tenant Test already exists"
+
+- name: "VLAN_GROUP 15: Update VLAN group tenant"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+      tenant: Test Tenant 2
+    state: present
+  register: results
+
+- name: "VLAN_GROUP 15: ASSERT - Update VLAN group tenant"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['tenant'] == 1
+      - results['diff']['after']['tenant'] == 2
+      - results['vlan_group']['name'] == "VLAN Group Tenant Test"
+      - results['vlan_group']['tenant'] == 2
+      - results['msg'] == "vlan_group VLAN Group Tenant Test updated"
+
+- name: "VLAN_GROUP 16: Delete VLAN group with tenant"
+  netbox.netbox.netbox_vlan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: VLAN Group Tenant Test
+      scope_type: dcim.site
+      scope: Test Site
+    state: absent
+  register: results
+
+- name: "VLAN_GROUP 16: ASSERT - Delete VLAN group with tenant"
+  ansible.builtin.assert:
+    that:
+      - results is changed
+      - results['diff']['before']['state'] == "present"
+      - results['diff']['after']['state'] == "absent"
+      - results['msg'] == "vlan_group VLAN Group Tenant Test deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_vm_interface.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_vm_interface.yml
@@ -1,0 +1,159 @@
+---
+##
+##
+### NETBOX_VM_INTERFACE
+##
+##
+- name: "NETBOX_VM_INTERFACE 1: Necessary info creation"
+  netbox.netbox.netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: Eth10
+    state: present
+  register: test_one
+
+- name: "NETBOX_VM_INTERFACE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['interface']['name'] == "Eth10"
+      - test_one['interface']['virtual_machine'] == 1
+      - test_one['msg'] == "interface Eth10 created"
+
+- name: "NETBOX_VM_INTERFACE 2: Create duplicate"
+  netbox.netbox.netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: Eth10
+    state: present
+  register: test_two
+
+- name: "NETBOX_VM_INTERFACE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['interface']['name'] == "Eth10"
+      - test_two['interface']['virtual_machine'] == 1
+      - test_two['msg'] == "interface Eth10 already exists"
+
+- name: "NETBOX_VM_INTERFACE 3: Updated"
+  netbox.netbox.netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: Eth10
+      enabled: false
+      mtu: 9000
+      mac_address: "00:00:00:AA:AA:01"
+      description: Updated test100-vm
+      mode: Tagged
+      # untagged_vlan:
+      #  name: Wireless
+      #  site: Test Site
+      # tagged_vlans:
+      #  - name: Data
+      #    site: Test Site
+      #  - name: VoIP
+      #    site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['enabled'] == false
+      - test_three['diff']['after']['mtu'] == 9000
+      - test_three['diff']['after']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_three['diff']['after']['description'] == "Updated test100-vm"
+      - test_three['diff']['after']['mode'] == "tagged"
+      # - test_three['diff']['after']['untagged_vlan'] == 1
+      # - test_three['diff']['after']['tagged_vlans'] == [2, 3]
+      - test_three['diff']['after']['tags'][0] == 4
+      - test_three['interface']['name'] == "Eth10"
+      - test_three['interface']['virtual_machine'] == 1
+      - test_three['interface']['enabled'] == false
+      - test_three['interface']['mtu'] == 9000
+      - test_three['interface']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_three['interface']['description'] == "Updated test100-vm"
+      - test_three['interface']['mode'] == "tagged"
+      # - test_three['interface']['untagged_vlan'] == 1
+      # - test_three['interface']['tagged_vlans'] == [2, 3]
+      - test_three['interface']['tags'][0] == 4
+      - test_three['msg'] == "interface Eth10 updated"
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
+  netbox.netbox.netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Eth10
+      virtual_machine: test100-vm
+    state: absent
+  register: test_four
+
+- name: "NETBOX_VM_INTERFACE 4: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['interface']['name'] == "Eth10"
+      - test_four['interface']['virtual_machine'] == 1
+      - test_four['msg'] == "interface Eth10 deleted"
+
+- name: "NETBOX_VM_INTERFACE 5: Attempt to update interface with same name on other VMs"
+  netbox.netbox.netbox_vm_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      virtual_machine: test100-vm
+      name: Eth0
+      enabled: false
+      mtu: 9000
+      mac_address: "00:00:00:AA:AA:01"
+      description: Updated test100-vm Eth0 intf
+      mode: Tagged
+      # untagged_vlan:
+      #   name: Wireless
+      #   site: Test Site
+      # tagged_vlans:
+      #   - name: Data
+      #     site: Test Site
+      #   - name: VoIP
+      #     site: Test Site
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: "NETBOX_VM_INTERFACE 5: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['enabled'] == false
+      - test_five['diff']['after']['mtu'] == 9000
+      - test_five['diff']['after']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_five['diff']['after']['description'] == "Updated test100-vm Eth0 intf"
+      - test_five['diff']['after']['mode'] == "tagged"
+      # - test_five['diff']['after']['untagged_vlan'] == 1
+      # - test_five['diff']['after']['tagged_vlans'] == [2, 3]
+      - test_five['diff']['after']['tags'][0] == 4
+      - test_five['interface']['name'] == "Eth0"
+      - test_five['interface']['virtual_machine'] == 1
+      - test_five['interface']['enabled'] == false
+      - test_five['interface']['mtu'] == 9000
+      - test_five['interface']['mac_address'] == "00:00:00:AA:AA:01"
+      - test_five['interface']['description'] == "Updated test100-vm Eth0 intf"
+      - test_five['interface']['mode'] == "tagged"
+      # - test_five['interface']['untagged_vlan'] == 1
+      # - test_five['interface']['tagged_vlans'] == [2, 3]
+      - test_five['interface']['tags'][0] == 4
+      - test_five['msg'] == "interface Eth0 updated"

--- a/tests/integration/targets/v4.5/tasks/netbox_vrf.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_vrf.yml
@@ -1,0 +1,137 @@
+---
+##
+##
+### NETBOX_VRF
+##
+##
+- name: "VRF 1: Necessary info creation"
+  netbox.netbox.netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VRF One
+    state: present
+  register: test_one
+
+- name: "VRF 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['vrf']['name'] == "Test VRF One"
+      - test_one['msg'] == "vrf Test VRF One created"
+
+- name: "VRF 2: Create duplicate"
+  netbox.netbox.netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VRF One
+    state: present
+  register: test_two
+
+- name: "VRF 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['vrf']['name'] == "Test VRF One"
+      - test_two['msg'] == "vrf Test VRF One already exists"
+
+- name: "VRF 3: Create VRF with same name, but different tenant"
+  netbox.netbox.netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VRF One
+      tenant: Test Tenant
+    state: present
+  register: test_three
+
+- name: "VRF 3: ASSERT - Create VRF with same name, but different site"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['state'] == "absent"
+      - test_three['diff']['after']['state'] == "present"
+      - test_three['vrf']['name'] == "Test VRF One"
+      - test_three['vrf']['tenant'] == 1
+      - test_three['msg'] == "vrf Test VRF One created"
+
+- name: "VRF 4: ASSERT - Update"
+  netbox.netbox.netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VRF One
+      rd: "65001:1"
+      enforce_unique: false
+      tenant: Test Tenant
+      description: Updated description
+      import_targets:
+        - 4000:4000
+        - 5000:5000
+      export_targets:
+        - 5000:5000
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_four
+
+- name: "VRF 4: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['rd'] == "65001:1"
+      - test_four['diff']['after']['enforce_unique'] == false
+      - test_four['diff']['after']['description'] == "Updated description"
+      - test_four['diff']['after']['tags'][0] == 4
+      - test_four['diff']['after']['import_targets'] | length == 2
+      - test_four['diff']['after']['export_targets'] | length == 1
+      - test_four['vrf']['name'] == "Test VRF One"
+      - test_four['vrf']['tenant'] == 1
+      - test_four['vrf']['rd'] == "65001:1"
+      - test_four['vrf']['enforce_unique'] == false
+      - test_four['vrf']['description'] == "Updated description"
+      - test_four['vrf']['tags'][0] == 4
+      - test_four['vrf']['import_targets'] | length == 2
+      - test_four['vrf']['export_targets'] | length == 1
+      - test_four['msg'] == "vrf Test VRF One updated"
+
+- name: "VRF 5: ASSERT - Delete more than one result"
+  netbox.netbox.netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VRF One
+    state: absent
+  ignore_errors: true
+  register: test_five
+
+- name: "VRF 5: ASSERT - Delete more than one result"
+  ansible.builtin.assert:
+    that:
+      - test_five is failed
+      - test_five['msg'] == "More than one result returned for Test VRF One"
+
+- name: "VRF 6: ASSERT - Delete"
+  netbox.netbox.netbox_vrf:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Test VRF One
+      tenant: Test Tenant
+    state: absent
+  register: test_six
+
+- name: "VRF 6: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['vrf']['name'] == "Test VRF One"
+      - test_six['vrf']['tenant'] == 1
+      - test_six['vrf']['rd'] == "65001:1"
+      - test_six['vrf']['enforce_unique'] == false
+      - test_six['vrf']['description'] == "Updated description"
+      - test_six['vrf']['tags'][0] == 4
+      - test_six['msg'] == "vrf Test VRF One deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_webhook.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_webhook.yml
@@ -1,0 +1,121 @@
+---
+##
+##
+### NETBOX_WEBHOOK
+##
+##
+- name: "WEBHOOK 1: Necessary info creation"
+  netbox.netbox.netbox_webhook:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      content_types:
+        - dcim.device
+      name: Example Webhook
+      type_create: true
+      payload_url: https://payload.url
+      body_template: !unsafe >-
+        {{ data }}
+    state: present
+  register: test_one
+
+- name: "WEBHOOK 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['webhook']['name'] == "Example Webhook"
+      - test_one['webhook']['type_create'] == True
+      - test_one['webhook']['payload_url'] == "https://payload.url"
+      - test_one['webhook']['content_types'] == ["dcim.device"]
+      - test_one['msg'] == "webhook Example Webhook created"
+
+- name: "WEBHOOK 2: Create duplicate"
+  netbox.netbox.netbox_webhook:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      content_types:
+        - dcim.device
+      name: Example Webhook
+      type_create: true
+      payload_url: https://payload.url
+      body_template: !unsafe >-
+        {{ data }}
+    state: present
+  register: test_two
+
+- name: "WEBHOOK 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['webhook']['name'] == "Example Webhook"
+      - test_two['msg'] == "webhook Example Webhook already exists"
+
+- name: "WEBHOOK 3: Update data and add on delete"
+  netbox.netbox.netbox_webhook:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      content_types:
+        - dcim.device
+      type_create: true
+      type_delete: true
+      name: Example Webhook
+      payload_url: https://payload.url
+      body_template: !unsafe >-
+        {{ data }}
+    state: present
+  register: test_three
+
+- name: "WEBHOOK 3: ASSERT - Updated"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['webhook']['name'] == "Example Webhook"
+      - test_three['msg'] == "webhook Example Webhook updated"
+
+- name: "WEBHOOK 4: Change content type"
+  netbox.netbox.netbox_webhook:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      content_types:
+        - virtualization.virtualmachine
+      name: Example Webhook
+      payload_url: https://payload.url
+      body_template: !unsafe >-
+        {{ data }}
+    state: present
+  register: test_four
+
+- name: "WEBHOOK 4: ASSERT - Change content type"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['content_types'] == ["virtualization.virtualmachine"]
+      - test_four['webhook']['name'] == "Example Webhook"
+      - test_four['msg'] == "webhook Example Webhook updated"
+
+- name: "WEBHOOK 5: Delete"
+  netbox.netbox.netbox_webhook:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      content_types:
+        - virtualization.virtualmachine
+      name: Example Webhook
+      payload_url: https://payload.url
+      body_template: !unsafe >-
+        {{ data }}
+    state: absent
+  register: test_five
+
+- name: "WEBHOOK 5: ASSERT - Deleted"
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['webhook']['name'] == "Example Webhook"
+      - test_five['msg'] == "webhook Example Webhook deleted"

--- a/tests/integration/targets/v4.5/tasks/netbox_wireless_lan.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_wireless_lan.yml
@@ -1,0 +1,103 @@
+---
+##
+##
+### NETBOX_WIRELESS_LAN
+##
+##
+- name: 1 - Test wireless LAN creation
+  netbox.netbox.netbox_wireless_lan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      ssid: Wireless LAN One
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['wireless_lan']['ssid'] == "Wireless LAN One"
+      - test_one['msg'] == "wireless_lan Wireless LAN One created"
+
+- name: Test duplicate wireless LAN
+  netbox.netbox.netbox_wireless_lan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      ssid: Wireless LAN One
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['wireless_lan']['ssid'] == "Wireless LAN One"
+      - test_two['msg'] == "wireless_lan Wireless LAN One already exists"
+
+- name: 3 - Test update
+  netbox.netbox.netbox_wireless_lan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      ssid: Wireless LAN One
+      description: New Description
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "New Description"
+      - test_three['wireless_lan']['ssid'] == "Wireless LAN One"
+      - test_three['wireless_lan']['description'] == "New Description"
+      - test_three['msg'] == "wireless_lan Wireless LAN One updated"
+
+- name: 4 - Test delete
+  netbox.netbox.netbox_wireless_lan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      ssid: Wireless LAN One
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "wireless_lan Wireless LAN One deleted"
+
+- name: 5 - Create wireless LAN with all parameters
+  netbox.netbox.netbox_wireless_lan:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      ssid: Wireless Network One
+      description: Cool Wireless Network
+      auth_type: wpa-enterprise
+      auth_cipher: aes
+      auth_psk: psk123456
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['wireless_lan']['ssid'] == "Wireless Network One"
+      - test_five['wireless_lan']['description'] == "Cool Wireless Network"
+      - test_five['wireless_lan']['auth_type'] == "wpa-enterprise"
+      - test_five['wireless_lan']['auth_cipher'] == "aes"
+      - test_five['wireless_lan']['auth_psk'] == "psk123456"
+      # - test_five['wireless_lan']['tags'] | length == 3
+      - test_five['msg'] == "wireless_lan Wireless Network One created"

--- a/tests/integration/targets/v4.5/tasks/netbox_wireless_lan_group.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_wireless_lan_group.yml
@@ -1,0 +1,97 @@
+---
+##
+##
+### NETBOX_WIRELESS_LAN_GROUP
+##
+##
+- name: 1 - Test wireless LAN group creation
+  netbox.netbox.netbox_wireless_lan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Wireless LAN Group One
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['wireless_lan_group']['name'] == "Wireless LAN Group One"
+      - test_one['msg'] == "wireless_lan_group Wireless LAN Group One created"
+
+- name: Test duplicate wireless LAN group
+  netbox.netbox.netbox_wireless_lan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Wireless LAN Group One
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['wireless_lan_group']['name'] == "Wireless LAN Group One"
+      - test_two['msg'] == "wireless_lan_group Wireless LAN Group One already exists"
+
+- name: 3 - Test update
+  netbox.netbox.netbox_wireless_lan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Wireless LAN Group One
+      description: New Description
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "New Description"
+      - test_three['wireless_lan_group']['name'] == "Wireless LAN Group One"
+      - test_three['wireless_lan_group']['description'] == "New Description"
+      - test_three['msg'] == "wireless_lan_group Wireless LAN Group One updated"
+
+- name: 4 - Test delete
+  netbox.netbox.netbox_wireless_lan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Wireless LAN Group One
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "wireless_lan_group Wireless LAN Group One deleted"
+
+- name: 5 - Create wireless LAN group with all parameters
+  netbox.netbox.netbox_wireless_lan_group:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      name: Wireless LAN Group One
+      description: Cool Wireless LAN Group
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['wireless_lan_group']['name'] == "Wireless LAN Group One"
+      - test_five['wireless_lan_group']['description'] == "Cool Wireless LAN Group"
+      - test_five['wireless_lan_group']['tags'] | length == 3
+      - test_five['msg'] == "wireless_lan_group Wireless LAN Group One created"

--- a/tests/integration/targets/v4.5/tasks/netbox_wireless_link.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_wireless_link.yml
@@ -1,0 +1,130 @@
+---
+##
+##
+### NETBOX_WIRELESS_LINK
+##
+##
+- name: 1 - Test wireless link creation
+  netbox.netbox.netbox_wireless_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      interface_a:
+        device: Test Nexus One
+        name: wlink1
+      interface_b:
+        device: test100
+        name: wlink1
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['wireless_link']['interface_a'] == 6
+      - test_one['wireless_link']['interface_b'] == 5
+      - test_one['msg'] == "wireless_link Test Nexus One wlink1 <> test100 wlink1 created"
+
+- name: Test duplicate wireless link
+  netbox.netbox.netbox_wireless_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      interface_a:
+        device: Test Nexus One
+        name: wlink1
+      interface_b:
+        device: test100
+        name: wlink1
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "wireless_link Test Nexus One wlink1 <> test100 wlink1 already exists"
+
+- name: 3 - Test update
+  netbox.netbox.netbox_wireless_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      interface_a:
+        device: Test Nexus One
+        name: wlink1
+      interface_b:
+        device: test100
+        name: wlink1
+      status: planned
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['wireless_link']['status'] == "planned"
+      - test_three['msg'] == "wireless_link Test Nexus One wlink1 <> test100 wlink1 updated"
+
+- name: 4 - Test delete
+  netbox.netbox.netbox_wireless_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      interface_a:
+        device: Test Nexus One
+        name: wlink1
+      interface_b:
+        device: test100
+        name: wlink1
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "wireless_link Test Nexus One wlink1 <> test100 wlink1 deleted"
+
+- name: 5 - Create wireless link with all parameters
+  netbox.netbox.netbox_wireless_link:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      interface_a:
+        device: Test Nexus One
+        name: wlink1
+      interface_b:
+        device: test100
+        name: wlink1
+      ssid: Wireless Network One
+      description: Cool Wireless Network
+      auth_type: wpa-enterprise
+      auth_cipher: aes
+      auth_psk: psk123456
+      tags:
+        - tagA
+        - tagB
+        - tagC
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['wireless_link']['ssid'] == "Wireless Network One"
+      - test_five['wireless_link']['description'] == "Cool Wireless Network"
+      - test_five['wireless_link']['interface_a'] == 6
+      - test_five['wireless_link']['interface_b'] == 5
+      - test_five['wireless_link']['auth_type'] == "wpa-enterprise"
+      - test_five['wireless_link']['auth_cipher'] == "aes"
+      - test_five['wireless_link']['auth_psk'] == "psk123456"
+      # - test_five['wireless_link']['tags'] | length == 3
+      - test_five['msg'] == "wireless_link Test Nexus One wlink1 <> test100 wlink1 created"

--- a/tests/netbox-docker/v4.5/docker-compose.override.yml
+++ b/tests/netbox-docker/v4.5/docker-compose.override.yml
@@ -1,0 +1,26 @@
+---
+services:
+  netbox-worker: &netbox-override
+    image: netboxcommunity/netbox:v4.5
+    healthcheck:
+      start_period: 300s
+      timeout: 3s
+      interval: 15s
+      test: ps -aux | grep -v grep | grep -q rqworker || exit 1
+  netbox:
+    <<: *netbox-override
+    ports:
+      - 32768:8080
+    healthcheck:
+      start_period: 300s
+      timeout: 3s
+      interval: 15s
+      test: curl -f http://localhost:8080/login/ || exit 1
+    environment:
+      SKIP_SUPERUSER: "false"
+      SUPERUSER_API_TOKEN: "0123456789abcdef0123456789abcdef01234567"
+      SUPERUSER_EMAIL: admin@localhost.com
+      SUPERUSER_NAME: admin
+      SUPERUSER_PASSWORD: admin123456
+    volumes:
+      - ./super_user.py:/opt/netbox/super_user.py:ro

--- a/tests/netbox-docker/v4.5/super_user.py
+++ b/tests/netbox-docker/v4.5/super_user.py
@@ -1,0 +1,41 @@
+"""
+Custom super_user.py for CI testing with NetBox v4.5+
+
+Creates a v1 (legacy) API token so that existing integration tests
+can authenticate with the static token value using the "Token <value>"
+header format.  v1 tokens remain supported in NetBox v4.5 (removal
+scheduled for v4.7).
+"""
+
+from os import environ
+
+from users.models import Token, User
+
+
+def _read_secret(secret_name, default=None):
+    try:
+        f = open("/run/secrets/" + secret_name, "r", encoding="utf-8")
+    except EnvironmentError:
+        return default
+    else:
+        with f:
+            return f.readline().strip()
+
+
+su_name = environ.get("SUPERUSER_NAME", "admin")
+su_email = environ.get("SUPERUSER_EMAIL", "admin@example.com")
+su_password = _read_secret("superuser_password", environ.get("SUPERUSER_PASSWORD", "admin"))
+su_api_token = _read_secret(
+    "superuser_api_token",
+    environ.get("SUPERUSER_API_TOKEN", "0123456789abcdef0123456789abcdef01234567"),
+)
+
+if not User.objects.filter(username=su_name):
+    u = User.objects.create_superuser(su_name, su_email, su_password)
+    from users.choices import TokenVersionChoices
+
+    Token.objects.create(user=u, token=su_api_token, version=TokenVersionChoices.V1)
+    print(
+        f"💡 Superuser Username: {su_name}, E-Mail: {su_email},"
+        f" API Token (v1): {su_api_token}"
+    )

--- a/tests/netbox-docker/v4.5/super_user.py
+++ b/tests/netbox-docker/v4.5/super_user.py
@@ -9,6 +9,7 @@ scheduled for v4.7).
 
 from os import environ
 
+from users.choices import TokenVersionChoices
 from users.models import Token, User
 
 
@@ -24,16 +25,16 @@ def _read_secret(secret_name, default=None):
 
 su_name = environ.get("SUPERUSER_NAME", "admin")
 su_email = environ.get("SUPERUSER_EMAIL", "admin@example.com")
-su_password = _read_secret("superuser_password", environ.get("SUPERUSER_PASSWORD", "admin"))
+su_password = _read_secret(
+    "superuser_password", environ.get("SUPERUSER_PASSWORD", "admin")
+)
 su_api_token = _read_secret(
     "superuser_api_token",
     environ.get("SUPERUSER_API_TOKEN", "0123456789abcdef0123456789abcdef01234567"),
 )
 
-if not User.objects.filter(username=su_name):
+if not User.objects.filter(username=su_name).exists():
     u = User.objects.create_superuser(su_name, su_email, su_password)
-    from users.choices import TokenVersionChoices
-
     Token.objects.create(user=u, token=su_api_token, version=TokenVersionChoices.V1)
     print(
         f"💡 Superuser Username: {su_name}, E-Mail: {su_email},"


### PR DESCRIPTION
## Summary
- Add v4.5 (netbox-docker 4.0.2) to CI matrix
- Add docker-compose override with custom `super_user.py` that creates a v1 (legacy) API token for backward compatibility (v4.5 defaults to v2 tokens with `Bearer nbt_<KEY>.<TOKEN>` auth header)
- Add v4.5 integration test targets (91 task files, inventory, regression)

### Module updates for v4.5 breaking changes
- **front_port/front_port_template**: Make `rear_port` optional; version-conditional logic strips it for v4.5+ (replaced by PortMapping model) and validates presence for older versions
- **token**: Make `key` optional; v4.5+ v2 tokens use description-based lookup instead of key-based; runtime validation enforces key for pre-v4.5
- **user**: Strip `is_staff` from data for v4.5+ (field removed from User model)
- **inventory fixtures**: Regenerated all 10 JSON fixtures from live v4.5 instance

## Test plan
- [x] v4.5 module integration tests pass (ok=1099, failed=0, ignored=9)
- [x] v4.1-v4.4 module integration tests pass (backward compatibility verified)
- [x] Inventory fixtures regenerated and verified (10/10 pass)
- [x] Linting (black + yamllint) passes
- [x] Unit tests pass (Python 3.11, 3.12, 3.13)
- [x] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)