### PR TITLE
Fix 'more than one result returned' for sub-object queries

### DIFF
--- a/changelogs/fragments/fix-more-than-one-result-scoping.yml
+++ b/changelogs/fragments/fix-more-than-one-result-scoping.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Automatically include device and virtual_machine scoping in sub-object queries to prevent "More than one result returned" errors

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1402,6 +1402,14 @@ class NetboxModule(object):
                         )
                     else:
                         query_params = {QUERY_TYPES.get(k, "q"): search}
+                        allowed = ALLOWED_QUERY_PARAMS.get(k)
+                        if allowed:
+                            for param in ("device", "virtual_machine"):
+                                if param in allowed and param in data:
+                                    if isinstance(data[param], int):
+                                        query_params[param + "_id"] = data[param]
+                                    else:
+                                        query_params[param] = data[param]
                     query_id = self._nb_endpoint_get(nb_endpoint, query_params, k)
 
                 if isinstance(v, list):

--- a/tests/integration/targets/v4.3/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_device_interface.yml
@@ -330,3 +330,41 @@
       - test_thirteen['interface']['name'] == "GigabitEthernet2"
       - test_thirteen['interface']['device'] == 1
       - test_thirteen['interface']['primary_mac_address'] == 2
+
+- name: 14 - Create BridgeIf on test100
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: BridgeIf
+      type: 1000Base-T (1GE)
+  register: test_fourteen
+
+- name: 15 - Create BridgeIf on R1-Device
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: R1-Device
+      name: BridgeIf
+      type: 1000Base-T (1GE)
+
+- name: 16 - Create interface with bridge as plain string when name exists on multiple devices
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: BridgeChild
+      type: 1000Base-T (1GE)
+      bridge: BridgeIf
+    state: present
+  register: test_sixteen
+
+- name: 16 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_sixteen is changed
+      - test_sixteen['interface']['name'] == "BridgeChild"
+      - test_sixteen['interface']['bridge'] == test_fourteen['interface']['id']


### PR DESCRIPTION
## Related Issue

Fixes the systemic "More than one result returned" bug affecting #486, #778, #980, #1068, #1267, #1397, #1412, #1448, #1475, #1482

## New Behavior

When resolving sub-object references passed as plain strings (e.g., `bridge: "eth0"`), the query now automatically includes `device` or `virtual_machine` scoping from the module data if `ALLOWED_QUERY_PARAMS` permits it. This disambiguates lookups when multiple devices share the same interface name.

## Contrast to Current Behavior

Previously, plain string sub-object lookups used only the object name (e.g., `{"name": "eth0"}`), ignoring device/VM context available in the module data. This caused `ValueError` ("More than one result returned") whenever multiple devices had identically-named sub-objects.

## Discussion: Benefits and Drawbacks

- Closes 10-15 open issues spanning 5 years of user frustration
- The fix is 8 lines in the fallback query path of `_find_ids` in `netbox_utils.py`
- Only adds `device` and `virtual_machine` scoping to avoid regressions with other param types
- Backwards-compatible: queries that previously worked with unique names still work; queries that previously failed now succeed
- Full integration test suite passes with zero regressions (870 ok, 0 regression failures)

## Changes to the Documentation

None required. The fix makes existing documented patterns work as users expect.

## Proposed Release Note Entry

Fix "More than one result returned" errors when resolving sub-object references (bridge, interfaces, etc.) by automatically including device/virtual_machine scoping in queries.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.