### PR TITLE
Add netbox_contact_assignment to netbox action_groups

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -27,6 +27,7 @@ action_groups:
     - netbox_console_server_port
     - netbox_console_server_port_template
     - netbox_contact
+    - netbox_contact_assignment
     - netbox_contact_group
     - netbox_contact_role
     - netbox_custom_field


### PR DESCRIPTION
Add netbox_contact_assignment to netbox action_group in runtime.yml



## Related Issue
#1568

## New Behavior
Allow the netbox.netbox.netbox_contact_assignment module to consume netbox.netbox.netbox module_defaults.

...

## Contrast to Current Behavior
Currently, the netbox_contact_assignment module is missing from runtime.yml and therefore cannot use the module_defaults assigned to the group.  Adding netbox_contact_assignment to the netbox list allows the module to use the module_defaults like all the other modules in this collection. 

...

## Discussion: Benefits and Drawbacks
This is how all the other modules are handled, this was just missed when the module was added.

...

## Proposed Release Note Entry
Add netbox_contact_assignment to netbox action_group in runtime.yml

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
