### PR TITLE
Release v3.23.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,40 @@ NetBox.NetBox Release Notes
 
 .. contents:: Topics
 
+v3.23.0
+=======
+
+Minor Changes
+-------------
+
+- Add NetBox v4.4 integration tests to CI matrix
+- Add NetBox v4.5 support to CI matrix (netbox-docker 4.0.2)
+- Add `module_type` as supported to `netbox_front_port_template`
+- Add `module_type` as supported to `netbox_rear_port_template`
+- Add local integration test runner (hacking/integration-test.sh)
+- Fix linting issues with newly released black version
+- Update netbox_front_port and netbox_front_port_template modules to handle v4.5 removal of rear_port/rear_port_position fields (replaced by PortMapping model)
+- Update netbox_token module to support v4.5 v2 tokens with description-based lookup
+- Update netbox_user module to strip is_staff field on v4.5+ (removed from User model)
+- Use `ansible.module_utils.common.text.converters` instead of the deprecated `ansible.module_utils._text`
+- netbox_vlan_group - Add tenant field support (https://github.com/netbox-community/ansible_modules/issues/1446)
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- This changes the behavior for generating slugs. If you were relying on the previous behavior, you need to be aware that this behavior has changed.
+
+Bugfixes
+--------
+
+- Adjust regex pattern for character conversion for slugs
+- Automatically include device and virtual_machine scoping in sub-object queries to prevent "More than one result returned" errors
+- Fix specifying primary_mac_address objects by id on vm interfaces for disambiguation
+- Make slug generation optional by providing `slug` key
+- Only do slug generation in netbox_secret if needed
+- Preserve the Authorization header when creating a custom NetBox API session, fixing authenticated requests with `validate_certs=false`
+- nb_inventory - Fix AttributeError when `ip_address` is None during DNS name lookup
+
 v3.22.0
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,3 +1,4 @@
+---
 ancestor: null
 releases:
   0.1.0:

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,4 +1,3 @@
----
 ancestor: null
 releases:
   0.1.0:
@@ -854,44 +853,45 @@ releases:
     release_date: '2025-03-04'
   3.22.0:
     changes:
-      minor_changes:
-      - Change `netbox_contact.contact_group` to `contact_groups`
-      - Add integration tests for contact groups
-      - Add support for custom headers for all modules
-      - Fix ansible-bad-import-from pylint errors
-      - Fix broken code path when using old api path on old netbox systems
-      - add workaround to _build_query_params for services and Netbox 4.3.0 - 4.4.3 (wrong parent_object_type data type)
-      - netbox_circuit_termination - Add parameters termination_id and termination_type for NetBox 4.2+
-      - netbox_tag - Add support for object_types on tags
-      - improve version_check_greater to be more universal
-      - sanitize netbox versions received from api
-      - test suite expanded to run on Python 3.11, 3.12, and 3.13.
-      - Make the unit-test data structures more flexible.
-      - Remove abandoned unit-test data.
-      - user.groups, user.permissions, user_group.permissions, permission.actions, and permission.object_types are now treated as unordered sets for update comparison purposes.
-      - rename variable version to api_version.
-      - rename variable full_version to netbox_version.
-      - add yamllint to project pipeline.
       bugfixes:
-      - Fix task duplicate task name in documentation that cause ansible-lint error
-      - nb_inventory - Fix service collection for version greater than 4.3
-      - Add netbox version check to support service creation for netbox version prior of 4.3
-      - Use dedicated function to check netbox version istead of self.full_version for rack.
-      - Fix typos in tag integration tests.
+      - Add netbox version check to support service creation for netbox version prior
+        of 4.3
       - Fix integration test for circuit termination, missing assignment
       - Fix integration test for service
-      - "nb_device_interface: Fix specifying primary_mac_address objects by id for disambiguation"
-      - add parent_object_type and parent_object_id to services ALLOWED_QUERY_PARAMS
-      - nb_inventory - Fixed empty inventory results when netbox server URL is a non-root path
+      - Fix task duplicate task name in documentation that cause ansible-lint error
+      - Fix typos in tag integration tests.
       - Support for related_object_filter when related_object_type is "object"
+      - Use dedicated function to check netbox version istead of self.full_version
+        for rack.
+      - add parent_object_type and parent_object_id to services ALLOWED_QUERY_PARAMS
+      - 'nb_device_interface: Fix specifying primary_mac_address objects by id for
+        disambiguation'
+      - nb_inventory - Fix service collection for version greater than 4.3
+      - nb_inventory - Fixed empty inventory results when netbox server URL is a non-root
+        path
       - netbox_service - Fix issue 1426 - broken netbox_service module
-    modules:
-    - description: Manage data sources in NetBox
-      name: netbox_data_source
-      namespace: ''
-    - description: Manage contact assignments in NetBox
-      name: netbox_contact_assignment
-      namespace: ''
+      minor_changes:
+      - Add integration tests for contact groups
+      - Add support for custom headers for all modules
+      - Change `netbox_contact.contact_group` to `contact_groups`
+      - Fix ansible-bad-import-from pylint errors
+      - Fix broken code path when using old api path on old netbox systems
+      - Make the unit-test data structures more flexible.
+      - Remove abandoned unit-test data.
+      - add workaround to _build_query_params for services and Netbox 4.3.0 - 4.4.3
+        (wrong parent_object_type data type)
+      - add yamllint to project pipeline.
+      - improve version_check_greater to be more universal
+      - netbox_circuit_termination - Add parameters termination_id and termination_type
+        for NetBox 4.2+
+      - netbox_tag - Add support for object_types on tags
+      - rename variable full_version to netbox_version.
+      - rename variable version to api_version.
+      - sanitize netbox versions received from api
+      - test suite expanded to run on Python 3.11, 3.12, and 3.13.
+      - user.groups, user.permissions, user_group.permissions, permission.actions,
+        and permission.object_types are now treated as unordered sets for update comparison
+        purposes.
     fragments:
     - 1182-fix-contact-groups.yml
     - 1433-add-custom-headers.yml
@@ -917,6 +917,61 @@ releases:
     - version_api.yml
     - version_netbox.yml
     - yamllint.yml
+    modules:
+    - description: Manage contact assignments in NetBox
+      name: netbox_contact_assignment
+      namespace: ''
+    - description: Manage data sources in NetBox
+      name: netbox_data_source
+      namespace: ''
+  3.23.0:
+    changes:
+      breaking_changes:
+      - This changes the behavior for generating slugs. If you were relying on the
+        previous behavior, you need to be aware that this behavior has changed.
+      bugfixes:
+      - Adjust regex pattern for character conversion for slugs
+      - Automatically include device and virtual_machine scoping in sub-object queries
+        to prevent "More than one result returned" errors
+      - Fix specifying primary_mac_address objects by id on vm interfaces for disambiguation
+      - Make slug generation optional by providing `slug` key
+      - Only do slug generation in netbox_secret if needed
+      - Preserve the Authorization header when creating a custom NetBox API session,
+        fixing authenticated requests with `validate_certs=false`
+      - nb_inventory - Fix AttributeError when `ip_address` is None during DNS name
+        lookup
+      minor_changes:
+      - Add NetBox v4.4 integration tests to CI matrix
+      - Add NetBox v4.5 support to CI matrix (netbox-docker 4.0.2)
+      - Add `module_type` as supported to `netbox_front_port_template`
+      - Add `module_type` as supported to `netbox_rear_port_template`
+      - Add local integration test runner (hacking/integration-test.sh)
+      - Fix linting issues with newly released black version
+      - Update netbox_front_port and netbox_front_port_template modules to handle
+        v4.5 removal of rear_port/rear_port_position fields (replaced by PortMapping
+        model)
+      - Update netbox_token module to support v4.5 v2 tokens with description-based
+        lookup
+      - Update netbox_user module to strip is_staff field on v4.5+ (removed from User
+        model)
+      - Use `ansible.module_utils.common.text.converters` instead of the deprecated
+        `ansible.module_utils._text`
+      - netbox_vlan_group - Add tenant field support (https://github.com/netbox-community/ansible_modules/issues/1446)
+    fragments:
+    - 1471-fix-netbox-user-docs.yml
+    - 1499-rework-slugify.yml
+    - 1508-fix-mac-lookup-by-id-vm-interface.yml
+    - 1535-add-netbox-v44-ci.yml
+    - 1543-add-netbox-v45-ci.yml
+    - 1547-fix-custom-session-authorization.yml
+    - add-tenant-to-vlan-group.yml
+    - black-lint-update.yaml
+    - deprecated-to-text.yml
+    - fix-ip-address-dns-check.yml
+    - fix-more-than-one-result-scoping.yml
+    - module_type_template.yml
+    - redhat-feedback-fixes.yml
+    release_date: '2026-05-01'
   3.3.0:
     changes:
       minor_changes:

--- a/changelogs/fragments/1471-fix-netbox-user-docs.yml
+++ b/changelogs/fragments/1471-fix-netbox-user-docs.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - "netbox_user - Fix incorrect parameter name and use RFC 2606 example domains in module documentation"

--- a/changelogs/fragments/1499-rework-slugify.yml
+++ b/changelogs/fragments/1499-rework-slugify.yml
@@ -1,7 +1,0 @@
----
-bugfixes:
-  - Adjust regex pattern for character conversion for slugs
-  - Only do slug generation in netbox_secret if needed
-  - Make slug generation optional by providing `slug` key
-breaking_changes:
-  - This changes the behavior for generating slugs. If you were relying on the previous behavior, you need to be aware that this behavior has changed.

--- a/changelogs/fragments/1508-fix-mac-lookup-by-id-vm-interface.yml
+++ b/changelogs/fragments/1508-fix-mac-lookup-by-id-vm-interface.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "Fix specifying primary_mac_address objects by id on vm interfaces for disambiguation"

--- a/changelogs/fragments/1535-add-netbox-v44-ci.yml
+++ b/changelogs/fragments/1535-add-netbox-v44-ci.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - Add NetBox v4.4 integration tests to CI matrix
-  - Add local integration test runner (hacking/integration-test.sh)

--- a/changelogs/fragments/1543-add-netbox-v45-ci.yml
+++ b/changelogs/fragments/1543-add-netbox-v45-ci.yml
@@ -1,6 +1,0 @@
----
-minor_changes:
-  - Add NetBox v4.5 support to CI matrix (netbox-docker 4.0.2)
-  - Update netbox_front_port and netbox_front_port_template modules to handle v4.5 removal of rear_port/rear_port_position fields (replaced by PortMapping model)
-  - Update netbox_user module to strip is_staff field on v4.5+ (removed from User model)
-  - Update netbox_token module to support v4.5 v2 tokens with description-based lookup

--- a/changelogs/fragments/1547-fix-custom-session-authorization.yml
+++ b/changelogs/fragments/1547-fix-custom-session-authorization.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - Preserve the Authorization header when creating a custom NetBox API session, fixing authenticated requests with `validate_certs=false`

--- a/changelogs/fragments/add-tenant-to-vlan-group.yml
+++ b/changelogs/fragments/add-tenant-to-vlan-group.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "netbox_vlan_group - Add tenant field support (https://github.com/netbox-community/ansible_modules/issues/1446)"

--- a/changelogs/fragments/black-lint-update.yaml
+++ b/changelogs/fragments/black-lint-update.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Fix linting issues with newly released black version

--- a/changelogs/fragments/deprecated-to-text.yml
+++ b/changelogs/fragments/deprecated-to-text.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Use `ansible.module_utils.common.text.converters` instead of the deprecated `ansible.module_utils._text`

--- a/changelogs/fragments/fix-ip-address-dns-check.yml
+++ b/changelogs/fragments/fix-ip-address-dns-check.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - nb_inventory - Fix AttributeError when `ip_address` is None during DNS name lookup

--- a/changelogs/fragments/fix-more-than-one-result-scoping.yml
+++ b/changelogs/fragments/fix-more-than-one-result-scoping.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - Automatically include device and virtual_machine scoping in sub-object queries to prevent "More than one result returned" errors

--- a/changelogs/fragments/module_type_template.yml
+++ b/changelogs/fragments/module_type_template.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - Add `module_type` as supported to `netbox_rear_port_template`
-  - Add `module_type` as supported to `netbox_front_port_template`

--- a/changelogs/fragments/redhat-feedback-fixes.yml
+++ b/changelogs/fragments/redhat-feedback-fixes.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - "Incorporate Red Hat certification feedback - update README, add .yamllint for changelog lint suppression"

--- a/changelogs/fragments/release-3.23.0.yml
+++ b/changelogs/fragments/release-3.23.0.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Release v3.23.0"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ copyright = "2020, Mikhail Yohman"
 author = "Mikhail Yohman <@FragmentedPacket>"
 
 # The full version, including alpha/beta/rc tags
-release = "3.22.0"
+release = "3.23.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -7,7 +7,7 @@
 Netbox.Netbox
 =============
 
-Collection version 3.22.0
+Collection version 3.23.0
 
 .. contents::
    :local:

--- a/docs/plugins/nb_inventory_inventory.rst
+++ b/docs/plugins/nb_inventory_inventory.rst
@@ -22,7 +22,7 @@ netbox.netbox.nb_inventory inventory -- NetBox inventory source
 .. Collection note
 
 .. note::
-    This inventory plugin is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This inventory plugin is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/nb_lookup_lookup.rst
+++ b/docs/plugins/nb_lookup_lookup.rst
@@ -22,7 +22,7 @@ netbox.netbox.nb_lookup lookup -- Queries and returns elements from NetBox
 .. Collection note
 
 .. note::
-    This lookup plugin is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This lookup plugin is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_aggregate_module.rst
+++ b/docs/plugins/netbox_aggregate_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_aggregate module -- Creates or removes aggregates from NetB
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_asn_module.rst
+++ b/docs/plugins/netbox_asn_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_asn module -- Create, update or delete ASNs within NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_cable_module.rst
+++ b/docs/plugins/netbox_cable_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_cable module -- Create, update or delete cables within NetB
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_circuit_module.rst
+++ b/docs/plugins/netbox_circuit_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_circuit module -- Create, update or delete circuits within 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_circuit_termination_module.rst
+++ b/docs/plugins/netbox_circuit_termination_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_circuit_termination module -- Create, update or delete circ
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_circuit_type_module.rst
+++ b/docs/plugins/netbox_circuit_type_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_circuit_type module -- Create, update or delete circuit typ
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_cluster_group_module.rst
+++ b/docs/plugins/netbox_cluster_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_cluster_group module -- Create, update or delete cluster gr
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_cluster_module.rst
+++ b/docs/plugins/netbox_cluster_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_cluster module -- Create, update or delete clusters within 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_cluster_type_module.rst
+++ b/docs/plugins/netbox_cluster_type_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_cluster_type module -- Create, update or delete cluster typ
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_config_context_module.rst
+++ b/docs/plugins/netbox_config_context_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_config_context module -- Creates, updates or deletes config
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_config_template_module.rst
+++ b/docs/plugins/netbox_config_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_config_template module -- Creates or removes config templat
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_console_port_module.rst
+++ b/docs/plugins/netbox_console_port_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_console_port module -- Create, update or delete console por
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_console_port_template_module.rst
+++ b/docs/plugins/netbox_console_port_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_console_port_template module -- Create, update or delete co
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_console_server_port_module.rst
+++ b/docs/plugins/netbox_console_server_port_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_console_server_port module -- Create, update or delete cons
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_console_server_port_template_module.rst
+++ b/docs/plugins/netbox_console_server_port_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_console_server_port_template module -- Create, update or de
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_contact_assignment_module.rst
+++ b/docs/plugins/netbox_contact_assignment_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_contact_assignment module -- Creates or removes contact ass
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_contact_group_module.rst
+++ b/docs/plugins/netbox_contact_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_contact_group module -- Creates or removes contact groups f
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_contact_module.rst
+++ b/docs/plugins/netbox_contact_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_contact module -- Creates or removes contacts from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_contact_role_module.rst
+++ b/docs/plugins/netbox_contact_role_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_contact_role module -- Creates or removes contact roles fro
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_custom_field_choice_set_module.rst
+++ b/docs/plugins/netbox_custom_field_choice_set_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_custom_field_choice_set module -- Creates, updates or delet
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_custom_field_module.rst
+++ b/docs/plugins/netbox_custom_field_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_custom_field module -- Creates, updates or deletes custom f
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_custom_link_module.rst
+++ b/docs/plugins/netbox_custom_link_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_custom_link module -- Creates, updates or deletes custom li
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_data_source_module.rst
+++ b/docs/plugins/netbox_data_source_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_data_source module -- Creates or removes data sources from 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_device_bay_module.rst
+++ b/docs/plugins/netbox_device_bay_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_device_bay module -- Create, update or delete device bays w
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_device_bay_template_module.rst
+++ b/docs/plugins/netbox_device_bay_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_device_bay_template module -- Create, update or delete devi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_device_interface_module.rst
+++ b/docs/plugins/netbox_device_interface_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_device_interface module -- Creates or removes interfaces on
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_device_interface_template_module.rst
+++ b/docs/plugins/netbox_device_interface_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_device_interface_template module -- Creates or removes inte
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_device_module.rst
+++ b/docs/plugins/netbox_device_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_device module -- Create, update or delete devices within Ne
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_device_role_module.rst
+++ b/docs/plugins/netbox_device_role_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_device_role module -- Create, update or delete devices role
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_device_type_module.rst
+++ b/docs/plugins/netbox_device_type_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_device_type module -- Create, update or delete device types
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_export_template_module.rst
+++ b/docs/plugins/netbox_export_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_export_template module -- Creates, updates or deletes expor
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_fhrp_group_assignment_module.rst
+++ b/docs/plugins/netbox_fhrp_group_assignment_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_fhrp_group_assignment module -- Create, update or delete FH
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_fhrp_group_module.rst
+++ b/docs/plugins/netbox_fhrp_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_fhrp_group module -- Create, update or delete FHRP groups w
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_front_port_module.rst
+++ b/docs/plugins/netbox_front_port_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_front_port module -- Create, update or delete front ports w
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.
@@ -348,7 +348,7 @@ Parameters
 
       .. ansible-option-type-line::
 
-        :ansible-option-type:`any` / :ansible-option-required:`required`
+        :ansible-option-type:`any`
 
       .. raw:: html
 
@@ -363,6 +363,8 @@ Parameters
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
       The rear\_port the front port is attached to
+
+      Required for NetBox \< v4.5. Ignored on v4.5+ (replaced by PortMapping model).
 
 
       .. raw:: html

--- a/docs/plugins/netbox_front_port_template_module.rst
+++ b/docs/plugins/netbox_front_port_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_front_port_template module -- Create, update or delete fron
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.
@@ -222,7 +222,7 @@ Parameters
 
       .. ansible-option-type-line::
 
-        :ansible-option-type:`any` / :ansible-option-required:`required`
+        :ansible-option-type:`any`
 
       .. raw:: html
 
@@ -237,6 +237,8 @@ Parameters
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
       The device type the front port template is attached to
+
+      Either :emphasis:`device\_type` or :emphasis:`module\_type` are required
 
 
       .. raw:: html
@@ -282,6 +284,53 @@ Parameters
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
       Label of the front port
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-data/module_type"></div>
+
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
+      .. _ansible_collections.netbox.netbox.netbox_front_port_template_module__parameter-data/module_type:
+
+      .. rst-class:: ansible-option-title
+
+      **module_type**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-data/module_type" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`any`
+
+      :ansible-option-versionadded:`added in netbox.netbox 3.23.0`
+
+
+      .. raw:: html
+
+        </div>
+
+      .. raw:: latex
+
+        \end{minipage}
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      The module type the front port template is attached to
+
+      Either :emphasis:`device\_type` or :emphasis:`module\_type` are required
 
 
       .. raw:: html
@@ -351,7 +400,7 @@ Parameters
 
       .. ansible-option-type-line::
 
-        :ansible-option-type:`any` / :ansible-option-required:`required`
+        :ansible-option-type:`any`
 
       .. raw:: html
 
@@ -366,6 +415,8 @@ Parameters
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
       The rear\_port\_template the front port template is attached to
+
+      Required for NetBox \< v4.5. Ignored on v4.5+ (replaced by PortMapping model).
 
 
       .. raw:: html
@@ -737,6 +788,17 @@ Examples
             data:
               name: Test Front Port Template
               device_type: Test Device Type
+              type: bnc
+              rear_port_template: Test Rear Port Template
+            state: present
+
+        - name: Create front port template for a module type within NetBox
+          netbox.netbox.netbox_front_port_template:
+            netbox_url: http://netbox.local
+            netbox_token: thisIsMyToken
+            data:
+              name: Test Front Port Template
+              module_type: Test Module Type
               type: bnc
               rear_port_template: Test Rear Port Template
             state: present

--- a/docs/plugins/netbox_interface_module.rst
+++ b/docs/plugins/netbox_interface_module.rst
@@ -17,7 +17,7 @@ netbox.netbox.netbox_interface
 .. Collection note
 
 .. note::
-    This plugin was part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This plugin was part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
 This module has been removed
 in version 0.1.0 of netbox.netbox.

--- a/docs/plugins/netbox_inventory_item_module.rst
+++ b/docs/plugins/netbox_inventory_item_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_inventory_item module -- Creates or removes inventory items
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_inventory_item_role_module.rst
+++ b/docs/plugins/netbox_inventory_item_role_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_inventory_item_role module -- Create, update or delete devi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_ip_address_module.rst
+++ b/docs/plugins/netbox_ip_address_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_ip_address module -- Creates or removes IP addresses from N
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_ipam_role_module.rst
+++ b/docs/plugins/netbox_ipam_role_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_ipam_role module -- Creates or removes ipam roles from NetB
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_journal_entry_module.rst
+++ b/docs/plugins/netbox_journal_entry_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_journal_entry module -- Creates a journal entry
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_l2vpn_module.rst
+++ b/docs/plugins/netbox_l2vpn_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_l2vpn module -- Create, update or delete L2VPNs within NetB
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_l2vpn_termination_module.rst
+++ b/docs/plugins/netbox_l2vpn_termination_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_l2vpn_termination module -- Create, update or delete L2VPNs
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_location_module.rst
+++ b/docs/plugins/netbox_location_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_location module -- Create, update or delete locations withi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_mac_address_module.rst
+++ b/docs/plugins/netbox_mac_address_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_mac_address module -- Create, update or delete MAC addresse
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_manufacturer_module.rst
+++ b/docs/plugins/netbox_manufacturer_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_manufacturer module -- Create or delete manufacturers withi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_module_bay_module.rst
+++ b/docs/plugins/netbox_module_bay_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_module_bay module -- Create, update or delete module bay wi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_module_module.rst
+++ b/docs/plugins/netbox_module_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_module module -- Create, update or delete module within Net
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_module_type_module.rst
+++ b/docs/plugins/netbox_module_type_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_module_type module -- Create, update or delete module types
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_permission_module.rst
+++ b/docs/plugins/netbox_permission_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_permission module -- Creates or removes permissions from Ne
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_platform_module.rst
+++ b/docs/plugins/netbox_platform_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_platform module -- Create or delete platforms within NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_power_feed_module.rst
+++ b/docs/plugins/netbox_power_feed_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_power_feed module -- Create, update or delete power feeds w
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_power_outlet_module.rst
+++ b/docs/plugins/netbox_power_outlet_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_power_outlet module -- Create, update or delete power outle
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_power_outlet_template_module.rst
+++ b/docs/plugins/netbox_power_outlet_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_power_outlet_template module -- Create, update or delete po
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_power_panel_module.rst
+++ b/docs/plugins/netbox_power_panel_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_power_panel module -- Create, update or delete power panels
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_power_port_module.rst
+++ b/docs/plugins/netbox_power_port_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_power_port module -- Create, update or delete power ports w
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_power_port_template_module.rst
+++ b/docs/plugins/netbox_power_port_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_power_port_template module -- Create, update or delete powe
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_prefix_module.rst
+++ b/docs/plugins/netbox_prefix_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_prefix module -- Creates or removes prefixes from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_provider_module.rst
+++ b/docs/plugins/netbox_provider_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_provider module -- Create, update or delete providers withi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_provider_network_module.rst
+++ b/docs/plugins/netbox_provider_network_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_provider_network module -- Create, update or delete provide
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_rack_group_module.rst
+++ b/docs/plugins/netbox_rack_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_rack_group module -- Create, update or delete racks groups 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_rack_module.rst
+++ b/docs/plugins/netbox_rack_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_rack module -- Create, update or delete racks within NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_rack_role_module.rst
+++ b/docs/plugins/netbox_rack_role_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_rack_role module -- Create, update or delete racks roles wi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_rear_port_module.rst
+++ b/docs/plugins/netbox_rear_port_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_rear_port module -- Create, update or delete rear ports wit
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_rear_port_template_module.rst
+++ b/docs/plugins/netbox_rear_port_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_rear_port_template module -- Create, update or delete rear 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.
@@ -222,7 +222,7 @@ Parameters
 
       .. ansible-option-type-line::
 
-        :ansible-option-type:`any` / :ansible-option-required:`required`
+        :ansible-option-type:`any`
 
       .. raw:: html
 
@@ -237,6 +237,8 @@ Parameters
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
       The device type the rear port template is attached to
+
+      Either :emphasis:`device\_type` or :emphasis:`module\_type` are required
 
 
       .. raw:: html
@@ -282,6 +284,53 @@ Parameters
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
       Label of the rear port
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-data/module_type"></div>
+
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
+      .. _ansible_collections.netbox.netbox.netbox_rear_port_template_module__parameter-data/module_type:
+
+      .. rst-class:: ansible-option-title
+
+      **module_type**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-data/module_type" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`any`
+
+      :ansible-option-versionadded:`added in netbox.netbox 3.23.0`
+
+
+      .. raw:: html
+
+        </div>
+
+      .. raw:: latex
+
+        \end{minipage}
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      The module type the rear port template is attached to
+
+      Either :emphasis:`device\_type` or :emphasis:`module\_type` are required
 
 
       .. raw:: html
@@ -695,6 +744,16 @@ Examples
             data:
               name: Test Rear Port Template
               device_type: Test Device Type
+              type: bnc
+            state: present
+
+        - name: Create rear port template for a module type within NetBox
+          netbox.netbox.netbox_rear_port_template:
+            netbox_url: http://netbox.local
+            netbox_token: thisIsMyToken
+            data:
+              name: Test Rear Port Template
+              module_type: Test Module Type
               type: bnc
             state: present
 

--- a/docs/plugins/netbox_region_module.rst
+++ b/docs/plugins/netbox_region_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_region module -- Creates or removes regions from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_rir_module.rst
+++ b/docs/plugins/netbox_rir_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_rir module -- Create, update or delete RIRs within NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_route_target_module.rst
+++ b/docs/plugins/netbox_route_target_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_route_target module -- Creates or removes route targets fro
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_service_module.rst
+++ b/docs/plugins/netbox_service_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_service module -- Creates or removes service from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_service_template_module.rst
+++ b/docs/plugins/netbox_service_template_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_service_template module -- Create, update or delete service
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_site_group_module.rst
+++ b/docs/plugins/netbox_site_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_site_group module -- Create, update, or delete site groups 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_site_module.rst
+++ b/docs/plugins/netbox_site_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_site module -- Creates or removes sites from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_tag_module.rst
+++ b/docs/plugins/netbox_tag_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_tag module -- Creates or removes tags from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_tenant_group_module.rst
+++ b/docs/plugins/netbox_tenant_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_tenant_group module -- Creates or removes tenant groups fro
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_tenant_module.rst
+++ b/docs/plugins/netbox_tenant_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_tenant module -- Creates or removes tenants from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_token_module.rst
+++ b/docs/plugins/netbox_token_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_token module -- Creates or removes tokens from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.
@@ -193,6 +193,8 @@ Parameters
 
       The description of the token to be created
 
+      On v4.5+, used together with user for idempotent token lookup (since key-based lookup is not available for v2 tokens).
+
 
       .. raw:: html
 
@@ -261,7 +263,7 @@ Parameters
 
       .. ansible-option-type-line::
 
-        :ansible-option-type:`string` / :ansible-option-required:`required`
+        :ansible-option-type:`string`
 
       .. raw:: html
 
@@ -275,7 +277,9 @@ Parameters
 
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
-      Key of the token to be created. Must be exactly 40 characters
+      Key of the token to be created. Must be exactly 40 characters.
+
+      Required for NetBox \< v4.5 (v1 tokens). Optional on v4.5+ (v2 tokens auto-generate keys).
 
 
       .. raw:: html

--- a/docs/plugins/netbox_tunnel_group_module.rst
+++ b/docs/plugins/netbox_tunnel_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_tunnel_group module -- Create, update or delete tunnel grou
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_tunnel_module.rst
+++ b/docs/plugins/netbox_tunnel_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_tunnel module -- Create, update or delete tunnels within Ne
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_user_group_module.rst
+++ b/docs/plugins/netbox_user_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_user_group module -- Creates or removes user groups from Ne
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_user_module.rst
+++ b/docs/plugins/netbox_user_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_user module -- Creates or removes users from NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.
@@ -368,6 +368,8 @@ Parameters
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
 
       Staff status of the user to be created
+
+      Only supported on NetBox \< v4.5. Ignored on v4.5+ (field removed).
 
 
       .. rst-class:: ansible-option-line
@@ -818,7 +820,7 @@ Examples
             netbox_token: thisIsMyToken
             data:
               username: MyUser
-              password: my@user.com
+              email: my@example.com
             state: present
 
         - name: Delete user within netbox
@@ -836,7 +838,7 @@ Examples
             data:
               username: MyUser2
               password: MyPassword
-              email: my@user.com
+              email: my@example.com
               first_name: My
               last_name: User
             state: present

--- a/docs/plugins/netbox_virtual_chassis_module.rst
+++ b/docs/plugins/netbox_virtual_chassis_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_virtual_chassis module -- Create, update or delete virtual 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_virtual_disk_module.rst
+++ b/docs/plugins/netbox_virtual_disk_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_virtual_disk module -- Creates or removes disks from virtua
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_virtual_machine_module.rst
+++ b/docs/plugins/netbox_virtual_machine_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_virtual_machine module -- Create, update or delete virtual\
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_vlan_group_module.rst
+++ b/docs/plugins/netbox_vlan_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_vlan_group module -- Create, update or delete vlans groups 
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.
@@ -617,6 +617,51 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-data/tenant"></div>
+
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
+      .. _ansible_collections.netbox.netbox.netbox_vlan_group_module__parameter-data/tenant:
+
+      .. rst-class:: ansible-option-title
+
+      **tenant**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-data/tenant" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`any`
+
+      :ansible-option-versionadded:`added in netbox.netbox 3.23.0`
+
+
+      .. raw:: html
+
+        </div>
+
+      .. raw:: latex
+
+        \end{minipage}
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      The tenant that the VLAN group will be assigned to
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-data/vid_ranges"></div>
 
       .. raw:: latex
@@ -942,6 +987,17 @@ Examples
                 [1300, 1329],
                 [1, 2]
               ]
+            state: present
+
+        - name: Create vlan group with tenant assignment
+          netbox_vlan_group:
+            netbox_url: http://netbox.local
+            netbox_token: thisIsMyToken
+            data:
+              name: Test vlan group
+              scope_type: "dcim.site"
+              scope: Test Site
+              tenant: Test Tenant
             state: present
 
         - name: Delete vlan group within netbox

--- a/docs/plugins/netbox_vlan_module.rst
+++ b/docs/plugins/netbox_vlan_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_vlan module -- Create, update or delete vlans within NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_vm_interface_module.rst
+++ b/docs/plugins/netbox_vm_interface_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_vm_interface module -- Creates or removes interfaces from v
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.
@@ -527,7 +527,7 @@ Parameters
 
       .. ansible-option-type-line::
 
-        :ansible-option-type:`string`
+        :ansible-option-type:`any`
 
       .. raw:: html
 

--- a/docs/plugins/netbox_vrf_module.rst
+++ b/docs/plugins/netbox_vrf_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_vrf module -- Create, update or delete vrfs within NetBox
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_webhook_module.rst
+++ b/docs/plugins/netbox_webhook_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_webhook module -- Creates, updates or deletes webhook confi
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_wireless_lan_group_module.rst
+++ b/docs/plugins/netbox_wireless_lan_group_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_wireless_lan_group module -- Creates or removes Wireless LA
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_wireless_lan_module.rst
+++ b/docs/plugins/netbox_wireless_lan_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_wireless_lan module -- Creates or removes Wireless LANs fro
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/netbox_wireless_link_module.rst
+++ b/docs/plugins/netbox_wireless_link_module.rst
@@ -22,7 +22,7 @@ netbox.netbox.netbox_wireless_link module -- Creates or removes Wireless links f
 .. Collection note
 
 .. note::
-    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.22.0).
+    This module is part of the `netbox.netbox collection <https://galaxy.ansible.com/ui/repo/published/netbox/netbox/>`_ (version 3.23.0).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: netbox
 name: netbox
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.22.0
+version: 3.23.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/netbox_front_port_template.py
+++ b/plugins/modules/netbox_front_port_template.py
@@ -41,6 +41,7 @@ options:
           - The module type the front port template is attached to
           - Either I(device_type) or I(module_type) are required
         type: raw
+        version_added: "3.23.0"
       name:
         description:
           - The name of the front port template

--- a/plugins/modules/netbox_rear_port_template.py
+++ b/plugins/modules/netbox_rear_port_template.py
@@ -41,6 +41,7 @@ options:
           - The module type the rear port template is attached to
           - Either I(device_type) or I(module_type) are required
         type: raw
+        version_added: "3.23.0"
       name:
         description:
           - The name of the rear port template


### PR DESCRIPTION
## Summary
- Bump version to 3.23.0 in `galaxy.yml` and `docs/conf.py`
- Add `version_added: "3.23.0"` to new `module_type` option on `netbox_front_port_template` and `netbox_rear_port_template`
- Regenerate docs and changelogs via `antsibull-changelog release` and `antsibull-docs`

## Changelog highlights

**Breaking Changes**
- Slug generation behavior has changed

**Bugfixes**
- Fix sub-object query scoping ("more than one result returned")
- Fix primary_mac_address lookup by id on vm interfaces
- Fix Authorization header on custom API sessions
- Fix AttributeError when ip_address is None during DNS name lookup
- Slug generation fixes (regex pattern, optional slug key, netbox_secret)

**Minor Changes**
- Add NetBox v4.4 and v4.5 CI support
- Add tenant field to vlan_group
- Add module_type to front/rear port templates
- v4.5 compatibility (token, user, front_port changes)
- Deprecation fix (ansible text converters)
- Local integration test runner

## Test plan
- [x] Changelog and docs regenerated cleanly
- [ ] CI passes