### PR TITLE
Incorporate Red Hat certification feedback

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+rules:
+  indentation:
+    ignore: &default_ignores |
+      # automatically generated, we can't control it
+      changelogs/changelog.yaml
+      # Will be gone when we release and automatically reformatted
+      changelogs/fragments/*

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ This Ansible collection consists of a set of modules to define the intended netw
 
 ## Installation
 
-### Python Modules and Ansible
+### Python Modules
 ```
 pip install pytz
 pip install pynetbox
-pip install ansible
 ```
 
 ### NetBox Ansible Collection
@@ -161,5 +160,3 @@ Some extra resources you might find useful for both the Ansible collection and f
 GNU General Public License v3.0 or later.
 
 See [LICENSE](https://github.com/netbox-community/ansible_modules/blob/devel/LICENSE) for the full text of the license.
-
-Link to the license that the collection is published under.

--- a/changelogs/fragments/redhat-feedback-fixes.yml
+++ b/changelogs/fragments/redhat-feedback-fixes.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Incorporate Red Hat certification feedback - update README, add .yamllint for changelog lint suppression"


### PR DESCRIPTION
## Summary
- Remove `pip install ansible` from README (Red Hat customers use execution environments with AAP)
- Remove stray boilerplate sentence from License section
- Add `.yamllint` to suppress changelog lint errors during certification

Feedback from Sandra McCann (Red Hat) when approving v3.21.0, tracked in INT-350.

## Test plan
- [x] README changes are correct
- [x] `.yamllint` ignores auto-generated changelog files