### PR TITLE
Add description & comments extractor for Devices & VMs

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -575,6 +575,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "cluster_device": self.extract_cluster_device,
             "is_virtual": self.extract_is_virtual,
             "serial": self.extract_serial,
+            "description": self.extract_description,
+            "comments": self.extract_comments,
             "asset_tag": self.extract_asset_tag,
             "time_zone": self.extract_site_time_zone,
             "utc_offset": self.extract_site_utc_offset,
@@ -1044,6 +1046,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def extract_serial(self, host):
         return host.get("serial", None)
+
+    def extract_description(self, host):
+        return host.get("description", None)
+
+    def extract_comments(self, host):
+        return host.get("comments", None)
 
     def extract_asset_tag(self, host):
         return host.get("asset_tag", None)


### PR DESCRIPTION
## Related Issue

#1133 

## New Behavior

Two extractors are added to provide descriptions and comments for devices and VMs in the inventory plugin.

...

## Contrast to Current Behavior

Current behavior is/was that description and comments were missing in the inventory.

...

## Discussion: Benefits and Drawbacks

With this PR implemented, it is no longer necessary to look up the descriptions and/or comments separately, as they are already fetched when fetching the devices and VMs. So there is no additional API request needed, which makes playbooks faster.

...

## Changes to the Documentation

No changes are needed as the fields which are available in the inventory are currently not documented (for example serial).

...

## Proposed Release Note Entry

Add description & comments to the inventory plugin.

...

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
