### PR TITLE
Fix custom session Authorization header for NetBox API

### DIFF
--- a/changelogs/fragments/1547-fix-custom-session-authorization.yml
+++ b/changelogs/fragments/1547-fix-custom-session-authorization.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Preserve the Authorization header when creating a custom NetBox API session, fixing authenticated requests with `validate_certs=false`

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -845,6 +845,7 @@ class NetboxModule(object):
                 headers = json.load(headers)
             if isinstance(headers, dict):
                 session.headers.update(headers)
+            session.headers.setdefault("Authorization", "Token %s" % token)
             if cert:
                 session.cert = tuple(i for i in cert)
             nb = pynetbox.api(url, token=token)

--- a/tests/unit/module_utils/netbox_utils/test_netbox_module.py
+++ b/tests/unit/module_utils/netbox_utils/test_netbox_module.py
@@ -183,6 +183,29 @@ def test_init(mock_netbox_module, find_ids_return):
     assert mock_netbox_module.data == find_ids_return
 
 
+def test_connect_netbox_api_sets_authorization_header(mocker, mock_netbox_module):
+    nb_client = mocker.Mock(name="pynetbox.api")
+    nb_client.version = "4.4"
+    nb_client.status.return_value = {"netbox-version": "4.4.9"}
+    pynetbox_api = mocker.patch(
+        "%s.pynetbox.api" % MOCKER_PATCH_PATH.rsplit(".", 1)[0], return_value=nb_client
+    )
+
+    netbox = mock_netbox_module._connect_netbox_api(
+        "http://netbox.local/",
+        "0123456789",
+        False,
+        None,
+        {"X-Test-Header": "present"},
+    )
+
+    pynetbox_api.assert_called_once_with("http://netbox.local/", token="0123456789")
+    assert netbox is nb_client
+    assert nb_client.http_session.verify is False
+    assert nb_client.http_session.headers["Authorization"] == "Token 0123456789"
+    assert nb_client.http_session.headers["X-Test-Header"] == "present"
+
+
 @pytest.mark.parametrize("before, after", load_relative_test_data("normalize_data"))
 def test_normalize_data_returns_correct_data(mock_netbox_module, before, after):
     norm_data = mock_netbox_module._normalize_data(before)


### PR DESCRIPTION
## Related Issue

#1539

## New Behavior

When a custom HTTP session is created for NetBox API access, the session now keeps the Authorization header so authenticated requests still succeed when `validate_certs=false`.

## Contrast to Current Behavior

The current code replaces the default pynetbox session but does not carry over the Authorization header, which causes authenticated requests to fail with 403 Forbidden.

## Discussion: Benefits and Drawbacks

This keeps authentication behavior consistent when a custom session is used and adds a regression test for the session setup. The change is backwards-compatible and limited to the NetBox API connection path. I do not see any meaningful drawback.

## Changes to the Documentation

None.

## Proposed Release Note Entry

Fix missing Authorization header on custom NetBox API sessions when `validate_certs=false`

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
