### PR TITLE
fix(netbox_cable): make every termination type idempotent on re-runs

### DIFF
--- a/changelogs/fragments/int-412-netbox-cable-termination-idempotency.yml
+++ b/changelogs/fragments/int-412-netbox-cable-termination-idempotency.yml
@@ -1,0 +1,15 @@
+---
+bugfixes:
+  - >-
+    ``netbox_cable`` - re-running a play that connects a non-interface
+    termination no longer raises an exception and no longer reports a false
+    ``changed``. Existing terminations of every type (console, console-server,
+    power port/outlet/feed, front/rear port and circuit termination) are now
+    normalized to the same dotted content-type form as the supplied data, so
+    cables are idempotent for all termination types rather than only
+    ``dcim.interface``
+    (https://github.com/netbox-community/ansible_modules/issues/1274,
+    https://github.com/netbox-community/ansible_modules/issues/1015,
+    https://github.com/netbox-community/ansible_modules/issues/1040,
+    https://github.com/netbox-community/ansible_modules/issues/946,
+    https://github.com/netbox-community/ansible_modules/issues/1217).

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -74,7 +74,6 @@ API_APPS_ENDPOINTS = dict(
         "rack_groups": {},
         "rack_roles": {},
         "rear_ports": {},
-        "rear-ports": {},
         "rear_port_templates": {},
         "regions": {},
         "sites": {},
@@ -417,7 +416,6 @@ ENDPOINT_NAME_MAPPING = {
     "rack_groups": "rack_group",
     "rack_roles": "rack_role",
     "rear_ports": "rear_port",
-    "rear-ports": "rearport",
     "rear_port_templates": "rear_port_template",
     "regions": "region",
     "rirs": "rir",
@@ -1576,20 +1574,11 @@ class NetboxModule(object):
             and data.get("b_terminations")
             and version_post_33
         ):
-
-            def _convert_termination(termination):
-                object_app = self._find_app(termination.endpoint.name)
-                object_name = ENDPOINT_NAME_MAPPING[termination.endpoint.name]
-                return {
-                    "object_id": termination.id,
-                    "object_type": f"{object_app}.{object_name}",
-                }
-
             serialized_nb_obj["a_terminations"] = list(
-                map(_convert_termination, self.nb_object.a_terminations)
+                map(self._convert_termination, self.nb_object.a_terminations)
             )
             serialized_nb_obj["b_terminations"] = list(
-                map(_convert_termination, self.nb_object.b_terminations)
+                map(self._convert_termination, self.nb_object.b_terminations)
             )
 
         if serialized_nb_obj == updated_obj:
@@ -1621,6 +1610,54 @@ class NetboxModule(object):
 
             diff = self._build_diff(before=data_before, after=data_after)
             return updated_obj, diff
+
+    def _convert_termination(self, termination):
+        """Normalize an existing cable termination to the dotted content-type
+        form used on the user-supplied data side, e.g.
+        ``{"object_id": 1, "object_type": "dcim.powerport"}``.
+
+        pynetbox returns each existing termination in one of three shapes,
+        depending on its version and whether the termination's content type is
+        mapped in pynetbox's ``CONTENT_TYPE_MAPPER``:
+
+        * a plain ``dict`` (unmapped content type) carrying the generic
+          foreign-key keys ``object_type``/``object_id`` verbatim,
+        * a ``GenericListObject`` (pynetbox >= 7.5) exposing ``object_type``
+          and ``object_id`` attributes, or
+        * a bare ``Record`` (older pynetbox) whose content type was dropped,
+          leaving only the related object's own fields.
+
+        Both forms that already carry ``object_type`` are returned as-is so
+        every termination type stays idempotent on re-runs, not just
+        ``dcim.interface``.
+        """
+        if isinstance(termination, dict):
+            return {
+                "object_id": termination["object_id"],
+                "object_type": termination["object_type"],
+            }
+
+        # ``vars()`` is inspected directly so that a missing attribute does not
+        # trigger an extra detail request via older pynetbox ``Record.__getattr__``.
+        termination_attrs = vars(termination)
+        if "object_type" in termination_attrs:
+            return {
+                "object_id": termination_attrs["object_id"],
+                "object_type": termination_attrs["object_type"],
+            }
+
+        # Bare Record: rebuild the content type from the record's endpoint name.
+        # pynetbox derives that name from the record URL in dash form
+        # (e.g. ``power-ports``); normalize it to the underscore form used by the
+        # lookup maps, then collapse the singular to NetBox's separator-less
+        # model label (``power_port`` -> ``powerport``).
+        endpoint_name = termination.endpoint.name.replace("-", "_")
+        object_app = self._find_app(endpoint_name)
+        object_name = ENDPOINT_NAME_MAPPING[endpoint_name].replace("_", "")
+        return {
+            "object_id": termination.id,
+            "object_type": f"{object_app}.{object_name}",
+        }
 
     def _ensure_object_exists(self, nb_endpoint, endpoint_name, name, data):
         """Used when `state` is present to make sure object exists or if the object exists

--- a/tests/integration/targets/v4.5/tasks/netbox_cable.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_cable.yml
@@ -191,3 +191,55 @@
       - test_six['cable']['termination_b_type'] == "dcim.interface"
       - test_six['cable']['termination_b_id'] == 4
       - test_six['msg'] == "cable circuits.circuittermination 1 <> dcim.interface GigabitEthernet2 created"
+
+# Second-run idempotency for non-interface terminations (issue #1274 console,
+# #946/#1217 circuit termination). Before the fix these re-runs raised an
+# exception while rebuilding the existing termination's content type; they must
+# now report no change.
+- name: "CABLE 7: Console cable second run (idempotency #1274)"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      termination_a_type: dcim.consoleserverport
+      termination_a:
+        name: Console Server Port
+        device: test100
+      termination_b_type: dcim.consoleport
+      termination_b:
+        name: Console Port
+        device: test100
+    state: present
+  register: test_seven
+
+- name: "CABLE 7: ASSERT - Console cable second run is idempotent"
+  ansible.builtin.assert:
+    that:
+      - not test_seven['changed']
+      - test_seven['cable']['termination_a_type'] == "dcim.consoleserverport"
+      - test_seven['cable']['termination_b_type'] == "dcim.consoleport"
+      - test_seven['msg'] == "cable dcim.consoleserverport Console Server Port <> dcim.consoleport Console Port already exists"
+
+- name: "CABLE 8: Circuit termination cable second run (idempotency #946/#1217)"
+  netbox.netbox.netbox_cable:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      termination_a_type: circuits.circuittermination
+      termination_a:
+        circuit: Test Circuit Two
+        term_side: A
+      termination_b_type: dcim.interface
+      termination_b:
+        device: test100
+        name: GigabitEthernet2
+    state: present
+  register: test_eight
+
+- name: "CABLE 8: ASSERT - Circuit termination cable second run is idempotent"
+  ansible.builtin.assert:
+    that:
+      - not test_eight['changed']
+      - test_eight['cable']['termination_a_type'] == "circuits.circuittermination"
+      - test_eight['cable']['termination_b_type'] == "dcim.interface"
+      - "'already exists' in test_eight['msg']"

--- a/tests/unit/module_utils/netbox_utils/test_netbox_module.py
+++ b/tests/unit/module_utils/netbox_utils/test_netbox_module.py
@@ -10,6 +10,7 @@ __metaclass__ = type
 import re
 from functools import partial
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 import pytest
 
@@ -395,6 +396,168 @@ def test_update_netbox_object_with_changes_check_mode_true(
     nb_obj_mock.update.assert_not_called()
     assert serialized_obj == updated_serialized_obj
     assert diff == on_update_diff
+
+
+# Every cable termination type, keyed by the dash-form endpoint name pynetbox
+# derives from the record URL, mapped to the dotted content type the module
+# emits on the user-supplied data side.
+CABLE_TERMINATION_TYPES = [
+    pytest.param("interfaces", "dcim.interface", id="interface"),
+    pytest.param("console-ports", "dcim.consoleport", id="console_port"),
+    pytest.param(
+        "console-server-ports",
+        "dcim.consoleserverport",
+        id="console_server_port",
+    ),
+    pytest.param("front-ports", "dcim.frontport", id="front_port"),
+    pytest.param("rear-ports", "dcim.rearport", id="rear_port"),
+    pytest.param("power-ports", "dcim.powerport", id="power_port"),
+    pytest.param("power-outlets", "dcim.poweroutlet", id="power_outlet"),
+    pytest.param("power-feeds", "dcim.powerfeed", id="power_feed"),
+    pytest.param(
+        "circuit-terminations",
+        "circuits.circuittermination",
+        id="circuit_termination",
+    ),
+]
+
+
+class _FakeRecord:
+    """Stand-in for an older-pynetbox termination Record.
+
+    Real attributes live in ``__dict__``; any missing-attribute access would
+    hit the API via ``Record.__getattr__``, so accessing one here fails the
+    test - this guards that the conversion never probes for ``object_type``
+    with a plain attribute lookup.
+    """
+
+    def __init__(self, object_id, endpoint_name):
+        self.id = object_id
+        self.endpoint = SimpleNamespace(name=endpoint_name)
+        self.url = "http://netbox.local/api/dcim/%s/%d/" % (endpoint_name, object_id)
+
+    def __getattr__(self, item):
+        raise AssertionError(
+            "unexpected attribute access for %r would hit the API" % item
+        )
+
+
+@pytest.mark.parametrize("endpoint_name, expected_type", CABLE_TERMINATION_TYPES)
+def test_convert_termination_record(mock_netbox_module, endpoint_name, expected_type):
+    """A bare Record (content type dropped) is rebuilt from its endpoint."""
+    termination = _FakeRecord(7, endpoint_name)
+
+    assert mock_netbox_module._convert_termination(termination) == {
+        "object_id": 7,
+        "object_type": expected_type,
+    }
+
+
+@pytest.mark.parametrize("endpoint_name, object_type", CABLE_TERMINATION_TYPES)
+def test_convert_termination_plain_dict(mock_netbox_module, endpoint_name, object_type):
+    """An unparsed generic-foreign-key dict is passed through verbatim."""
+    termination = {
+        "object_id": 9,
+        "object_type": object_type,
+        "object": {"id": 9},
+    }
+
+    assert mock_netbox_module._convert_termination(termination) == {
+        "object_id": 9,
+        "object_type": object_type,
+    }
+
+
+@pytest.mark.parametrize("endpoint_name, object_type", CABLE_TERMINATION_TYPES)
+def test_convert_termination_generic_list_object(
+    mock_netbox_module, endpoint_name, object_type
+):
+    """A GenericListObject (pynetbox >= 7.5) already carries the content type."""
+    termination = SimpleNamespace(
+        object_id=3,
+        object_type=object_type,
+        object=SimpleNamespace(id=3),
+    )
+
+    assert mock_netbox_module._convert_termination(termination) == {
+        "object_id": 3,
+        "object_type": object_type,
+    }
+
+
+def _cable_nb_object(mocker, a_terminations, b_terminations, serialized):
+    nb_obj = mocker.Mock(name="cable_nb_obj")
+    nb_obj.a_terminations = a_terminations
+    nb_obj.b_terminations = b_terminations
+    nb_obj.serialize.return_value = serialized
+    return nb_obj
+
+
+def test_update_netbox_object_cable_non_interface_idempotent(
+    mocker, mock_netbox_module
+):
+    """A power-feed <> power-port cable re-run makes no change and no error.
+
+    Reproduces the second-run crash from issues #1040/#1274: the power feed
+    comes back as a plain dict and the power port as a dash-form Record.
+    """
+    mock_netbox_module.api_version = "4.4"
+    serialized = {
+        "a_terminations": [{"object_id": 1, "object_type": "dcim.powerfeed"}],
+        "b_terminations": [{"object_id": 2, "object_type": "dcim.powerport"}],
+        "status": "connected",
+    }
+    mock_netbox_module.nb_object = _cable_nb_object(
+        mocker,
+        a_terminations=[
+            {"object_id": 1, "object_type": "dcim.powerfeed", "object": {"id": 1}}
+        ],
+        b_terminations=[_FakeRecord(2, "power-ports")],
+        serialized=serialized,
+    )
+    data = {
+        "a_terminations": [{"object_id": 1, "object_type": "dcim.powerfeed"}],
+        "b_terminations": [{"object_id": 2, "object_type": "dcim.powerport"}],
+        "status": "connected",
+    }
+
+    serialized_obj, diff = mock_netbox_module._update_netbox_object(data)
+
+    mock_netbox_module.nb_object.update.assert_not_called()
+    assert diff is None
+    assert serialized_obj["a_terminations"] == data["a_terminations"]
+    assert serialized_obj["b_terminations"] == data["b_terminations"]
+
+
+def test_update_netbox_object_cable_detects_real_change(mocker, mock_netbox_module):
+    """A genuine field change on a non-interface cable still reports changed."""
+    mock_netbox_module.api_version = "4.4"
+    serialized = {
+        "a_terminations": [{"object_id": 1, "object_type": "dcim.powerfeed"}],
+        "b_terminations": [{"object_id": 2, "object_type": "dcim.powerport"}],
+        "status": "connected",
+    }
+    mock_netbox_module.nb_object = _cable_nb_object(
+        mocker,
+        a_terminations=[
+            {"object_id": 1, "object_type": "dcim.powerfeed", "object": {"id": 1}}
+        ],
+        b_terminations=[_FakeRecord(2, "power-ports")],
+        serialized=serialized,
+    )
+    data = {
+        "a_terminations": [{"object_id": 1, "object_type": "dcim.powerfeed"}],
+        "b_terminations": [{"object_id": 2, "object_type": "dcim.powerport"}],
+        "status": "planned",
+    }
+
+    serialized_obj, diff = mock_netbox_module._update_netbox_object(data)
+
+    mock_netbox_module.nb_object.update.assert_called_once_with(data)
+    assert diff == {
+        "before": {"status": "connected"},
+        "after": {"status": "planned"},
+    }
 
 
 @pytest.mark.parametrize("version", ["2.13", "2.12", "2.11", "2.10.8", "2.10"])


### PR DESCRIPTION
## Summary

Connecting a cable works, but re-running the same play raised an exception for **every** termination type except `dcim.interface` ↔ `dcim.interface`. Users had to delete cables before re-running their playbooks. This makes `netbox_cable` idempotent for all termination types — console, console-server, power port/outlet/feed, front/rear port and circuit termination — so a second run reports `ok` instead of crashing or falsely reporting a change.

## What was wrong

On update, the module rebuilt each existing termination's content type from pynetbox internals (`termination.endpoint.name`). That reconstruction failed in three independent ways:

- **Dash vs underscore.** pynetbox derives the endpoint name from the record URL in dash form (`power-ports`, `console-ports`, `circuit-terminations`), but the internal lookup maps are keyed in underscore form, so the lookup raised. `dcim.interface` was the only type that survived, because `interfaces` contains no dash — matching the reported "interface works, everything else fails" pattern.
- **Plain-dict terminations.** For some types pynetbox returns the termination as a plain dict with no `.endpoint` attribute, raising `AttributeError`.
- **Form mismatch.** Even when the lookup succeeded it produced `dcim.power_port`, which can never equal the user-supplied `dcim.powerport`, so the cable was reported as changed on every run.

A previous one-off fix had added a single dash-form key for rear ports only, papering over one endpoint at a time.

## What changed

- The termination normalizer now reads the content type directly when it is already present (plain dict or pynetbox `GenericListObject`), and otherwise rebuilds it from the record's endpoint, matching the dotted `app.model` form the module emits on the data side. This covers all termination types and is robust across pynetbox versions.
- The rear-ports dash-form band-aid is removed, since the general path now handles every endpoint.

## Tests

- Unit tests for the normalizer covering each termination type (console, console-server, front/rear port, power port/outlet/feed, interface, circuit termination) across the three shapes pynetbox can return, plus end-to-end checks that a non-interface cable re-run reports no change while a genuine field change is still detected.
- Integration assertions added for the second run of the console and circuit-termination cases.

Note: the `netbox_cable` integration target is currently disabled in the per-version `main.yml` (it predates the v4 task directories), so the integration assertions above are authored but not yet wired into a CI run; re-enabling and validating that target against current netbox-docker is best done as a follow-up. The unit suite is the executable regression guard for this fix.

Fixes #1274
Fixes #1015
Fixes #1040
Fixes #946
Fixes #1217
