### PR TITLE
Template nb_inventory headers

### DIFF
--- a/changelogs/fragments/1526-nb-inventory-templated-headers.yml
+++ b/changelogs/fragments/1526-nb-inventory-templated-headers.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - >-
+    nb_inventory - Template configured headers before applying them, allowing
+    values such as ``X-NetBox-Branch`` to be rendered for NetBox Branching
+    inventory workflows
+    (https://github.com/netbox-community/ansible_modules/issues/1526).

--- a/docs/plugins/nb_inventory_inventory.rst
+++ b/docs/plugins/nb_inventory_inventory.rst
@@ -1198,6 +1198,8 @@ Parameters
 
       Dictionary of headers to be passed to the NetBox API.
 
+      Header values may use Jinja2 templates.
+
 
       .. rst-class:: ansible-option-line
 
@@ -2636,6 +2638,7 @@ Examples
       - tenant__n: internal
     headers:
       Cookie: "{{ auth_cookie }}"
+      X-NetBox-Branch: "{{ lookup('ansible.builtin.env', 'NETBOX_BRANCH_ID') }}"
 
     # has_primary_ip is a useful way to filter out patch panels and other passive devices
     # Adding '__n' to a field searches for the negation of the value.

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -265,7 +265,9 @@ DOCUMENTATION = """
                 - If set, sets the inventory hostname from this field in custom_fields instead
             default: False
         headers:
-            description: Dictionary of headers to be passed to the NetBox API.
+            description:
+                - Dictionary of headers to be passed to the NetBox API.
+                - Header values may use Jinja2 templates.
             default: {}
             env:
                 - name: NETBOX_HEADERS
@@ -288,6 +290,7 @@ device_query_filters:
   - tenant__n: internal
 headers:
   Cookie: "{{ auth_cookie }}"
+  X-NetBox-Branch: "{{ lookup('ansible.builtin.env', 'NETBOX_BRANCH_ID') }}"
 
 # has_primary_ip is a useful way to filter out patch panels and other passive devices
 # Adding '__n' to a field searches for the negation of the value.
@@ -2149,6 +2152,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self.headers.update({"Authorization": "Token %s" % token})
         headers = self.get_option("headers")
         if headers:
+            if version.parse(ansible_version) >= version.parse("2.11"):
+                self.templar.available_variables = self._vars
+                headers = self.templar.template(headers, fail_on_undefined=False)
             if isinstance(headers, str):
                 headers = json.loads(headers)
             if isinstance(headers, dict):

--- a/tests/unit/inventory/test_nb_inventory.py
+++ b/tests/unit/inventory/test_nb_inventory.py
@@ -248,6 +248,10 @@ def test_fetch_api_docs(inventory_fixture, netbox_ver):
 
 def test_new_token(inventory_fixture, templar_fixture):
     mock_get_option = Mock()
+    mock_get_option.side_effect = lambda option: {
+        "token": {"type": "foo", "value": "bar"},
+        "headers": None,
+    }[option]
 
     mock_templar_template_token = Mock()
     mock_templar_template_token.return_value = {"type": "foo", "value": "bar"}
@@ -263,6 +267,57 @@ def test_new_token(inventory_fixture, templar_fixture):
 
     assert "Authorization" in inventory_fixture.headers
     assert inventory_fixture.headers["Authorization"] == "Foo bar"
+
+
+def test_headers_are_templated(inventory_fixture, templar_fixture):
+    raw_headers = {
+        "X-NetBox-Branch": "{{ lookup('ansible.builtin.env', 'NETBOX_BRANCH_ID') }}",
+        "X-Test-Header": "static",
+    }
+    rendered_headers = {
+        "X-NetBox-Branch": "branch-schema-id",
+        "X-Test-Header": "static",
+    }
+
+    def template(value, fail_on_undefined=False):
+        if value == raw_headers:
+            return rendered_headers
+        return value
+
+    inventory_fixture.templar = templar_fixture
+    inventory_fixture.templar.template = Mock(side_effect=template)
+    inventory_fixture.get_option = Mock(
+        side_effect=lambda option: {"token": None, "headers": raw_headers}[option]
+    )
+    inventory_fixture.headers = {}
+
+    inventory_fixture._set_authorization()
+
+    assert inventory_fixture.headers["X-NetBox-Branch"] == "branch-schema-id"
+    assert inventory_fixture.headers["X-Test-Header"] == "static"
+
+
+def test_header_string_is_templated_before_json_decode(
+    inventory_fixture, templar_fixture
+):
+    raw_headers = '{"X-NetBox-Branch": "{{ branch_id }}"}'
+    rendered_headers = '{"X-NetBox-Branch": "branch-schema-id"}'
+
+    def template(value, fail_on_undefined=False):
+        if value == raw_headers:
+            return rendered_headers
+        return value
+
+    inventory_fixture.templar = templar_fixture
+    inventory_fixture.templar.template = Mock(side_effect=template)
+    inventory_fixture.get_option = Mock(
+        side_effect=lambda option: {"token": None, "headers": raw_headers}[option]
+    )
+    inventory_fixture.headers = {}
+
+    inventory_fixture._set_authorization()
+
+    assert inventory_fixture.headers["X-NetBox-Branch"] == "branch-schema-id"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Template `nb_inventory` headers before they are added to the request headers.

This keeps the existing `NETBOX_HEADERS` JSON-string path working and allows values such as `X-NetBox-Branch` to be rendered from Jinja.

Fixes #1526.

## Testing

- `/tmp/netbox-ansible-test-venv/bin/python -m pytest -q tests/unit/inventory/test_nb_inventory.py`
- `/tmp/netbox-ansible-test-venv/bin/python -m pytest -q tests/unit`
- `/tmp/netbox-ansible-test-venv/bin/python -m py_compile plugins/inventory/nb_inventory.py tests/unit/inventory/test_nb_inventory.py`
