### PR TITLE
fix(netbox_device_interface): persist legacy mac_address on NetBox v4.2+

### DIFF
--- a/changelogs/fragments/1502-device-interface-mac-address-readonly.yml
+++ b/changelogs/fragments/1502-device-interface-mac-address-readonly.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - >-
+    netbox_device_interface - the legacy ``mac_address`` option no longer reports a
+    phantom change every run on NetBox v4.2+ (where the field is read-only); its value is
+    now stored as the interface's ``primary_mac_address``
+    (https://github.com/netbox-community/ansible_modules/issues/1502).

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -111,6 +111,19 @@ class NetboxDcimModule(NetboxModule):
 
         data = self.data
 
+        # NetBox v4.2+ made the interface serializer's legacy `mac_address` field
+        # read-only, so it is silently dropped on write. Always pull it out of the
+        # payload here; translate it into the interface's primary MAC (after the
+        # interface is ensured below) only when an explicit `primary_mac_address` was
+        # not provided, so an explicit primary always wins.
+        legacy_mac_address = None
+        if self.endpoint == "interfaces" and self._version_check_greater(
+            self.api_version, "4.2", greater_or_equal=True
+        ):
+            popped_mac_address = data.pop("mac_address", None)
+            if popped_mac_address and not data.get("primary_mac_address"):
+                legacy_mac_address = popped_mac_address
+
         # Handle rack and form_factor
         if endpoint_name == "rack":
             if self._version_check_greater(
@@ -283,6 +296,10 @@ class NetboxDcimModule(NetboxModule):
 
         if self.state == "present":
             self._ensure_object_exists(nb_endpoint, endpoint_name, name, data)
+            if legacy_mac_address:
+                self._set_primary_mac_address(
+                    endpoint_name, name, legacy_mac_address, "dcim.interface"
+                )
 
         elif self.state == "absent":
             self._ensure_object_absent(endpoint_name, name)

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -837,6 +837,85 @@ class NetboxModule(object):
 
         return t_greater > t_lesser if not greater_or_equal else t_greater >= t_lesser
 
+    def _set_primary_mac_address(
+        self, endpoint_name, name, mac_address, assigned_object_type
+    ):
+        """Store a legacy ``mac_address`` as the interface's primary MAC.
+
+        Find or create a ``MACAddress`` assigned to the interface and set it as
+        ``primary_mac_address``. The interface's read-only ``mac_address`` mirrors its
+        primary MAC, so a re-run that already has the right primary makes no change.
+        Called after the interface is ensured, so ``self.nb_object`` is the interface.
+        """
+        mac_address = mac_address.upper()
+        # After an update with no field changes, _ensure_object_exists leaves
+        # self.nb_object as the serialized dict rather than a pynetbox Record.
+        nb_object = self.nb_object
+        serialized = nb_object if isinstance(nb_object, dict) else nb_object.serialize()
+
+        # The interface's read-only `mac_address` already reflects its primary MAC.
+        if serialized.get("mac_address") == mac_address:
+            return
+
+        if self.check_mode:
+            self._mark_changed_by_mac(endpoint_name, name)
+            return
+
+        interface_id = serialized["id"]
+        mac = self._find_or_create_mac_address(
+            mac_address, assigned_object_type, interface_id
+        )
+        app = assigned_object_type.split(".")[0]
+        nb_endpoint = getattr(getattr(self.nb, app), self.endpoint)
+        if serialized.get("primary_mac_address") != mac.id:
+            nb_endpoint.get(interface_id).update({"primary_mac_address": mac.id})
+        # Re-fetch so the returned object's read-only `mac_address` reflects the primary.
+        self.nb_object = nb_endpoint.get(interface_id)
+
+        before = (self.result.get("diff") or {}).get("before") or {}
+        after = (self.result.get("diff") or {}).get("after") or {}
+        self._mark_changed_by_mac(endpoint_name, name)
+        self.result["diff"] = self._build_diff(
+            before={
+                **before,
+                "primary_mac_address": serialized.get("primary_mac_address"),
+            },
+            after={**after, "primary_mac_address": mac.id, "mac_address": mac_address},
+        )
+
+    def _mark_changed_by_mac(self, endpoint_name, name):
+        """Flag the interface as changed by the MAC update, without clobbering a more
+        specific message already set by ``_ensure_object_exists`` (e.g. ``... created``).
+        """
+        self.result["changed"] = True
+        prior = self.result.get("msg", "")
+        if not prior or "already exists" in prior:
+            self.result["msg"] = "%s %s updated" % (endpoint_name, name)
+
+    def _find_or_create_mac_address(
+        self, mac_address, assigned_object_type, assigned_object_id
+    ):
+        """Return the MACAddress for ``mac_address`` assigned to the object, creating it
+        if needed. MAC addresses are not unique in NetBox v4.2+, so match on both the
+        address and the assigned object to stay idempotent.
+        """
+        for candidate in self.nb.dcim.mac_addresses.filter(mac_address=mac_address):
+            if (
+                str(candidate.assigned_object_type) == assigned_object_type
+                and candidate.assigned_object_id == assigned_object_id
+            ):
+                return candidate
+        try:
+            return self.nb.dcim.mac_addresses.create(
+                {
+                    "mac_address": mac_address,
+                    "assigned_object_type": assigned_object_type,
+                    "assigned_object_id": assigned_object_id,
+                }
+            )
+        except pynetbox.RequestError as e:
+            self._handle_errors(msg=e.error)
+
     def _connect_netbox_api(self, url, token, ssl_verify, cert, headers=None):
         try:
             session = requests.Session()

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -914,7 +914,9 @@ class NetboxModule(object):
                 }
             )
         except pynetbox.RequestError as e:
-            self._handle_errors(msg=e.error)
+            self._handle_errors(
+                msg=e.error or f"Failed to create MAC address {mac_address}"
+            )
 
     def _connect_netbox_api(self, url, token, ssl_verify, cert, headers=None):
         try:

--- a/plugins/modules/netbox_device_interface.py
+++ b/plugins/modules/netbox_device_interface.py
@@ -84,6 +84,7 @@ options:
       mac_address:
         description:
           - The MAC address of the interface
+          - On NetBox 4.2 and later this field is read-only; the value is stored as the interface's C(primary_mac_address).
         required: false
         type: str
       primary_mac_address:

--- a/tests/integration/targets/v4.2/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/v4.2/tasks/netbox_device_interface.yml
@@ -330,3 +330,57 @@
       - test_thirteen['interface']['name'] == "GigabitEthernet2"
       - test_thirteen['interface']['device'] == 1
       - test_thirteen['interface']['primary_mac_address'] == 2
+
+- name: "14 - Legacy mac_address sets the interface's primary MAC (NetBox v4.2+)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_fourteen
+
+- name: "14 - ASSERT - changed and the MAC is now the interface's primary"
+  ansible.builtin.assert:
+    that:
+      - test_fourteen is changed
+      - test_fourteen['interface']['mac_address'] == "DE:AD:BE:EF:00:14"
+      - test_fourteen['interface']['primary_mac_address'] is not none
+
+- name: "15 - Legacy mac_address again - idempotent (the #1502 phantom-change fix)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_fifteen
+
+- name: "15 - ASSERT - second run reports no change"
+  ansible.builtin.assert:
+    that:
+      - not test_fifteen['changed']
+
+- name: "16 - Legacy mac_address in check mode (already set) - no phantom change"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  check_mode: true
+  register: test_sixteen
+
+- name: "16 - ASSERT - check mode reports no phantom change"
+  ansible.builtin.assert:
+    that:
+      - not test_sixteen['changed']

--- a/tests/integration/targets/v4.3/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/v4.3/tasks/netbox_device_interface.yml
@@ -368,3 +368,57 @@
       - test_sixteen is changed
       - test_sixteen['interface']['name'] == "BridgeChild"
       - test_sixteen['interface']['bridge'] == test_fourteen['interface']['id']
+
+- name: "17 - Legacy mac_address sets the interface's primary MAC (NetBox v4.2+)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_seventeen
+
+- name: "17 - ASSERT - changed and the MAC is now the interface's primary"
+  ansible.builtin.assert:
+    that:
+      - test_seventeen is changed
+      - test_seventeen['interface']['mac_address'] == "DE:AD:BE:EF:00:14"
+      - test_seventeen['interface']['primary_mac_address'] is not none
+
+- name: "18 - Legacy mac_address again - idempotent (the #1502 phantom-change fix)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_eighteen
+
+- name: "18 - ASSERT - second run reports no change"
+  ansible.builtin.assert:
+    that:
+      - not test_eighteen['changed']
+
+- name: "19 - Legacy mac_address in check mode (already set) - no phantom change"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  check_mode: true
+  register: test_nineteen
+
+- name: "19 - ASSERT - check mode reports no phantom change"
+  ansible.builtin.assert:
+    that:
+      - not test_nineteen['changed']

--- a/tests/integration/targets/v4.4/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/v4.4/tasks/netbox_device_interface.yml
@@ -330,3 +330,57 @@
       - test_thirteen['interface']['name'] == "GigabitEthernet2"
       - test_thirteen['interface']['device'] == 1
       - test_thirteen['interface']['primary_mac_address'] == 2
+
+- name: "14 - Legacy mac_address sets the interface's primary MAC (NetBox v4.2+)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_fourteen
+
+- name: "14 - ASSERT - changed and the MAC is now the interface's primary"
+  ansible.builtin.assert:
+    that:
+      - test_fourteen is changed
+      - test_fourteen['interface']['mac_address'] == "DE:AD:BE:EF:00:14"
+      - test_fourteen['interface']['primary_mac_address'] is not none
+
+- name: "15 - Legacy mac_address again - idempotent (the #1502 phantom-change fix)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_fifteen
+
+- name: "15 - ASSERT - second run reports no change"
+  ansible.builtin.assert:
+    that:
+      - not test_fifteen['changed']
+
+- name: "16 - Legacy mac_address in check mode (already set) - no phantom change"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "0123456789abcdef0123456789abcdef01234567"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  check_mode: true
+  register: test_sixteen
+
+- name: "16 - ASSERT - check mode reports no phantom change"
+  ansible.builtin.assert:
+    that:
+      - not test_sixteen['changed']

--- a/tests/integration/targets/v4.5/tasks/netbox_device_interface.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_device_interface.yml
@@ -330,3 +330,57 @@
       - test_thirteen['interface']['name'] == "GigabitEthernet2"
       - test_thirteen['interface']['device'] == 1
       - test_thirteen['interface']['primary_mac_address'] == 2
+
+- name: "14 - Legacy mac_address sets the interface's primary MAC (NetBox v4.2+)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_fourteen
+
+- name: "14 - ASSERT - changed and the MAC is now the interface's primary"
+  ansible.builtin.assert:
+    that:
+      - test_fourteen is changed
+      - test_fourteen['interface']['mac_address'] == "DE:AD:BE:EF:00:14"
+      - test_fourteen['interface']['primary_mac_address'] is not none
+
+- name: "15 - Legacy mac_address again - idempotent (the #1502 phantom-change fix)"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  register: test_fifteen
+
+- name: "15 - ASSERT - second run reports no change"
+  ansible.builtin.assert:
+    that:
+      - not test_fifteen['changed']
+
+- name: "16 - Legacy mac_address in check mode (already set) - no phantom change"
+  netbox.netbox.netbox_device_interface:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      device: test100
+      name: MacLegacyIf
+      type: 1000Base-T (1GE)
+      mac_address: "DE:AD:BE:EF:00:14"
+    state: present
+  check_mode: true
+  register: test_sixteen
+
+- name: "16 - ASSERT - check mode reports no phantom change"
+  ansible.builtin.assert:
+    that:
+      - not test_sixteen['changed']

--- a/tests/unit/module_utils/netbox_utils/test_netbox_module.py
+++ b/tests/unit/module_utils/netbox_utils/test_netbox_module.py
@@ -459,3 +459,119 @@ def test_version_sanitize_value_error(mock_netbox_module, nb_obj_mock, version):
     mock_netbox_module.nb_object = nb_obj_mock
     with pytest.raises(ValueError):
         mock_netbox_module._version_sanitize(version)
+
+
+@pytest.mark.parametrize(
+    "check_mode, nb_object",
+    [
+        pytest.param(
+            False,
+            {"id": 5, "mac_address": "00:11:22:33:44:55"},
+            id="already-primary",
+        ),
+        pytest.param(
+            True,
+            {"id": 5, "mac_address": None, "primary_mac_address": None},
+            id="check-mode-predicts-change-no-write",
+        ),
+    ],
+)
+def test_set_primary_mac_address_no_write(mock_netbox_module, check_mode, nb_object):
+    """When the MAC is already the primary (or in check mode) no MACAddress is created
+    or assigned."""
+    mock_netbox_module.endpoint = "interfaces"
+    mock_netbox_module.check_mode = check_mode
+    mock_netbox_module.result = {"changed": False}
+    mock_netbox_module.nb_object = nb_object
+
+    mock_netbox_module._set_primary_mac_address(
+        "interface", "eth0", "00:11:22:33:44:55", "dcim.interface"
+    )
+
+    mock_netbox_module.nb.dcim.mac_addresses.create.assert_not_called()
+    # Idempotent already-primary makes no change; check mode predicts a change.
+    assert mock_netbox_module.result["changed"] is check_mode
+
+
+def test_set_primary_mac_address_creates_and_assigns(mocker, mock_netbox_module):
+    """A legacy mac_address with no matching MACAddress creates one assigned to the
+    interface and sets it as primary."""
+    mock_netbox_module.endpoint = "interfaces"
+    mock_netbox_module.check_mode = False
+    mock_netbox_module.result = {"changed": False}
+    mock_netbox_module.nb_object = {
+        "id": 5,
+        "mac_address": None,
+        "primary_mac_address": None,
+    }
+    mock_netbox_module.nb.dcim.mac_addresses.filter.return_value = []
+    created_mac = mocker.Mock()
+    created_mac.id = 99
+    mock_netbox_module.nb.dcim.mac_addresses.create.return_value = created_mac
+    interface_record = mocker.Mock()
+    mock_netbox_module.nb.dcim.interfaces.get.return_value = interface_record
+
+    mock_netbox_module._set_primary_mac_address(
+        "interface", "eth0", "00:11:22:33:44:55", "dcim.interface"
+    )
+
+    mock_netbox_module.nb.dcim.mac_addresses.create.assert_called_once_with(
+        {
+            "mac_address": "00:11:22:33:44:55",
+            "assigned_object_type": "dcim.interface",
+            "assigned_object_id": 5,
+        }
+    )
+    interface_record.update.assert_called_once_with({"primary_mac_address": 99})
+    assert mock_netbox_module.result["changed"] is True
+    assert mock_netbox_module.result["diff"]["after"]["mac_address"] == (
+        "00:11:22:33:44:55"
+    )
+
+
+def test_find_or_create_mac_address_reuses_existing(mocker, mock_netbox_module):
+    """An existing MACAddress with the same address already assigned to the interface is
+    reused rather than duplicated."""
+    existing = mocker.Mock()
+    existing.id = 7
+    existing.assigned_object_type = "dcim.interface"
+    existing.assigned_object_id = 5
+    mock_netbox_module.nb.dcim.mac_addresses.filter.return_value = [existing]
+
+    result = mock_netbox_module._find_or_create_mac_address(
+        "00:11:22:33:44:55", "dcim.interface", 5
+    )
+
+    assert result is existing
+    mock_netbox_module.nb.dcim.mac_addresses.create.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "prior_msg, expected_msg",
+    [
+        pytest.param(
+            "interface eth0 already exists",
+            "interface eth0 updated",
+            id="already-exists-becomes-updated",
+        ),
+        pytest.param(
+            "interface eth0 created",
+            "interface eth0 created",
+            id="created-preserved",
+        ),
+        pytest.param(None, "interface eth0 updated", id="no-prior-msg-becomes-updated"),
+    ],
+)
+def test_mark_changed_by_mac_keeps_specific_msg(
+    mock_netbox_module, prior_msg, expected_msg
+):
+    """Adding the primary MAC marks the interface changed but must not clobber a more
+    specific message (e.g. '... created') already set by _ensure_object_exists."""
+    mock_netbox_module.result = {"changed": False}
+    if prior_msg is not None:
+        mock_netbox_module.result["msg"] = prior_msg
+
+    mock_netbox_module._mark_changed_by_mac("interface", "eth0")
+
+    assert mock_netbox_module.result["changed"] is True
+    assert mock_netbox_module.result["msg"] == expected_msg


### PR DESCRIPTION
## Problem

On NetBox 4.2+, setting the legacy `mac_address` on `netbox_device_interface` reports `changed` on every run — including check mode — but stores nothing. NetBox 4.2 moved MACs to a standalone `MACAddress` model and made the interface field read-only, so the API silently drops the value and the module's local diff reappears forever. Users believe the MAC is in NetBox when it isn't.

## Solution

On NetBox 4.2+ the module now persists the value: it finds or creates a `MACAddress` assigned to the interface and sets it as the interface's `primary_mac_address`. Existing playbooks keep working, the task is idempotent, check mode reports a change only when one would really be made, and an explicitly supplied `primary_mac_address` always wins over the legacy field. NetBox < 4.2, where the field is still writable, is unchanged.

## Testing

Verified manually against a live NetBox 4.5.0: the first run creates exactly one assigned `MACAddress` and sets it primary; re-running the identical task reports no change and creates no duplicate; check mode writes nothing. Exercised both on an existing interface and when creating an interface with `mac_address` in a single task.

New unit tests cover the create-and-assign, reuse, already-primary, and check-mode paths. Integration plays for v4.2–v4.5 assert the MAC becomes primary, the second run is `ok`, and check mode reports no phantom change.

Fixes #1502
