### PR TITLE
Add netbox_rack_type module and rack_type option for netbox_rack

### DIFF
--- a/changelogs/fragments/add-netbox-rack-type-module.yml
+++ b/changelogs/fragments/add-netbox-rack-type-module.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - Added ``netbox_rack_type`` module to create, update or delete rack types
+    (``dcim.rack-types`` endpoint, requires NetBox v4.1+) (#1322).
+  - Added ``rack_type`` option to ``netbox_rack`` so racks can be associated
+    to a rack type and inherit its form factor and dimensions (#1450).
+  - Added ``rack-types`` endpoint to the ``nb_lookup`` plugin.

--- a/docs/module_utils/netbox_dcim/index.rst
+++ b/docs/module_utils/netbox_dcim/index.rst
@@ -29,6 +29,7 @@ Constants
 .. autodata:: plugins.module_utils.netbox_dcim.NB_RACKS
 .. autodata:: plugins.module_utils.netbox_dcim.NB_RACK_ROLES
 .. autodata:: plugins.module_utils.netbox_dcim.NB_RACK_GROUPS
+.. autodata:: plugins.module_utils.netbox_dcim.NB_RACK_TYPES
 .. autodata:: plugins.module_utils.netbox_dcim.NB_REAR_PORTS
 .. autodata:: plugins.module_utils.netbox_dcim.NB_REAR_PORT_TEMPLATES
 .. autodata:: plugins.module_utils.netbox_dcim.NB_REGIONS

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -71,6 +71,7 @@ action_groups:
     - netbox_rack
     - netbox_rack_group
     - netbox_rack_role
+    - netbox_rack_type
     - netbox_rear_port
     - netbox_rear_port_template
     - netbox_region

--- a/plugins/lookup/nb_lookup.py
+++ b/plugins/lookup/nb_lookup.py
@@ -247,6 +247,7 @@ def get_endpoint(netbox, term):
         "rack-groups": {"endpoint": netbox.dcim.rack_groups},
         "rack-reservations": {"endpoint": netbox.dcim.rack_reservations},
         "rack-roles": {"endpoint": netbox.dcim.rack_roles},
+        "rack-types": {"endpoint": netbox.dcim.rack_types},
         "racks": {"endpoint": netbox.dcim.racks},
         "rear-port-templates": {"endpoint": netbox.dcim.rear_port_templates},
         "rear-ports": {"endpoint": netbox.dcim.rear_ports},

--- a/plugins/module_utils/netbox_dcim.py
+++ b/plugins/module_utils/netbox_dcim.py
@@ -43,6 +43,7 @@ NB_POWER_PORT_TEMPLATES = "power_port_templates"
 NB_RACKS = "racks"
 NB_RACK_ROLES = "rack_roles"
 NB_RACK_GROUPS = "rack_groups"
+NB_RACK_TYPES = "rack_types"
 NB_REAR_PORTS = "rear_ports"
 NB_REAR_PORT_TEMPLATES = "rear_port_templates"
 NB_REGIONS = "regions"
@@ -94,6 +95,7 @@ class NetboxDcimModule(NetboxModule):
         - racks
         - rack_roles
         - rack_groups
+        - rack_types
         - rear_ports
         - rear_port_templates
         - regions

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -949,8 +949,9 @@ class NetboxModule(object):
         """
         temp_dict = dict()
         if self._version_check_greater(self.api_version, "2.7", greater_or_equal=True):
-            # Rack types (NetBox v4.1+) natively use form_factor; the legacy
-            # form_factor -> type conversion only applies to older endpoints.
+            # Endpoints such as interfaces expose NetBox's `type` field under
+            # the legacy `form_factor` name and need this rename. Rack types
+            # (NetBox v4.1+) use `form_factor` natively, so skip the rename.
             if data.get("form_factor") and self.endpoint != "rack_types":
                 temp_dict["type"] = data.pop("form_factor")
 

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -73,6 +73,7 @@ API_APPS_ENDPOINTS = dict(
         "racks": {},
         "rack_groups": {},
         "rack_roles": {},
+        "rack_types": {},
         "rear_ports": {},
         "rear-ports": {},
         "rear_port_templates": {},
@@ -206,6 +207,7 @@ QUERY_TYPES = dict(
     rack="name",
     rack_group="slug",
     rack_role="slug",
+    rack_type="slug",
     rear_port="name",
     rear_port_template="name",
     region="slug",
@@ -315,6 +317,7 @@ CONVERT_TO_ID = {
     "rack": "racks",
     "rack_group": "rack_groups",
     "rack_role": "rack_roles",
+    "rack_type": "rack_types",
     "region": "regions",
     "regions": "regions",
     "rear_port": "rear_ports",
@@ -416,6 +419,7 @@ ENDPOINT_NAME_MAPPING = {
     "racks": "rack",
     "rack_groups": "rack_group",
     "rack_roles": "rack_role",
+    "rack_types": "rack_type",
     "rear_ports": "rear_port",
     "rear-ports": "rearport",
     "rear_port_templates": "rear_port_template",
@@ -561,6 +565,7 @@ ALLOWED_QUERY_PARAMS = {
     "rack": set(["name", "site", "location"]),
     "rack_group": set(["slug"]),
     "rack_role": set(["slug"]),
+    "rack_type": set(["slug"]),
     "region": set(["slug"]),
     "rear_port": set(["name", "device"]),
     "rear_port_template": set(["name", "device_type"]),
@@ -710,6 +715,7 @@ SLUG_REQUIRED = {
     "locations",
     "rack_groups",
     "rack_roles",
+    "rack_types",
     "regions",
     "rirs",
     "roles",
@@ -943,7 +949,9 @@ class NetboxModule(object):
         """
         temp_dict = dict()
         if self._version_check_greater(self.api_version, "2.7", greater_or_equal=True):
-            if data.get("form_factor"):
+            # Rack types (NetBox v4.1+) natively use form_factor; the legacy
+            # form_factor -> type conversion only applies to older endpoints.
+            if data.get("form_factor") and self.endpoint != "rack_types":
                 temp_dict["type"] = data.pop("form_factor")
 
         for key in data:

--- a/plugins/modules/netbox_rack.py
+++ b/plugins/modules/netbox_rack.py
@@ -81,6 +81,13 @@ options:
           - Asset tag that is associated to the rack
         required: false
         type: str
+      rack_type:
+        description:
+          - The rack type the rack will be associated to (requires NetBox v4.1+)
+          - The rack will inherit the form factor, width, height and outer dimensions of the rack type
+        required: false
+        type: raw
+        version_added: "3.24.0"
       type:
         description:
           - The type of rack
@@ -277,6 +284,7 @@ def main():
                     rack_role=dict(required=False, type="raw"),
                     serial=dict(required=False, type="str"),
                     asset_tag=dict(required=False, type="str"),
+                    rack_type=dict(required=False, type="raw"),
                     type=dict(
                         required=False,
                         type="str",

--- a/plugins/modules/netbox_rack_type.py
+++ b/plugins/modules/netbox_rack_type.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2026, Jim Bartus (@jbartus) <jbartus@netboxlabs.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: netbox_rack_type
+short_description: Create, update or delete rack types within NetBox
+description:
+  - Creates, updates or removes rack types from NetBox
+notes:
+  - Tags should be defined as a YAML list
+  - This should be ran with connection C(local) and hosts C(localhost)
+  - Rack types require NetBox v4.1 or newer
+author:
+  - Jim Bartus (@jbartus)
+requirements:
+  - pynetbox
+version_added: '3.24.0'
+extends_documentation_fragment:
+  - netbox.netbox.common
+options:
+  data:
+    description:
+      - Defines the rack type configuration
+    suboptions:
+      manufacturer:
+        description:
+          - The manufacturer of the rack type
+        required: false
+        type: raw
+      model:
+        description:
+          - The model of the rack type
+        required: true
+        type: raw
+      slug:
+        description:
+          - The slug of the rack type. Must follow slug formatting (URL friendly)
+          - If not specified, it will slugify the model
+          - ex. test-rack-type
+        required: false
+        type: str
+      form_factor:
+        description:
+          - The form factor of the rack type
+        choices:
+          - 2-post-frame
+          - 4-post-frame
+          - 4-post-cabinet
+          - wall-frame
+          - wall-frame-vertical
+          - wall-cabinet
+          - wall-cabinet-vertical
+        required: false
+        type: str
+      width:
+        description:
+          - The rail-to-rail width
+        choices:
+          - 10
+          - 19
+          - 21
+          - 23
+        required: false
+        type: int
+      u_height:
+        description:
+          - The height of the rack type in rack units
+        required: false
+        type: int
+      starting_unit:
+        description:
+          - The lowest unit number of the rack type
+        required: false
+        type: int
+      desc_units:
+        description:
+          - Rack units will be numbered top-to-bottom
+        required: false
+        type: bool
+      outer_width:
+        description:
+          - The outer width of the rack type
+        required: false
+        type: int
+      outer_height:
+        description:
+          - The outer height of the rack type (requires NetBox v4.4+)
+        required: false
+        type: int
+      outer_depth:
+        description:
+          - The outer depth of the rack type
+        required: false
+        type: int
+      outer_unit:
+        description:
+          - Whether the outer dimensions are in Millimeters or Inches and is I(required) if outer dimensions are specified
+        choices:
+          - mm
+          - in
+        required: false
+        type: str
+      weight:
+        description:
+          - The weight of the rack type
+        required: false
+        type: float
+      max_weight:
+        description:
+          - Maximum load capacity of the rack type
+        required: false
+        type: int
+      weight_unit:
+        description:
+          - The weight unit
+        choices:
+          - kg
+          - g
+          - lb
+          - oz
+        required: false
+        type: str
+      mounting_depth:
+        description:
+          - The mounting depth of the rack type
+        required: false
+        type: int
+      description:
+        description:
+          - Description of the rack type
+        required: false
+        type: str
+      comments:
+        description:
+          - Comments that may include additional information in regards to the rack type
+        required: false
+        type: str
+      tags:
+        description:
+          - Any tags that the rack type may need to be associated with
+        required: false
+        type: list
+        elements: raw
+      custom_fields:
+        description:
+          - must exist in NetBox
+        required: false
+        type: dict
+    required: true
+    type: dict
+"""
+
+EXAMPLES = r"""
+- name: "Test NetBox modules"
+  connection: local
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Create rack type within NetBox with only required information
+      netbox.netbox.netbox_rack_type:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          model: Test Rack Type
+          manufacturer: Test Manufacturer
+        state: present
+
+    - name: Create rack type within NetBox with more information
+      netbox.netbox.netbox_rack_type:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          model: AR3350B2
+          manufacturer: APC
+          slug: ar3350b2
+          description: APC NetShelter SX Server Rack Gen 2
+          form_factor: 4-post-cabinet
+          u_height: 42
+          outer_width: 750
+          outer_depth: 1200
+          outer_unit: mm
+        state: present
+
+    - name: Delete rack type within netbox
+      netbox.netbox.netbox_rack_type:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          model: Test Rack Type
+        state: absent
+"""
+
+RETURN = r"""
+rack_type:
+  description: Serialized object as created or already existent within NetBox
+  returned: success (when I(state=present))
+  type: dict
+msg:
+  description: Message indicating failure or info about what has been achieved
+  returned: always
+  type: str
+"""
+
+from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import (
+    NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
+)
+from ansible_collections.netbox.netbox.plugins.module_utils.netbox_dcim import (
+    NetboxDcimModule,
+    NB_RACK_TYPES,
+)
+from copy import deepcopy
+
+
+def main():
+    """
+    Main entry point for module execution
+    """
+    argument_spec = deepcopy(NETBOX_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    manufacturer=dict(required=False, type="raw"),
+                    model=dict(required=True, type="raw"),
+                    slug=dict(required=False, type="str"),
+                    form_factor=dict(
+                        required=False,
+                        type="str",
+                        choices=[
+                            "2-post-frame",
+                            "4-post-frame",
+                            "4-post-cabinet",
+                            "wall-frame",
+                            "wall-frame-vertical",
+                            "wall-cabinet",
+                            "wall-cabinet-vertical",
+                        ],
+                    ),
+                    width=dict(
+                        required=False,
+                        type="int",
+                        choices=[10, 19, 21, 23],
+                    ),
+                    u_height=dict(required=False, type="int"),
+                    starting_unit=dict(required=False, type="int"),
+                    desc_units=dict(required=False, type="bool"),
+                    outer_width=dict(required=False, type="int"),
+                    outer_height=dict(required=False, type="int"),
+                    outer_depth=dict(required=False, type="int"),
+                    outer_unit=dict(
+                        required=False,
+                        type="str",
+                        choices=["mm", "in"],
+                    ),
+                    weight=dict(required=False, type="float"),
+                    max_weight=dict(required=False, type="int"),
+                    weight_unit=dict(
+                        required=False,
+                        type="str",
+                        choices=[
+                            "kg",
+                            "g",
+                            "lb",
+                            "oz",
+                        ],
+                    ),
+                    mounting_depth=dict(required=False, type="int"),
+                    description=dict(required=False, type="str"),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type="list", elements="raw"),
+                    custom_fields=dict(required=False, type="dict"),
+                ),
+            ),
+        )
+    )
+
+    required_if = [("state", "present", ["model"]), ("state", "absent", ["model"])]
+
+    module = NetboxAnsibleModule(
+        argument_spec=argument_spec, supports_check_mode=True, required_if=required_if
+    )
+
+    netbox_rack_type = NetboxDcimModule(module, NB_RACK_TYPES)
+    netbox_rack_type.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/integration/targets/v4.5/tasks/main.yml
+++ b/tests/integration/targets/v4.5/tasks/main.yml
@@ -134,6 +134,15 @@
   tags:
     - netbox_rack_role
 
+- name: NETBOX_RACK_TYPE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_rack_type.yml
+    apply:
+      tags:
+        - netbox_rack_type
+  tags:
+    - netbox_rack_type
+
 - name: NETBOX_LOCATION TESTS
   ansible.builtin.include_tasks:
     file: netbox_location.yml

--- a/tests/integration/targets/v4.5/tasks/netbox_rack_type.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_rack_type.yml
@@ -1,0 +1,186 @@
+---
+##
+##
+### NETBOX_RACK_TYPE
+##
+##
+- name: "RACK_TYPE 0: Resolve API token"
+  ansible.builtin.set_fact:
+    netbox_rack_type_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+
+- name: "RACK_TYPE 1: Necessary info creation"
+  netbox.netbox.netbox_rack_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      model: Test Rack Type
+      manufacturer: Test Manufacturer
+      form_factor: 4-post-cabinet
+    state: present
+  register: test_one
+
+- name: "RACK_TYPE 1: ASSERT - Necessary info creation"
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['rack_type']['model'] == "Test Rack Type"
+      - test_one['rack_type']['slug'] == "test-rack-type"
+      - test_one['rack_type']['form_factor'] == "4-post-cabinet"
+      - test_one['msg'] == "rack_type Test Rack Type created"
+
+- name: "RACK_TYPE 2: Create duplicate"
+  netbox.netbox.netbox_rack_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      model: Test Rack Type
+      manufacturer: Test Manufacturer
+      form_factor: 4-post-cabinet
+    state: present
+  register: test_two
+
+- name: "RACK_TYPE 2: ASSERT - Create duplicate"
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['rack_type']['model'] == "Test Rack Type"
+      - test_two['rack_type']['slug'] == "test-rack-type"
+      - test_two['msg'] == "rack_type Test Rack Type already exists"
+
+- name: "RACK_TYPE 3: Update"
+  netbox.netbox.netbox_rack_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      model: Test Rack Type
+      manufacturer: Test Manufacturer
+      form_factor: 4-post-cabinet
+      description: Test Rack Type description
+      u_height: 48
+      outer_width: 750
+      outer_depth: 1200
+      outer_unit: mm
+      weight_unit: kg
+      max_weight: 1000
+    state: present
+  register: test_three
+
+- name: "RACK_TYPE 3: ASSERT - Update"
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Test Rack Type description"
+      - test_three['rack_type']['model'] == "Test Rack Type"
+      - test_three['rack_type']['slug'] == "test-rack-type"
+      - test_three['rack_type']['description'] == "Test Rack Type description"
+      - test_three['rack_type']['u_height'] == 48
+      - test_three['rack_type']['outer_width'] == 750
+      - test_three['rack_type']['outer_depth'] == 1200
+      - test_three['rack_type']['outer_unit'] == "mm"
+      - test_three['rack_type']['weight_unit'] == "kg"
+      - test_three['rack_type']['max_weight'] == 1000
+      - test_three['msg'] == "rack_type Test Rack Type updated"
+
+- name: "RACK_TYPE 3.1: Update duplicate (idempotency)"
+  netbox.netbox.netbox_rack_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      model: Test Rack Type
+      manufacturer: Test Manufacturer
+      form_factor: 4-post-cabinet
+      description: Test Rack Type description
+      u_height: 48
+      outer_width: 750
+      outer_depth: 1200
+      outer_unit: mm
+      weight_unit: kg
+      max_weight: 1000
+    state: present
+  register: test_three_one
+
+- name: "RACK_TYPE 3.1: ASSERT - Update duplicate (idempotency)"
+  ansible.builtin.assert:
+    that:
+      - not test_three_one['changed']
+      - test_three_one['msg'] == "rack_type Test Rack Type already exists"
+
+- name: "RACK_TYPE 4: Create rack associated to the rack type"
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      name: Test Rack Type Rack
+      site: Test Site
+      rack_type: Test Rack Type
+    state: present
+  register: test_four
+
+- name: "RACK_TYPE 4: ASSERT - Create rack associated to the rack type"
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['rack']['name'] == "Test Rack Type Rack"
+      - test_four['rack']['rack_type'] == test_one['rack_type']['id']
+      - test_four['rack']['form_factor'] == "4-post-cabinet"
+      - test_four['rack']['u_height'] == 48
+      - test_four['msg'] == "rack Test Rack Type Rack created"
+
+- name: "RACK_TYPE 5: ASSERT - Lookup rack type via nb_lookup"
+  ansible.builtin.assert:
+    that:
+      - lookup_result | count == 1
+      - (lookup_result | first)['value']['model'] == "Test Rack Type"
+  vars:
+    lookup_result: "{{ query('netbox.netbox.nb_lookup', 'rack-types', api_endpoint='http://localhost:32768', token=netbox_rack_type_token, api_filter='slug=test-rack-type')
+      }}"
+
+- name: "RACK_TYPE 6: Delete rack"
+  netbox.netbox.netbox_rack:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      name: Test Rack Type Rack
+      site: Test Site
+    state: absent
+  register: test_six
+
+- name: "RACK_TYPE 6: ASSERT - Delete rack"
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+      - test_six['msg'] == "rack Test Rack Type Rack deleted"
+
+- name: "RACK_TYPE 7: Delete"
+  netbox.netbox.netbox_rack_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      model: Test Rack Type
+    state: absent
+  register: test_seven
+
+- name: "RACK_TYPE 7: ASSERT - Delete"
+  ansible.builtin.assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "present"
+      - test_seven['diff']['after']['state'] == "absent"
+      - test_seven['msg'] == "rack_type Test Rack Type deleted"
+
+- name: "RACK_TYPE 7.1: Delete duplicate (idempotency)"
+  netbox.netbox.netbox_rack_type:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ netbox_rack_type_token }}"
+    data:
+      model: Test Rack Type
+    state: absent
+  register: test_seven_one
+
+- name: "RACK_TYPE 7.1: ASSERT - Delete duplicate (idempotency)"
+  ansible.builtin.assert:
+    that:
+      - not test_seven_one['changed']
+      - test_seven_one['msg'] == "rack_type Test Rack Type already absent"

--- a/tests/unit/module_utils/netbox_utils/test_netbox_module.py
+++ b/tests/unit/module_utils/netbox_utils/test_netbox_module.py
@@ -247,6 +247,17 @@ def test_change_choices_id(mocker, mock_netbox_module, endpoint, data, expected)
     assert new_data == expected
 
 
+def test_convert_identical_keys_form_factor(mock_netbox_module):
+    data = {"model": "Test Rack Type", "form_factor": "4-post-cabinet"}
+
+    converted = mock_netbox_module._convert_identical_keys(dict(data))
+    assert converted == {"model": "Test Rack Type", "type": "4-post-cabinet"}
+
+    mock_netbox_module.endpoint = "rack_types"
+    converted = mock_netbox_module._convert_identical_keys(dict(data))
+    assert converted == data
+
+
 @pytest.mark.parametrize(
     "parent, module_data, expected",
     load_relative_test_data("build_query_params_no_child"),

--- a/tests/unit/module_utils/test_data/netbox_utils/build_query_params_no_child.json
+++ b/tests/unit/module_utils/test_data/netbox_utils/build_query_params_no_child.json
@@ -244,6 +244,16 @@
         }
     },
     {
+        "parent": "rack_type",
+        "module_data": {
+            "model": "Test Rack Type",
+            "slug": "test-rack-type"
+        },
+        "expected": {
+            "slug": "test-rack-type"
+        }
+    },
+    {
         "parent": "region",
         "module_data": {
             "name": "Test Region",

--- a/tests/unit/module_utils/test_data/netbox_utils/find_app.json
+++ b/tests/unit/module_utils/test_data/netbox_utils/find_app.json
@@ -52,6 +52,10 @@
         "app": "dcim"
     },
     {
+        "endpoint": "rack_types",
+        "app": "dcim"
+    },
+    {
         "endpoint": "regions",
         "app": "dcim"
     },

--- a/tests/unit/module_utils/test_data/netbox_utils/normalize_data.json
+++ b/tests/unit/module_utils/test_data/netbox_utils/normalize_data.json
@@ -193,6 +193,14 @@
     },
     {
         "before": {
+            "rack_type": "Test Rack Type"
+        },
+        "after": {
+            "rack_type": "test-rack-type"
+        }
+    },
+    {
+        "before": {
             "region": "Test Region_1"
         },
         "after": {


### PR DESCRIPTION
## New Behavior
  
  - New `netbox_rack_type` module to create/update/delete rack types (`dcim.rack-types`, NetBox v4.1+).
  - New `rack_type` option on `netbox_rack` to associate a rack with a type.
  - New `rack-types` endpoint in `nb_lookup`.

  ## Contrast to Current Behavior
  
  Rack types can't be managed through the collection today (only via raw `uri` tasks). Includes a one-line fix in `_convert_identical_keys()` so the `form_factor`→`type` legacy conversion skips the `rack_types` endpoint, which uses `form_factor` natively; covered by a unit test.

  ## Discussion: Benefits and Drawbacks
  
  Fills a NetBox 4.1 gap. Backwards-compatible. Tested end-to-end against NetBox v4.5 plus unit/integration tests.

  ## Changes to the Documentation
  
  Adds the `NB_RACK_TYPES` autodata entry.

  ## Proposed Release Note Entry
  
  Added `netbox_rack_type` module, a `rack_type` option on `netbox_rack`, and a `rack-types` endpoint in `nb_lookup`.

  ## Double Check
  
  * [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
  * [x] I have explained my PR according to the information in the comments or in a linked issue.
  * [x] My PR targets the `devel` branch.
