### PR TITLE
Docs: fix Use Case 3 lookup example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ tasks:
   - name: Obtain list of devices from NetBox
     debug:
       msg: >
-        "Device {{ item.value.display_name }} (ID: {{ item.key }}) was
+        "Device {{ item.value.display }} (ID: {{ item.key }}) was
          manufactured by {{ item.value.device_type.manufacturer.name }}"
     loop: "{{ query('netbox.netbox.nb_lookup', 'devices',
                     api_endpoint='http://localhost/',


### PR DESCRIPTION
## Related Issue

#1521

## New Behavior

Correct the README Use Case 3 example to use `item.value.display` instead of `item.value.display_name`.

## Contrast to Current Behavior

The current example references `item.value.display_name`, which does not match the current returned structure.

## Discussion: Benefits and Drawbacks

This fixes a broken example in the main README and makes the lookup example consistent with the current data structure. It is backwards-compatible and limited to documentation only. I do not see any drawbacks.

## Changes to the Documentation

Updated the README example in Use Case 3.

## Proposed Release Note Entry

Fix README Use Case 3 lookup example to use `item.value.display`

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
