### PR TITLE
Fix VLAN group lookup query

### DIFF
--- a/changelogs/fragments/1570-vlan-group-lookup.yml
+++ b/changelogs/fragments/1570-vlan-group-lookup.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    netbox_prefix - Resolve VLAN group scoping for nested VLAN lookups with
+    ``group_id`` so same-named VLANs can be disambiguated by group
+    (https://github.com/netbox-community/ansible_modules/issues/1570).

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -1069,7 +1069,18 @@ class NetboxModule(object):
             matches = query_params.intersection(set(module_data.keys()))
 
         for match in matches:
-            if match in QUERY_PARAMS_IDS:
+            if parent in (
+                "tagged_vlans",
+                "untagged_vlan",
+                "vlan",
+            ) and match in ("group", "vlan_group"):
+                data = child if child else module_data
+                if match == "group":
+                    data = {"vlan_group": data[match]}
+
+                query_id = self._get_query_param_id("vlan_group", data)
+                query_dict.update({"group_id": query_id})
+            elif match in QUERY_PARAMS_IDS:
                 if child:
                     query_id = self._get_query_param_id(match, child)
                 else:

--- a/tests/integration/targets/regression-v4.5/tasks/main.yml
+++ b/tests/integration/targets/regression-v4.5/tasks/main.yml
@@ -299,3 +299,49 @@
   ansible.builtin.assert:
     that:
       - test_results['interface']['primary_mac_address'] == 3
+
+- name: "Issue #1570 - Create VLAN in first group"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      name: Issue 1570 VLAN
+      vid: 1570
+      site: Test Site
+      tenant: Test Tenant
+      vlan_group: Test Vlan Group
+    state: present
+  register: issue_1570_vlan_group_1
+
+- name: "Issue #1570 - Create VLAN in second group"
+  netbox.netbox.netbox_vlan:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      name: Issue 1570 VLAN
+      vid: 1570
+      site: Test Site
+      tenant: Test Tenant
+      vlan_group: Test Vlan Group 2
+    state: present
+  register: issue_1570_vlan_group_2
+
+- name: "Issue #1570 - Create prefix with nested VLAN group lookup"
+  netbox.netbox.netbox_prefix:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      prefix: 10.254.157.0/24
+      vlan:
+        name: Issue 1570 VLAN
+        site: Test Site
+        tenant: Test Tenant
+        vlan_group: Test Vlan Group 2
+    state: present
+  register: issue_1570_prefix
+
+- name: "ASSERT Issue #1570"
+  ansible.builtin.assert:
+    that:
+      - issue_1570_vlan_group_1.vlan.id != issue_1570_vlan_group_2.vlan.id
+      - issue_1570_prefix.prefix.vlan == issue_1570_vlan_group_2.vlan.id

--- a/tests/unit/module_utils/test_data/netbox_utils/build_query_params_child.json
+++ b/tests/unit/module_utils/test_data/netbox_utils/build_query_params_child.json
@@ -156,7 +156,35 @@
             "site_id": 1,
             "tenant_id": 1,
             "vid": 1,
-            "group": "Test VLAN group"
+            "group_id": 1
+        }
+    },
+    {
+        "parent": "vlan",
+        "module_data": {
+            "prefix": "10.10.10.0/24",
+            "description": "Test Prefix",
+            "vlan": {
+                "name": "Test VLAN",
+                "site": "Test Site",
+                "tenant": "Test Tenant",
+                "vid": 1,
+                "group": "test-vlan-group"
+            }
+        },
+        "child": {
+            "name": "Test VLAN",
+            "site": "Test Site",
+            "tenant": "Test Tenant",
+            "vid": 1,
+            "group": "test-vlan-group"
+        },
+        "expected": {
+            "name": "Test VLAN",
+            "site_id": 1,
+            "tenant_id": 1,
+            "vid": 1,
+            "group_id": 1
         }
     },
     {


### PR DESCRIPTION
## Summary

Resolve VLAN group scoping for nested VLAN lookups with `group_id`.

This covers the documented `vlan_group` key and avoids resolving the VLAN API's `group` filter through the generic tenant-group mapping.

Fixes #1570.

## Testing

- `/tmp/netbox-ansible-test-venv/bin/python -m pytest -q tests/unit/module_utils/netbox_utils/test_netbox_module.py::test_build_query_params_child`
- `/tmp/netbox-ansible-test-venv/bin/python -m pytest -q tests/unit`
- `/tmp/netbox-ansible-test-venv/bin/python -m py_compile plugins/module_utils/netbox_utils.py tests/unit/module_utils/netbox_utils/test_netbox_module.py`
- `PATH=/tmp/netbox-ansible-test-venv/bin:$PATH COLLECTION_TMP_DIR=/tmp/test-collections-pr1584 ./hacking/integration-test.sh regression-v4.5` against NetBox Docker v4.5.10