### PR TITLE
fix(nb_inventory): create site groups when group_by contains only site_group

### DIFF
--- a/changelogs/fragments/fix-group-by-site-group-only.yml
+++ b/changelogs/fragments/fix-group-by-site-group-only.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - >-
+    nb_inventory - fixed ``AttributeError: 'InventoryModule' object has no
+    attribute 'site_group_names'`` when ``group_by`` contains ``site_group``
+    without also containing ``site``, ``location`` or ``region``. The check
+    that triggers site group creation looked up ``site`` twice instead of
+    ``site_group``
+    (https://github.com/netbox-community/ansible_modules/issues/1528,
+    https://github.com/netbox-community/ansible_modules/issues/1357).

--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -2064,7 +2064,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # - the location groups are added as sub-groups of sites
         # So, we need to make sure we're also grouping by sites if regions or locations are enabled
         site_group_by = self._pluralize_group_by("site")
-        site_group_group_by = self._pluralize_group_by("site")
+        site_group_group_by = self._pluralize_group_by("site_group")
         if (
             site_group_by in self.group_by
             or "location" in self.group_by


### PR DESCRIPTION
## Summary

Fixes the long-standing `AttributeError: 'InventoryModule' object has no attribute 'site_group_names'` that occurs when `group_by` contains `site_group` without also containing `site`, `location` or `region`.

Fixes #1528
Fixes #1357

## Root cause

In `main()`, the gate that decides whether to call `_add_site_groups()` computes `site_group_group_by` from `"site"` instead of `"site_group"` (a copy-paste of the line above it):

```python
site_group_by = self._pluralize_group_by("site")
site_group_group_by = self._pluralize_group_by("site")   # <-- should be "site_group"
if (
    site_group_by in self.group_by
    or "location" in self.group_by
    or "region" in self.group_by
    or site_group_group_by in self.group_by
):
    self._add_site_groups()
```

With `group_by: [site_group]` alone, none of the four conditions match, so `_add_site_groups()` never runs and `self.site_group_names` is never created. `_add_site_group_groups()` *does* run (since `site_group` is in `group_by`) and dereferences `self.site_group_names[site_id]`, crashing as soon as any site is assigned to a site group.

The same helper call is already done correctly in `add_host_to_groups()`:

```python
site_group_group_by = self._pluralize_group_by("site_group")
```

The common workaround (adding `region` to `group_by` alongside `site_group`) works because `"region" in self.group_by` forces `_add_site_groups()` to run.

## Testing

- Reproduced before the fix by driving `main()` with mocked lookup data and `group_by: [site_group]`: crashes with the exact `AttributeError` from the issues. After the fix, the site group hierarchy is created correctly (`site_group_<slug>` → `site_<slug>` → hosts).
- `tests/unit/inventory/`: 35 passed.
