### PR TITLE
ci: add ansible-core 2.19 compatibility matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
+        include:
+          # ansible-core 2.19 compatibility legs (INT-236). The pin is
+          # deliberate: bump it intentionally when evaluating a new 2.19.x
+          # point release, not on every upstream release.
+          - python-version: "3.11"
+            ansible-core: "==2.19.9"
+          - python-version: "3.12"
+            ansible-core: "==2.19.9"
+          - python-version: "3.13"
+            ansible-core: "==2.19.9"
 
     steps:
 
@@ -47,6 +57,10 @@ jobs:
 
       - name: Install Python packages
         run: poetry install --no-root
+
+      - name: Override ansible-core version
+        if: matrix.ansible-core != ''
+        run: pip install --upgrade "ansible-core${{ matrix.ansible-core }}"
 
       - name: Build and install collection
         run: |
@@ -84,6 +98,12 @@ jobs:
             NETBOX_DOCKER_VERSION: 3.4.2
           - VERSION: "v4.5"
             NETBOX_DOCKER_VERSION: 4.0.2
+          # ansible-core 2.19 compatibility leg against the latest NetBox
+          # (INT-236). Pin bumped deliberately, not on every upstream
+          # release.
+          - VERSION: "v4.5"
+            NETBOX_DOCKER_VERSION: 4.0.2
+            ansible-core: "==2.19.9"
 
     steps:
 
@@ -113,6 +133,10 @@ jobs:
 
       - name: Install Python packages
         run: poetry install --no-root
+
+      - name: Override ansible-core version
+        if: matrix.ansible-core != ''
+        run: pip install --upgrade "ansible-core${{ matrix.ansible-core }}"
 
       - name: Build and install collection
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,16 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        include:
-          # ansible-core 2.19 compatibility legs (INT-236). The pin is
-          # deliberate: bump it intentionally when evaluating a new 2.19.x
-          # point release, not on every upstream release.
-          - python-version: "3.11"
-            ansible-core: "==2.19.9"
-          - python-version: "3.12"
-            ansible-core: "==2.19.9"
-          - python-version: "3.13"
-            ansible-core: "==2.19.9"
+        # Empty value keeps the Poetry-resolved 2.18.x baseline; "==2.19.9"
+        # pins the 2.19 compatibility leg (INT-236). Bump the pin
+        # deliberately when evaluating a new 2.19.x point release, not on
+        # every upstream release.
+        ansible-core: ["", "==2.19.9"]
 
     steps:
 

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -12,6 +12,12 @@ bugfixes:
     the returned integer. ansible-core 2.19's stricter conditional handling
     rejects non-boolean ``assert: that:`` predicates.
   - >-
+    Integration test fixtures: ``netbox_inventory_item`` assertions that
+    compare ``test.msg`` against a string containing ``": "`` (colon then
+    space) are now wrapped in outer single quotes. ansible-core 2.19
+    rejects conditionals that YAML parses as anything other than a string;
+    previously the embedded colon-space was silently accepted.
+  - >-
     ``netbox_contact``: the NetBox-version compatibility gate
     (``contact_group`` vs ``contact_groups``, introduced in NetBox v4.3)
     now exits via ``module.fail_json`` instead of raising a bare

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -5,35 +5,20 @@ minor_changes:
     existing 2.18 baseline. Three new unit-test legs (Python 3.11, 3.12,
     3.13) and one integration leg (NetBox v4.5) install a pinned 2.19.x
     point release on top of the Poetry-resolved environment.
+  - >-
+    Internal integration test fixtures (``netbox_ip_address``,
+    ``netbox_lookup``, ``netbox_inventory_item``, ``netbox_contact``)
+    updated for ansible-core 2.19's stricter templating: explicit
+    ``is not none``/``| length > 0`` boolean checks, ``| int`` coercion on
+    templated counts, and outer single-quoting of conditionals containing
+    ``": "``.
 bugfixes:
-  - >-
-    Integration test fixtures: the ``netbox_ip_address`` ``nat_inside``
-    assertion now uses ``is not none`` instead of relying on truthiness of
-    the returned integer. ansible-core 2.19's stricter conditional handling
-    rejects non-boolean ``assert: that:`` predicates.
-  - >-
-    Integration test fixtures: ``netbox_lookup`` "device query by ID"
-    assertion now checks ``query_result | length > 0`` instead of relying
-    on truthiness of the returned list. ansible-core 2.19 rejects
-    non-boolean conditionals.
-  - >-
-    Integration test fixtures: ``netbox_lookup`` count assertions now
-    compare against an integer instead of a quoted-digit string
-    (``query_result | int == 4``). ansible-core 2.19 preserves the int
-    type from the ``count`` filter end-to-end, where 2.18 silently
-    coerced templated output to string.
-  - >-
-    Integration test fixtures: ``netbox_inventory_item`` assertions that
-    compare ``test.msg`` against a string containing ``": "`` (colon then
-    space) are now wrapped in outer single quotes. ansible-core 2.19
-    rejects conditionals that YAML parses as anything other than a string;
-    previously the embedded colon-space was silently accepted.
   - >-
     ``netbox_contact``: the NetBox-version compatibility gate
     (``contact_group`` vs ``contact_groups``, introduced in NetBox v4.3)
     now exits via ``module.fail_json`` instead of raising a bare
     ``Exception``. Previously the error string ended up in
-    ``module_stderr`` as a traceback; ansible-core 2.19 no longer
+    ``module_stderr`` as a Python traceback; ansible-core 2.19 no longer
     populates ``module_stderr`` for module subprocess failures, so the
     message is now reported via ``msg`` on every supported ansible-core
-    version. Test fixtures updated accordingly to assert against ``msg``.
+    version.

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -11,3 +11,8 @@ bugfixes:
     assertion now uses ``is not none`` instead of relying on truthiness of
     the returned integer. ansible-core 2.19's stricter conditional handling
     rejects non-boolean ``assert: that:`` predicates.
+  - >-
+    Integration test fixtures: ``netbox_contact`` version-gate assertions
+    now read the error string from ``test_seven['msg']`` instead of
+    ``test_seven['module_stderr']``. ansible-core 2.19 no longer populates
+    ``module_stderr`` for clean ``fail_json`` failures.

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -12,6 +12,12 @@ bugfixes:
     the returned integer. ansible-core 2.19's stricter conditional handling
     rejects non-boolean ``assert: that:`` predicates.
   - >-
+    Integration test fixtures: ``netbox_lookup`` count assertions now
+    compare against an integer instead of a quoted-digit string
+    (``query_result | int == 4``). ansible-core 2.19 preserves the int
+    type from the ``count`` filter end-to-end, where 2.18 silently
+    coerced templated output to string.
+  - >-
     Integration test fixtures: ``netbox_inventory_item`` assertions that
     compare ``test.msg`` against a string containing ``": "`` (colon then
     space) are now wrapped in outer single quotes. ansible-core 2.19

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -12,7 +12,11 @@ bugfixes:
     the returned integer. ansible-core 2.19's stricter conditional handling
     rejects non-boolean ``assert: that:`` predicates.
   - >-
-    Integration test fixtures: ``netbox_contact`` version-gate assertions
-    now read the error string from ``test_seven['msg']`` instead of
-    ``test_seven['module_stderr']``. ansible-core 2.19 no longer populates
-    ``module_stderr`` for clean ``fail_json`` failures.
+    ``netbox_contact``: the NetBox-version compatibility gate
+    (``contact_group`` vs ``contact_groups``, introduced in NetBox v4.3)
+    now exits via ``module.fail_json`` instead of raising a bare
+    ``Exception``. Previously the error string ended up in
+    ``module_stderr`` as a traceback; ansible-core 2.19 no longer
+    populates ``module_stderr`` for module subprocess failures, so the
+    message is now reported via ``msg`` on every supported ansible-core
+    version. Test fixtures updated accordingly to assert against ``msg``.

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -1,0 +1,9 @@
+---
+minor_changes:
+  - >-
+    CI now exercises the collection against ansible-core 2.19 alongside the
+    existing 2.18 baseline. Three new unit-test legs (Python 3.11, 3.12,
+    3.13) and one integration leg (NetBox v4.5) install a pinned 2.19.x
+    point release on top of the Poetry-resolved environment. No source
+    changes were required for compatibility — sanity and all unit tests
+    pass on ansible-core 2.19.

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -12,6 +12,11 @@ bugfixes:
     the returned integer. ansible-core 2.19's stricter conditional handling
     rejects non-boolean ``assert: that:`` predicates.
   - >-
+    Integration test fixtures: ``netbox_lookup`` "device query by ID"
+    assertion now checks ``query_result | length > 0`` instead of relying
+    on truthiness of the returned list. ansible-core 2.19 rejects
+    non-boolean conditionals.
+  - >-
     Integration test fixtures: ``netbox_lookup`` count assertions now
     compare against an integer instead of a quoted-digit string
     (``query_result | int == 4``). ansible-core 2.19 preserves the int

--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -4,6 +4,10 @@ minor_changes:
     CI now exercises the collection against ansible-core 2.19 alongside the
     existing 2.18 baseline. Three new unit-test legs (Python 3.11, 3.12,
     3.13) and one integration leg (NetBox v4.5) install a pinned 2.19.x
-    point release on top of the Poetry-resolved environment. No source
-    changes were required for compatibility — sanity and all unit tests
-    pass on ansible-core 2.19.
+    point release on top of the Poetry-resolved environment.
+bugfixes:
+  - >-
+    Integration test fixtures: the ``netbox_ip_address`` ``nat_inside``
+    assertion now uses ``is not none`` instead of relying on truthiness of
+    the returned integer. ansible-core 2.19's stricter conditional handling
+    rejects non-boolean ``assert: that:`` predicates.

--- a/plugins/module_utils/netbox_tenancy.py
+++ b/plugins/module_utils/netbox_tenancy.py
@@ -113,15 +113,15 @@ class NetboxTenancyModule(NetboxModule):
                 if not self._version_check_greater(
                     self.api_version, "4.3", greater_or_equal=True
                 ):
-                    raise Exception(
-                        f"contact_groups is not available in Netbox {self.api_version}. Use contact_group instead, or upgrade to Netbox 4.3 or greater."
+                    self.module.fail_json(
+                        msg=f"contact_groups is not available in Netbox {self.api_version}. Use contact_group instead, or upgrade to Netbox 4.3 or greater."
                     )
             if data.get("group"):
                 if self._version_check_greater(
                     self.api_version, "4.3", greater_or_equal=True
                 ):
-                    raise Exception(
-                        f"contact_group is not available in Netbox {self.api_version}. Use contact_groups instead."
+                    self.module.fail_json(
+                        msg=f"contact_group is not available in Netbox {self.api_version}. Use contact_groups instead."
                     )
 
         # For ease and consistency of use, the contact assignment module takes the name of the contact, role, and target object rather than an ID or slug.

--- a/plugins/module_utils/netbox_tenancy.py
+++ b/plugins/module_utils/netbox_tenancy.py
@@ -116,6 +116,7 @@ class NetboxTenancyModule(NetboxModule):
                     self.module.fail_json(
                         msg=f"contact_groups is not available in Netbox {self.api_version}. Use contact_group instead, or upgrade to Netbox 4.3 or greater."
                     )
+                    return
             if data.get("group"):
                 if self._version_check_greater(
                     self.api_version, "4.3", greater_or_equal=True
@@ -123,6 +124,7 @@ class NetboxTenancyModule(NetboxModule):
                     self.module.fail_json(
                         msg=f"contact_group is not available in Netbox {self.api_version}. Use contact_groups instead."
                     )
+                    return
 
         # For ease and consistency of use, the contact assignment module takes the name of the contact, role, and target object rather than an ID or slug.
         # We must massage the data a bit by looking up the ID corresponding to the given name so that we can pass the ID to the API.

--- a/tests/integration/targets/v4.0/tasks/netbox_contact.yml
+++ b/tests/integration/targets/v4.0/tasks/netbox_contact.yml
@@ -140,4 +140,4 @@
 - name: 7 - ASSERT
   ansible.builtin.assert:
     that:
-      - "'contact_groups is not available in Netbox 4.0. Use contact_group instead, or upgrade to Netbox 4.3 or greater.' in test_seven['module_stderr']"
+      - "'contact_groups is not available in Netbox 4.0. Use contact_group instead, or upgrade to Netbox 4.3 or greater.' in test_seven['msg']"

--- a/tests/integration/targets/v4.0/tasks/netbox_inventory_item.yml
+++ b/tests/integration/targets/v4.0/tasks/netbox_inventory_item.yml
@@ -154,7 +154,7 @@
   ansible.builtin.assert:
     that:
       - test_six.failed
-      - test_six.msg == "Could not resolve id of inventory_item_role: Foo"
+      - 'test_six.msg == "Could not resolve id of inventory_item_role: Foo"'
 
 - name: "INVENTORY_ITEM 7: Create inventory item with component"
   netbox.netbox.netbox_inventory_item:
@@ -200,4 +200,4 @@
   ansible.builtin.assert:
     that:
       - test_eight.failed
-      - test_eight.msg == "parameters are required together: component_type, component"
+      - 'test_eight.msg == "parameters are required together: component_type, component"'

--- a/tests/integration/targets/v4.0/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v4.0/tasks/netbox_ip_address.yml
@@ -172,7 +172,7 @@
       - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
-      - test_eight['ip_address'].get('nat_inside')
+      - test_eight['ip_address'].get('nat_inside') is not none
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/v4.0/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.0/tasks/netbox_lookup.yml
@@ -6,20 +6,20 @@
 ##
 - name: "NETBOX_LOOKUP 1: Lookup returns exactly two sites"
   ansible.builtin.assert:
-    that: query_result == "3"
+    that: query_result | int == 3
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | count }}"
 
 - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   ansible.builtin.assert:
-    that: query_result == "0"
+    that: query_result | int == 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`Wibble`]')
       | count }}"
 
 - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`TestDeviceR1`]')
       | count }}"
@@ -61,14 +61,14 @@
 
 - name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       | community.general.json_query('[?value.display==`L2`]') | count }}"
 
 - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567',
       raw_data=True) | community.general.json_query('[?display==`L2`]') | count }}"

--- a/tests/integration/targets/v4.0/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.0/tasks/netbox_lookup.yml
@@ -84,7 +84,7 @@
 
 - name: "NETBOX_LOOKUP 10: Device query by ID"
   ansible.builtin.assert:
-    that: query_result
+    that: query_result | length > 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='id=1', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       }}"

--- a/tests/integration/targets/v4.1/tasks/netbox_contact.yml
+++ b/tests/integration/targets/v4.1/tasks/netbox_contact.yml
@@ -140,4 +140,4 @@
 - name: 7 - ASSERT
   ansible.builtin.assert:
     that:
-      - "'contact_groups is not available in Netbox 4.1. Use contact_group instead, or upgrade to Netbox 4.3 or greater.' in test_seven['module_stderr']"
+      - "'contact_groups is not available in Netbox 4.1. Use contact_group instead, or upgrade to Netbox 4.3 or greater.' in test_seven['msg']"

--- a/tests/integration/targets/v4.1/tasks/netbox_inventory_item.yml
+++ b/tests/integration/targets/v4.1/tasks/netbox_inventory_item.yml
@@ -154,7 +154,7 @@
   ansible.builtin.assert:
     that:
       - test_six.failed
-      - test_six.msg == "Could not resolve id of inventory_item_role: Foo"
+      - 'test_six.msg == "Could not resolve id of inventory_item_role: Foo"'
 
 - name: "INVENTORY_ITEM 7: Create inventory item with component"
   netbox.netbox.netbox_inventory_item:
@@ -200,4 +200,4 @@
   ansible.builtin.assert:
     that:
       - test_eight.failed
-      - test_eight.msg == "parameters are required together: component_type, component"
+      - 'test_eight.msg == "parameters are required together: component_type, component"'

--- a/tests/integration/targets/v4.1/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v4.1/tasks/netbox_ip_address.yml
@@ -172,7 +172,7 @@
       - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
-      - test_eight['ip_address'].get('nat_inside')
+      - test_eight['ip_address'].get('nat_inside') is not none
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/v4.1/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.1/tasks/netbox_lookup.yml
@@ -6,20 +6,20 @@
 ##
 - name: "NETBOX_LOOKUP 1: Lookup returns exactly two sites"
   ansible.builtin.assert:
-    that: query_result == "3"
+    that: query_result | int == 3
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | count }}"
 
 - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   ansible.builtin.assert:
-    that: query_result == "0"
+    that: query_result | int == 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`Wibble`]')
       | count }}"
 
 - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`TestDeviceR1`]')
       | count }}"
@@ -61,14 +61,14 @@
 
 - name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       | community.general.json_query('[?value.display==`L2`]') | count }}"
 
 - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567',
       raw_data=True) | community.general.json_query('[?display==`L2`]') | count }}"

--- a/tests/integration/targets/v4.1/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.1/tasks/netbox_lookup.yml
@@ -84,7 +84,7 @@
 
 - name: "NETBOX_LOOKUP 10: Device query by ID"
   ansible.builtin.assert:
-    that: query_result
+    that: query_result | length > 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='id=1', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       }}"

--- a/tests/integration/targets/v4.2/tasks/netbox_contact.yml
+++ b/tests/integration/targets/v4.2/tasks/netbox_contact.yml
@@ -140,4 +140,4 @@
 - name: 7 - ASSERT
   ansible.builtin.assert:
     that:
-      - "'contact_groups is not available in Netbox 4.2. Use contact_group instead, or upgrade to Netbox 4.3 or greater.' in test_seven['module_stderr']"
+      - "'contact_groups is not available in Netbox 4.2. Use contact_group instead, or upgrade to Netbox 4.3 or greater.' in test_seven['msg']"

--- a/tests/integration/targets/v4.2/tasks/netbox_inventory_item.yml
+++ b/tests/integration/targets/v4.2/tasks/netbox_inventory_item.yml
@@ -154,7 +154,7 @@
   ansible.builtin.assert:
     that:
       - test_six.failed
-      - test_six.msg == "Could not resolve id of inventory_item_role: Foo"
+      - 'test_six.msg == "Could not resolve id of inventory_item_role: Foo"'
 
 - name: "INVENTORY_ITEM 7: Create inventory item with component"
   netbox.netbox.netbox_inventory_item:
@@ -200,4 +200,4 @@
   ansible.builtin.assert:
     that:
       - test_eight.failed
-      - test_eight.msg == "parameters are required together: component_type, component"
+      - 'test_eight.msg == "parameters are required together: component_type, component"'

--- a/tests/integration/targets/v4.2/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v4.2/tasks/netbox_ip_address.yml
@@ -172,7 +172,7 @@
       - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
-      - test_eight['ip_address'].get('nat_inside')
+      - test_eight['ip_address'].get('nat_inside') is not none
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/v4.2/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.2/tasks/netbox_lookup.yml
@@ -6,20 +6,20 @@
 ##
 - name: "NETBOX_LOOKUP 1: Lookup returns exactly two sites"
   ansible.builtin.assert:
-    that: query_result == "3"
+    that: query_result | int == 3
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | count }}"
 
 - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   ansible.builtin.assert:
-    that: query_result == "0"
+    that: query_result | int == 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`Wibble`]')
       | count }}"
 
 - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`TestDeviceR1`]')
       | count }}"
@@ -61,14 +61,14 @@
 
 - name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       | community.general.json_query('[?value.display==`L2`]') | count }}"
 
 - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567',
       raw_data=True) | community.general.json_query('[?display==`L2`]') | count }}"

--- a/tests/integration/targets/v4.2/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.2/tasks/netbox_lookup.yml
@@ -84,7 +84,7 @@
 
 - name: "NETBOX_LOOKUP 10: Device query by ID"
   ansible.builtin.assert:
-    that: query_result
+    that: query_result | length > 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='id=1', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       }}"

--- a/tests/integration/targets/v4.3/tasks/netbox_contact.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_contact.yml
@@ -140,4 +140,4 @@
 - name: 7 - ASSERT
   ansible.builtin.assert:
     that:
-      - "'contact_group is not available in Netbox 4.3. Use contact_groups instead.' in test_seven['module_stderr']"
+      - "'contact_group is not available in Netbox 4.3. Use contact_groups instead.' in test_seven['msg']"

--- a/tests/integration/targets/v4.3/tasks/netbox_inventory_item.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_inventory_item.yml
@@ -154,7 +154,7 @@
   ansible.builtin.assert:
     that:
       - test_six.failed
-      - test_six.msg == "Could not resolve id of inventory_item_role: Foo"
+      - 'test_six.msg == "Could not resolve id of inventory_item_role: Foo"'
 
 - name: "INVENTORY_ITEM 7: Create inventory item with component"
   netbox.netbox.netbox_inventory_item:
@@ -200,4 +200,4 @@
   ansible.builtin.assert:
     that:
       - test_eight.failed
-      - test_eight.msg == "parameters are required together: component_type, component"
+      - 'test_eight.msg == "parameters are required together: component_type, component"'

--- a/tests/integration/targets/v4.3/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_ip_address.yml
@@ -172,7 +172,7 @@
       - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
-      - test_eight['ip_address'].get('nat_inside')
+      - test_eight['ip_address'].get('nat_inside') is not none
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/v4.3/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_lookup.yml
@@ -6,20 +6,20 @@
 ##
 - name: "NETBOX_LOOKUP 1: Lookup returns exactly four sites"
   ansible.builtin.assert:
-    that: query_result == "4"
+    that: query_result | int == 4
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | count }}"
 
 - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   ansible.builtin.assert:
-    that: query_result == "0"
+    that: query_result | int == 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`Wibble`]')
       | count }}"
 
 - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`TestDeviceR1`]')
       | count }}"
@@ -61,14 +61,14 @@
 
 - name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       | community.general.json_query('[?value.display==`L2`]') | count }}"
 
 - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567',
       raw_data=True) | community.general.json_query('[?display==`L2`]') | count }}"

--- a/tests/integration/targets/v4.3/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_lookup.yml
@@ -84,7 +84,7 @@
 
 - name: "NETBOX_LOOKUP 10: Device query by ID"
   ansible.builtin.assert:
-    that: query_result
+    that: query_result | length > 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='id=1', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       }}"

--- a/tests/integration/targets/v4.4/tasks/netbox_contact.yml
+++ b/tests/integration/targets/v4.4/tasks/netbox_contact.yml
@@ -140,4 +140,4 @@
 - name: 7 - ASSERT
   ansible.builtin.assert:
     that:
-      - "'contact_group is not available in Netbox 4.4. Use contact_groups instead.' in test_seven['module_stderr']"
+      - "'contact_group is not available in Netbox 4.4. Use contact_groups instead.' in test_seven['msg']"

--- a/tests/integration/targets/v4.4/tasks/netbox_inventory_item.yml
+++ b/tests/integration/targets/v4.4/tasks/netbox_inventory_item.yml
@@ -154,7 +154,7 @@
   ansible.builtin.assert:
     that:
       - test_six.failed
-      - test_six.msg == "Could not resolve id of inventory_item_role: Foo"
+      - 'test_six.msg == "Could not resolve id of inventory_item_role: Foo"'
 
 - name: "INVENTORY_ITEM 7: Create inventory item with component"
   netbox.netbox.netbox_inventory_item:
@@ -200,4 +200,4 @@
   ansible.builtin.assert:
     that:
       - test_eight.failed
-      - test_eight.msg == "parameters are required together: component_type, component"
+      - 'test_eight.msg == "parameters are required together: component_type, component"'

--- a/tests/integration/targets/v4.4/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v4.4/tasks/netbox_ip_address.yml
@@ -172,7 +172,7 @@
       - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
-      - test_eight['ip_address'].get('nat_inside')
+      - test_eight['ip_address'].get('nat_inside') is not none
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/v4.4/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.4/tasks/netbox_lookup.yml
@@ -6,20 +6,20 @@
 ##
 - name: "NETBOX_LOOKUP 1: Lookup returns exactly four sites"
   ansible.builtin.assert:
-    that: query_result == "4"
+    that: query_result | int == 4
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | count }}"
 
 - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   ansible.builtin.assert:
-    that: query_result == "0"
+    that: query_result | int == 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`Wibble`]')
       | count }}"
 
 - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567') | community.general.json_query('[?value.display==`TestDeviceR1`]')
       | count }}"
@@ -61,14 +61,14 @@
 
 - name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       | community.general.json_query('[?value.display==`L2`]') | count }}"
 
 - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567',
       raw_data=True) | community.general.json_query('[?display==`L2`]') | count }}"

--- a/tests/integration/targets/v4.4/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.4/tasks/netbox_lookup.yml
@@ -84,7 +84,7 @@
 
 - name: "NETBOX_LOOKUP 10: Device query by ID"
   ansible.builtin.assert:
-    that: query_result
+    that: query_result | length > 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='id=1', api_endpoint='http://localhost:32768', token='0123456789abcdef0123456789abcdef01234567')
       }}"

--- a/tests/integration/targets/v4.5/tasks/netbox_contact.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_contact.yml
@@ -140,4 +140,4 @@
 - name: 7 - ASSERT
   ansible.builtin.assert:
     that:
-      - "'contact_group is not available in Netbox 4.5. Use contact_groups instead.' in test_seven['module_stderr']"
+      - "'contact_group is not available in Netbox 4.5. Use contact_groups instead.' in test_seven['msg']"

--- a/tests/integration/targets/v4.5/tasks/netbox_inventory_item.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_inventory_item.yml
@@ -154,7 +154,7 @@
   ansible.builtin.assert:
     that:
       - test_six.failed
-      - test_six.msg == "Could not resolve id of inventory_item_role: Foo"
+      - 'test_six.msg == "Could not resolve id of inventory_item_role: Foo"'
 
 - name: "INVENTORY_ITEM 7: Create inventory item with component"
   netbox.netbox.netbox_inventory_item:
@@ -200,4 +200,4 @@
   ansible.builtin.assert:
     that:
       - test_eight.failed
-      - test_eight.msg == "parameters are required together: component_type, component"
+      - 'test_eight.msg == "parameters are required together: component_type, component"'

--- a/tests/integration/targets/v4.5/tasks/netbox_ip_address.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_ip_address.yml
@@ -172,7 +172,7 @@
       - test_eight['msg'] == "ip_address 10.10.1.30/16 created"
       - test_eight['ip_address']['address'] == "10.10.1.30/16"
       - test_eight['ip_address']['family'] == 4
-      - test_eight['ip_address'].get('nat_inside')
+      - test_eight['ip_address'].get('nat_inside') is not none
       - test_eight['ip_address']['vrf'] == 1
 
 - name: "9 - Create IP address on GigabitEthernet2 - test100 - State: present"

--- a/tests/integration/targets/v4.5/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_lookup.yml
@@ -10,20 +10,20 @@
 
 - name: "NETBOX_LOOKUP 1: Lookup returns exactly four sites"
   ansible.builtin.assert:
-    that: query_result == "4"
+    that: query_result | int == 4
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost:32768', token=netbox_token_v45) | count }}"
 
 - name: "NETBOX_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   ansible.builtin.assert:
-    that: query_result == "0"
+    that: query_result | int == 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token=netbox_token_v45) | community.general.json_query('[?value.display==`Wibble`]')
       | count }}"
 
 - name: "NETBOX_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_endpoint='http://localhost:32768', token=netbox_token_v45) | community.general.json_query('[?value.display==`TestDeviceR1`]')
       | count }}"
@@ -65,14 +65,14 @@
 
 - name: "NETBOX_LOOKUP 7: Device query returns exactly the L2 device"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token=netbox_token_v45)
       | community.general.json_query('[?value.display==`L2`]') | count }}"
 
 - name: "NETBOX_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   ansible.builtin.assert:
-    that: query_result == "1"
+    that: query_result | int == 1
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='role=core-switch tag=lookup', api_endpoint='http://localhost:32768', token=netbox_token_v45,
       raw_data=True) | community.general.json_query('[?display==`L2`]') | count }}"

--- a/tests/integration/targets/v4.5/tasks/netbox_lookup.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_lookup.yml
@@ -88,7 +88,7 @@
 
 - name: "NETBOX_LOOKUP 10: Device query by ID"
   ansible.builtin.assert:
-    that: query_result
+    that: query_result | length > 0
   vars:
     query_result: "{{ query('netbox.netbox.nb_lookup', 'devices', api_filter='id=1', api_endpoint='http://localhost:32768', token=netbox_token_v45)
       }}"


### PR DESCRIPTION
## Summary

ansible-core 2.19 introduces a major templating / data-tagging rewrite. The collection had not been validated against it, and if it were incompatible by the time Ansible 12 ships, the collection would risk exclusion from the Ansible package release. This PR wires 2.19 into CI and fixes the breakages that surfaced once the CI legs actually ran.

> **Heads-up for the merger:** the unit-test job names change shape (`unit_testing (3.11)` → `unit_testing (3.11, )` and `unit_testing (3.11, ==2.19.9)`). If branch protection has the old names pinned as required status checks, the required-checks list will need updating around merge time.

## Changes

### CI (`.github/workflows/main.yml`)
- `unit_testing`: add `ansible-core` as a second matrix dimension with values `["", "==2.19.9"]`. Cross-product = 6 legs (3 Pythons × {Poetry-resolved 2.18.x, pinned 2.19.9}).
- `integration_testing`: add one new combo (`v4.5 + ansible-core==2.19.9`) via `include:` — separate from existing entries because the integration matrix is `include:`-only, so each entry is a distinct combo.
- New `Override ansible-core version` step (both jobs): `pip install --upgrade "ansible-core==2.19.9"` when `matrix.ansible-core` is set; no-op otherwise.

### Source fix
- `plugins/module_utils/netbox_tenancy.py`: the NetBox-version compatibility gate (`contact_group` vs `contact_groups`, introduced in NetBox v4.3) now exits via `module.fail_json(msg=…)` instead of `raise Exception(…)`. Previously the error string ended up in `module_stderr` as a Python traceback; ansible-core 2.19 no longer populates `module_stderr` for module subprocess failures, so the message is now reported via `msg` on every supported ansible-core version.

### Test fixtures (six NetBox-version directories, v4.0–v4.5)
- `netbox_ip_address`: `.get('nat_inside')` → `… is not none` (non-bool conditional).
- `netbox_lookup`: count assertions cast to `| int` (2.19 preserves int type end-to-end).
- `netbox_lookup`: `that: query_result` → `that: query_result | length > 0` (list truthiness).
- `netbox_inventory_item`: assertions containing `": "` are now outer-single-quoted (YAML mapping vs string).
- `netbox_contact`: assert against `test_seven['msg']` instead of `test_seven['module_stderr']` (paired with the source fix above).

### Changelog
- `changelogs/fragments/int-236-ansible-core-219-ci.yml` — 1 `minor_changes` entry (CI) + 5 `bugfixes` entries.

## Strictness

The new ansible-core 2.19 legs are **required** (no `continue-on-error`) and pinned to `ansible-core==2.19.9` (current latest stable 2.19.x). The pin is deliberate, not tracking: future 2.19.x point releases won't auto-bump CI. Bump the pin when:
- A new 2.19.x point release lands and you want to evaluate it.
- A user reports a bug against a newer 2.19.x.
- 2.20 ships — bump 2.19 to its final 2.19.x at that point and add a 2.20 leg.

Rationale: tracking (`~=2.19.0`) would expose merges to upstream regressions in 2.19.x point releases. Pinning keeps the protection (we cannot ship a regression on the pinned version) without the noise.

## Test plan

- [x] Local reproduction on ansible-core 2.19.10 (from `stable-2.19`, Python 3.13.9, `ansible-test ... --docker`): sanity (23 tests) + units (229 tests) green.
- [x] Six iterative CI runs surfaced the porting work above; the final run (`ec1524c`) is fully green across all 13 legs — 6 unit, 6 integration including the new 2.19 leg.
- [x] 2.18 baseline legs stayed green through every iteration (the source fix in `netbox_tenancy.py` and all fixture edits work on both ansible-core versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
