### PR TITLE
feat(inventory): add nb_inventory_graphql plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/_build/*
 
 # https://github.com/ansible/ansible/issues/68499
 # ansible_collections/
+collections/ansible_collections/netbox/netbox

--- a/changelogs/fragments/nb-inventory-graphql-plugin.yml
+++ b/changelogs/fragments/nb-inventory-graphql-plugin.yml
@@ -1,0 +1,14 @@
+---
+minor_changes:
+  - >-
+    Added the ``nb_inventory_graphql`` inventory plugin, a GraphQL-based alternative to
+    ``nb_inventory``. Instead of a fixed set of REST-derived options, it is configured through
+    user-supplied ``sources`` (arbitrary ``.graphql`` query files plus a JSON ``list_path`` into
+    the response) and the standard ``constructed`` fragment (``compose``, ``groups``,
+    ``keyed_groups``) for all grouping and derived variables, so it has no built-in knowledge of
+    the NetBox schema and needs no new options as NetBox's GraphQL schema grows.
+  - >-
+    Added the ``any_attribute_equals`` Jinja test, a small NetBox-agnostic helper for
+    ``nb_inventory_graphql`` ``compose`` expressions that need to cross-reference two independent
+    nested lists against each other (for example, finding the interface that owns a device's
+    primary IP), which plain ``selectattr`` cannot express.

--- a/examples/nb_inventory_graphql/netbox_graphql.yml
+++ b/examples/nb_inventory_graphql/netbox_graphql.yml
@@ -1,0 +1,18 @@
+# Minimal starter config for nb_inventory_graphql: id, name, and primary IPs for both VMs and
+# devices. Copy this whole examples/nb_inventory_graphql/ directory into your own inventory
+# location and extend queries/*.graphql with whatever additional fields you need - the plugin
+# turns every field you select into a host variable automatically, no option changes required.
+plugin: netbox.netbox.nb_inventory_graphql
+api_endpoint: "{{ lookup('env', 'NETBOX_API') }}"
+token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
+ansible_host_dns_name: true
+
+sources:
+  - name: vms
+    query_file: queries/virtual_machines.graphql
+    list_path: virtual_machine_list
+    hostname: "{{ name }}"
+  - name: devices
+    query_file: queries/devices.graphql
+    list_path: device_list
+    hostname: "{{ name }}"

--- a/examples/nb_inventory_graphql/queries/devices.graphql
+++ b/examples/nb_inventory_graphql/queries/devices.graphql
@@ -1,0 +1,8 @@
+query ($pagination: OffsetPaginationInput) {
+  device_list(pagination: $pagination) {
+    id
+    name
+    primary_ip4 { address dns_name }
+    primary_ip6 { address dns_name }
+  }
+}

--- a/examples/nb_inventory_graphql/queries/virtual_machines.graphql
+++ b/examples/nb_inventory_graphql/queries/virtual_machines.graphql
@@ -1,0 +1,8 @@
+query ($pagination: OffsetPaginationInput) {
+  virtual_machine_list(pagination: $pagination) {
+    id
+    name
+    primary_ip4 { address dns_name }
+    primary_ip6 { address dns_name }
+  }
+}

--- a/plugins/inventory/nb_inventory_graphql.py
+++ b/plugins/inventory/nb_inventory_graphql.py
@@ -1,0 +1,463 @@
+# Copyright (c) 2026 Mikulas Willaschek
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+    name: nb_inventory_graphql
+    author:
+      - Mikulas Willaschek
+    short_description: Generic NetBox inventory source using the GraphQL API
+    description:
+      - Builds an Ansible inventory from one or more user-defined GraphQL queries against a
+        NetBox instance ("sources"). The plugin has no built-in knowledge of the NetBox schema;
+        it sends whatever query a source points to, walks the response to a list of objects, and
+        turns each object into a host. All fields of an object become host variables verbatim.
+      - Grouping and derived host variables are handled entirely through the standard Ansible
+        C(constructed) fragment (C(compose), C(groups), C(keyed_groups)) rather than
+        plugin-specific options — this is what makes the plugin generic across VMs, devices, or
+        any other NetBox object type without requiring new Python code or options per type.
+      - Nested data (services, interfaces, IP addresses, ...) is resolved server-side by
+        GraphQL, so no client-side joining of separately fetched endpoints takes place.
+      - C(sources[].query_file) is required — this plugin does not ship a default query. Minimal
+        starter queries for virtual machines and devices (C(id), C(name), C(primary_ip4),
+        C(primary_ip6)) are shipped under C(examples/nb_inventory_graphql/) in this collection;
+        copy and extend them for anything more.
+      - Targets NetBox 4.6.5. No version branching is performed.
+    extends_documentation_fragment:
+      - ansible.builtin.constructed
+      - ansible.builtin.inventory_cache
+    options:
+      plugin:
+        description: Token that ensures this is a source file for the C(nb_inventory_graphql) plugin.
+        required: true
+        choices: ["netbox.netbox.nb_inventory_graphql"]
+        type: str
+      api_endpoint:
+        description: Root URL of the NetBox instance. The GraphQL endpoint is derived as C(<api_endpoint>/graphql/).
+        required: true
+        type: str
+        env:
+          - name: NETBOX_API
+      token:
+        description:
+          - NetBox API token.
+          - May be a plain string, which is sent as header C(Authorization) with value C(Token <value>).
+          - May also be a dictionary with the keys C(type) and C(value), which is sent as
+            header C(Authorization) with value C(<Type> <value>) to support Bearer or OAuth tokens.
+        required: false
+        type: raw
+        env:
+          - name: NETBOX_TOKEN
+          - name: NETBOX_API_KEY
+      validate_certs:
+        description: Whether to validate the TLS certificate of the NetBox instance.
+        default: true
+        type: boolean
+      cert:
+        description: Path to a client certificate used for mutual TLS.
+        type: path
+      key:
+        description: Path to the private key belonging to I(cert).
+        type: path
+      ca_path:
+        description: Path to a CA bundle used to validate the NetBox certificate.
+        type: path
+      follow_redirects:
+        description: How to handle HTTP redirects returned by NetBox.
+        default: urllib2
+        choices: ["urllib2", "all", "yes", "safe", "none"]
+        type: str
+      timeout:
+        description: Timeout in seconds for the GraphQL request.
+        default: 60
+        type: int
+      headers:
+        description:
+          - Additional HTTP headers merged into the request after the authorization header.
+          - Useful for example to select a branch with C(X-NetBox-Branch).
+        default: {}
+        type: dict
+        env:
+          - name: NETBOX_HEADERS
+      ansible_host_dns_name:
+        description:
+          - Use the DNS name of the primary IP as C(ansible_host) instead of the IP itself.
+          - Falls back to the IP address when the primary IP has no DNS name.
+          - Kept as an explicit, dedicated option rather than expressed through C(compose)
+            because C(ansible_host) is security-relevant (it is the SSH connection target) and
+            the fallback chain (DNS name, then IPv4, then IPv6, then unset) is intricate enough
+            to warrant a small, directly testable Python function over a Jinja expression. It can
+            still be overridden per-host via C(compose).
+          - Only takes effect for objects whose GraphQL selection includes a C(primary_ip4) and/or
+            C(primary_ip6) field shaped as C({address, dns_name}), matching NetBox's own schema.
+        default: false
+        type: boolean
+      sources:
+        description:
+          - One or more independent GraphQL queries. Every source is fetched with its own HTTP
+            request(s) (paginated, see O(sources[].list_path)) and every element found in it
+            becomes one inventory host.
+          - If two sources produce the same hostname, the source that runs later in the list wins
+            (its fields overwrite same-named fields from the earlier source) and a warning is
+            emitted — sources are not merged silently.
+        required: true
+        type: list
+        elements: dict
+        version_added: "3.24.0"
+        options:
+          name:
+            description: Unique label for this source, used in error messages and warnings only.
+            required: true
+            type: str
+          query_file:
+            description:
+              - Path to a C(.graphql) file containing the query to run.
+              - Relative paths are resolved against the directory of the inventory configuration
+                file (not the current working directory).
+              - The query SHOULD declare and use a C($pagination) variable of type
+                C(OffsetPaginationInput) on its top-level list field so the plugin can paginate
+                large result sets; if it does not, NetBox silently ignores the extra variable and
+                only the server's default page is returned.
+            required: true
+            type: path
+          list_path:
+            description:
+              - Dotted path to the list of objects inside the GraphQL response's C(data) object,
+                for example C(virtual_machine_list) or C(nested.list_field).
+              - This is a plain, recursive dictionary lookup — not a query language of its own.
+            required: true
+            type: str
+          hostname:
+            description:
+              - Jinja2 template evaluated against each raw object from O(sources[].list_path) to
+                produce the inventory hostname.
+              - Falls back to a random UUID if the template renders empty, matching how NetBox
+                itself allows unnamed devices.
+            required: true
+            type: str
+          variables:
+            description:
+              - GraphQL query variables, passed through to the request unmodified (in addition to
+                the pagination variable the plugin injects itself).
+            default: {}
+            type: dict
+"""
+
+EXAMPLES = r"""
+# --- (a) Minimal example: one source, no grouping -------------------------------------------
+# See examples/nb_inventory_graphql/ in this collection for ready-to-copy starter files
+# (netbox_graphql.yml + queries/virtual_machines.graphql + queries/devices.graphql).
+plugin: netbox.netbox.nb_inventory_graphql
+api_endpoint: "{{ lookup('env', 'NETBOX_API') }}"
+token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
+sources:
+  - name: vms
+    query_file: queries/virtual_machines.graphql
+    list_path: virtual_machine_list
+    hostname: "{{ name }}"
+
+# --- (b) group by service name and by status --------------------------------------------------
+plugin: netbox.netbox.nb_inventory_graphql
+api_endpoint: "{{ lookup('env', 'NETBOX_API') }}"
+token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
+ansible_host_dns_name: true
+sources:
+  - name: vms
+    query_file: queries/virtual_machines.graphql
+    list_path: virtual_machine_list
+    hostname: "{{ name }}"
+keyed_groups:
+  - key: services | map(attribute='name') | list
+    prefix: service
+  - key: status
+    prefix: status
+
+# --- (c) compose reference cases -------------------------------------------------------------
+plugin: netbox.netbox.nb_inventory_graphql
+api_endpoint: "{{ lookup('env', 'NETBOX_API') }}"
+token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
+sources:
+  - name: vms
+    query_file: queries/virtual_machines.graphql
+    list_path: virtual_machine_list
+    hostname: "{{ name }}"
+compose:
+  # Use case 1: "first element matching a condition" — pure standard Jinja, no plugin support needed.
+  n8n_service: >-
+    services | selectattr('name', 'equalto', 'n8n') | list | first | default(omit)
+  # Use case 2: cross-referencing two independent nested structures against each other (which
+  # interface owns the primary IP?) — selectattr can only compare against a fixed value, not
+  # recurse into another variable's nested list, so this needs the any_attribute_equals test
+  # shipped alongside this plugin.
+  primary_interface: >-
+    interfaces
+    | selectattr('ip_addresses', 'any_attribute_equals', 'address', primary_ip4.address)
+    | first | default(omit)
+
+# --- (d) two sources: VMs and devices in one inventory ---------------------------------------
+plugin: netbox.netbox.nb_inventory_graphql
+api_endpoint: "{{ lookup('env', 'NETBOX_API') }}"
+token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
+sources:
+  - name: vms
+    query_file: queries/virtual_machines.graphql
+    list_path: virtual_machine_list
+    hostname: "{{ name }}"
+  - name: devices
+    query_file: queries/devices.graphql
+    list_path: device_list
+    hostname: "{{ name }}"
+groups:
+  netbox_devices: "device_type is defined"
+"""
+
+import json
+import os
+import uuid
+from ipaddress import ip_interface
+from urllib.error import HTTPError, URLError
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.module_utils.urls import open_url
+from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, Constructable
+
+# NetBox's MAX_PAGE_SIZE for this deployment. Sent as an explicit pagination argument on every
+# request; a server-side default limit could not be determined empirically (see the PR description
+# for the verification performed against a live NetBox 4.6.5 instance).
+PAGE_SIZE = 1000
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+    NAME = "nb_inventory_graphql"
+
+    def verify_file(self, path):
+        if not super(InventoryModule, self).verify_file(path):
+            return False
+        return path.endswith((".yml", ".yaml"))
+
+    def _set_authorization(self):
+        """Build the request headers. Never log their content — they carry the token."""
+        self.headers = {"Content-Type": "application/json"}
+
+        self.templar.available_variables = self._vars
+        token = self.templar.template(self.get_option("token"), fail_on_undefined=False)
+        if token:
+            if isinstance(token, dict):
+                self.headers["Authorization"] = "%s %s" % (
+                    token["type"].capitalize(),
+                    token["value"],
+                )
+            else:
+                self.headers["Authorization"] = "Token %s" % token
+
+        headers = self.get_option("headers")
+        if isinstance(headers, str):
+            headers = json.loads(headers)
+        if headers:
+            self.headers.update(headers)
+
+    def _post_graphql(self, query, variables):
+        """Issue one POST request and return the GraphQL 'data' object."""
+        body = json.dumps({"query": query, "variables": variables})
+        try:
+            response = open_url(
+                self.graphql_url,
+                data=body,
+                method="POST",
+                headers=self.headers,
+                timeout=self.get_option("timeout"),
+                validate_certs=self.get_option("validate_certs"),
+                follow_redirects=self.get_option("follow_redirects"),
+                client_cert=self.get_option("cert"),
+                client_key=self.get_option("key"),
+                ca_path=self.get_option("ca_path"),
+            )
+        except HTTPError as e:
+            if e.code == 401:
+                raise AnsibleError(
+                    "nb_inventory_graphql: HTTP 401 Unauthorized. "
+                    "The 'token' option is missing or invalid."
+                )
+            if e.code == 403:
+                raise AnsibleError(
+                    "nb_inventory_graphql: HTTP 403 Forbidden. "
+                    "The token does not have permission to read the GraphQL API."
+                )
+            raise AnsibleError(
+                "nb_inventory_graphql: HTTP %s from %s: %s"
+                % (e.code, self.graphql_url, to_native(e.read()))
+            )
+        except URLError as e:
+            raise AnsibleError(
+                "nb_inventory_graphql: could not reach %s: %s. Consider raising the 'timeout' option."
+                % (self.graphql_url, to_native(e.reason))
+            )
+
+        try:
+            raw = to_text(response.read(), errors="surrogate_or_strict")
+        except UnicodeError:
+            raise AnsibleError(
+                "nb_inventory_graphql: incorrect encoding of the response from NetBox."
+            )
+
+        try:
+            payload = json.loads(raw)
+        except ValueError:
+            raise AnsibleError(
+                "nb_inventory_graphql: NetBox did not return JSON from %s. This usually means no "
+                "valid token was supplied and NetBox redirected to its login page."
+                % self.graphql_url
+            )
+
+        errors = payload.get("errors")
+        data = payload.get("data")
+        if errors:
+            messages = "; ".join(err.get("message", str(err)) for err in errors)
+            if not data:
+                raise AnsibleError(
+                    "nb_inventory_graphql: GraphQL errors: %s" % messages
+                )
+            self.display.warning(
+                "nb_inventory_graphql: partial GraphQL errors: %s" % messages
+            )
+
+        return data or {}
+
+    def _resolve_query_path(self, query_file):
+        if os.path.isabs(query_file):
+            return query_file
+        return os.path.join(self._inventory_dir, query_file)
+
+    def _read_query_file(self, query_file):
+        path = self._resolve_query_path(query_file)
+        try:
+            return self.loader.get_text_file_contents(path)
+        except AnsibleError as e:
+            raise AnsibleError(
+                "nb_inventory_graphql: could not read query_file '%s' ('%s'): %s"
+                % (query_file, path, to_native(e))
+            )
+
+    @staticmethod
+    def _resolve_list_path(data, list_path, source_name):
+        """Walk a dotted path into the GraphQL 'data' object."""
+        node = data
+        for segment in list_path.split("."):
+            if not isinstance(node, dict) or segment not in node:
+                raise AnsibleError(
+                    "nb_inventory_graphql: source '%s': list_path '%s' not found in the response. "
+                    "Available top-level keys: %s."
+                    % (source_name, list_path, sorted(data.keys()))
+                )
+            node = node[segment]
+        if not isinstance(node, list):
+            raise AnsibleError(
+                "nb_inventory_graphql: source '%s': list_path '%s' does not resolve to a list (got %s)."
+                % (source_name, list_path, type(node).__name__)
+            )
+        return node
+
+    def _fetch_source_elements(self, source):
+        """Fetch all objects of one source, paginating defensively until a short page is seen."""
+        query = self._read_query_file(source["query_file"])
+        base_variables = source.get("variables") or {}
+        elements = []
+        offset = 0
+        while True:
+            variables = dict(
+                base_variables, pagination={"offset": offset, "limit": PAGE_SIZE}
+            )
+            data = self._post_graphql(query, variables)
+            page = self._resolve_list_path(data, source["list_path"], source["name"])
+            elements.extend(page)
+            if len(page) < PAGE_SIZE:
+                break
+            offset += PAGE_SIZE
+        return elements
+
+    @staticmethod
+    def _extract_ip(ip_object):
+        """Strip the prefix length off a NetBox address field, e.g. '10.0.0.1/24' -> '10.0.0.1'."""
+        if not ip_object or not ip_object.get("address"):
+            return None
+        return str(ip_interface(ip_object["address"]).ip)
+
+    def _derive_ansible_host(self, element, hostname):
+        """ansible_host stays explicit Python, not Jinja — see the option's docstring for why."""
+        primary_ip = element.get("primary_ip4") or element.get("primary_ip6")
+        if not primary_ip:
+            return
+
+        address = self._extract_ip(primary_ip)
+        if address:
+            self.inventory.set_variable(hostname, "ansible_host", address)
+
+        if self.get_option("ansible_host_dns_name"):
+            dns_name = primary_ip.get("dns_name")
+            if dns_name:
+                self.inventory.set_variable(hostname, "ansible_host", dns_name)
+
+    def _render_hostname(self, template, element):
+        self.templar.available_variables = element
+        hostname = self.templar.template(template, fail_on_undefined=False)
+        return hostname or str(uuid.uuid4())
+
+    def _populate_host_from_element(self, source, element, seen_hosts):
+        """Turn one raw GraphQL object into a host: dump fields, derive ansible_host, then run the
+        standard Constructable hooks against the resulting host variables."""
+        hostname = self._render_hostname(source["hostname"], element)
+
+        previous_source = seen_hosts.get(hostname)
+        if previous_source is not None and previous_source != source["name"]:
+            self.display.warning(
+                "nb_inventory_graphql: host '%s' from source '%s' overwrites data previously set "
+                "by source '%s'." % (hostname, source["name"], previous_source)
+            )
+        seen_hosts[hostname] = source["name"]
+
+        self.inventory.add_host(host=hostname)
+        for key, value in element.items():
+            self.inventory.set_variable(hostname, key, value)
+        self._derive_ansible_host(element, hostname)
+
+        host_vars = self.inventory.get_host(hostname).get_vars()
+        strict = self.get_option("strict")
+        self._set_composite_vars(
+            self.get_option("compose"), host_vars, hostname, strict=strict
+        )
+        self._add_host_to_composed_groups(
+            self.get_option("groups"), host_vars, hostname, strict=strict
+        )
+        self._add_host_to_keyed_groups(
+            self.get_option("keyed_groups"), host_vars, hostname, strict=strict
+        )
+
+    def parse(self, inventory, loader, path, cache=True):
+        super(InventoryModule, self).parse(inventory, loader, path)
+        self._read_config_data(path)
+        self._inventory_dir = os.path.dirname(os.path.abspath(path))
+
+        # TODO: cache each source's GraphQL result under get_cache_key(endpoint + query + variables).
+        self.use_cache = cache
+        if self.get_option("cache"):
+            self.display.warning(
+                "nb_inventory_graphql: the 'cache' option has no effect yet, caching is not implemented."
+            )
+
+        api_endpoint = self.templar.template(
+            self.get_option("api_endpoint"), fail_on_undefined=False
+        )
+        if not api_endpoint:
+            raise AnsibleError("nb_inventory_graphql: 'api_endpoint' is required.")
+        self.graphql_url = "%s/graphql/" % api_endpoint.rstrip("/")
+
+        self._set_authorization()
+
+        seen_hosts = {}
+        for source in self.get_option("sources"):
+            for element in self._fetch_source_elements(source):
+                self._populate_host_from_element(source, element, seen_hosts)

--- a/plugins/test/any_attribute_equals.py
+++ b/plugins/test/any_attribute_equals.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Mikulas Willaschek
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+def _resolve_attribute(item, attribute_path):
+    node = item
+    for part in attribute_path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def any_attribute_equals(items, attribute_path, value):
+    if not items:
+        return False
+    return any(_resolve_attribute(item, attribute_path) == value for item in items)
+
+
+class TestModule(object):
+    def tests(self):
+        return {"any_attribute_equals": any_attribute_equals}

--- a/plugins/test/any_attribute_equals.yml
+++ b/plugins/test/any_attribute_equals.yml
@@ -1,0 +1,46 @@
+DOCUMENTATION:
+  name: any_attribute_equals
+  author: Mikulas Willaschek
+  short_description: Does any item in a list have an attribute equal to a value
+  description:
+    - Checks whether at least one element of a list has a given, optionally dotted, attribute
+      path equal to a given value.
+    - Intended for cross-referencing two independent nested structures against each other in a
+      C(compose) expression, e.g. matching an interface's IP addresses against a device's primary
+      IP — a case C(selectattr) alone cannot express because it only compares an item's attribute
+      against a fixed value, not against another variable's nested list.
+    - Strictly generic; it has no knowledge of NetBox or any other data source.
+  options:
+    _input:
+      description: The list of items to search. A falsy value (V(none), empty list) yields V(false).
+      type: list
+      required: true
+    attribute_path:
+      description: Dotted attribute path to look up on each item, for example C(address) or C(a.b.c).
+      type: string
+      required: true
+    value:
+      description: >-
+        The value to compare each resolved attribute against. Items where the path does not
+        resolve (missing key at any level) never match and do not raise an error.
+      type: raw
+      required: true
+EXAMPLES: |
+  interfaces:
+    - name: eth0
+      ip_addresses:
+        - address: 10.0.0.1/24
+    - name: eth1
+      ip_addresses: []
+  primary_ip4:
+    address: 10.0.0.1/24
+
+  # -> the eth0 dict
+  primary_interface: >-
+    interfaces
+    | selectattr('ip_addresses', 'any_attribute_equals', 'address', primary_ip4.address)
+    | first | default(omit)
+RETURN:
+  _value:
+    description: V(true) if at least one item's attribute matches, V(false) otherwise.
+    type: boolean

--- a/tests/unit/inventory/fixtures/nb_inventory_graphql/devices.json
+++ b/tests/unit/inventory/fixtures/nb_inventory_graphql/devices.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "device_list": [
+      {
+        "id": "2",
+        "name": "host-01",
+        "status": "active",
+        "primary_ip4": { "address": "192.0.2.43/24", "dns_name": "host-01.example.com" },
+        "primary_ip6": null,
+        "role": { "name": "Hypervisor Node", "slug": "hypervisor-node" },
+        "device_type": { "model": "Server Model 1", "manufacturer": { "name": "Generic Vendor" } }
+      }
+    ]
+  }
+}

--- a/tests/unit/inventory/fixtures/nb_inventory_graphql/empty.json
+++ b/tests/unit/inventory/fixtures/nb_inventory_graphql/empty.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "virtual_machine_list": []
+  }
+}

--- a/tests/unit/inventory/fixtures/nb_inventory_graphql/errors_fatal.json
+++ b/tests/unit/inventory/fixtures/nb_inventory_graphql/errors_fatal.json
@@ -1,0 +1,9 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Cannot query field 'bogus_field' on type 'VirtualMachineType'.",
+      "locations": [{ "line": 1, "column": 34 }]
+    }
+  ]
+}

--- a/tests/unit/inventory/fixtures/nb_inventory_graphql/errors_partial.json
+++ b/tests/unit/inventory/fixtures/nb_inventory_graphql/errors_partial.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "virtual_machine_list": [
+      {
+        "id": "1",
+        "name": "prod-vm-01",
+        "status": "active",
+        "primary_ip4": { "address": "192.0.2.198/24", "dns_name": "prod-vm-01" },
+        "primary_ip6": null,
+        "services": [],
+        "interfaces": []
+      }
+    ]
+  },
+  "errors": [
+    {
+      "message": "You do not have permission to access field 'custom_fields' on 'VirtualMachineType'."
+    }
+  ]
+}

--- a/tests/unit/inventory/fixtures/nb_inventory_graphql/queries/devices.graphql
+++ b/tests/unit/inventory/fixtures/nb_inventory_graphql/queries/devices.graphql
@@ -1,0 +1,6 @@
+query ($pagination: OffsetPaginationInput) {
+  device_list(pagination: $pagination) {
+    id
+    name
+  }
+}

--- a/tests/unit/inventory/fixtures/nb_inventory_graphql/queries/vms.graphql
+++ b/tests/unit/inventory/fixtures/nb_inventory_graphql/queries/vms.graphql
@@ -1,0 +1,6 @@
+query ($pagination: OffsetPaginationInput) {
+  virtual_machine_list(pagination: $pagination) {
+    id
+    name
+  }
+}

--- a/tests/unit/inventory/fixtures/nb_inventory_graphql/standard.json
+++ b/tests/unit/inventory/fixtures/nb_inventory_graphql/standard.json
@@ -1,0 +1,83 @@
+{
+  "data": {
+    "virtual_machine_list": [
+      {
+        "id": "3",
+        "name": "app-vm-01",
+        "status": "offline",
+        "primary_ip4": { "address": "192.0.2.73/24", "dns_name": "app-vm-01" },
+        "primary_ip6": null,
+        "services": [
+          { "id": "1", "name": "web", "protocol": "tcp", "ports": [3000], "description": "" },
+          { "id": "2", "name": "api", "protocol": "tcp", "ports": [8000], "description": "" }
+        ],
+        "interfaces": [
+          {
+            "id": "3",
+            "name": "ens18",
+            "enabled": true,
+            "mtu": null,
+            "mac_address": "52:54:00:12:34:41",
+            "tags": [{ "slug": "vm-tag" }],
+            "ip_addresses": [
+              { "id": "10", "address": "192.0.2.73/24", "dns_name": "app-vm-01", "status": "active" },
+              { "id": "11", "address": "2001:db8:1::73/64", "dns_name": "app-vm-01", "status": "active" },
+              { "id": "12", "address": "fd00:1::73/64", "dns_name": "app-vm-01", "status": "active" }
+            ]
+          },
+          {
+            "id": "4",
+            "name": "net0",
+            "enabled": true,
+            "mtu": null,
+            "mac_address": "52:54:00:12:34:41",
+            "tags": [{ "slug": "vm-tag" }],
+            "ip_addresses": []
+          }
+        ]
+      },
+      {
+        "id": "1",
+        "name": "prod-vm-01",
+        "status": "active",
+        "primary_ip4": { "address": "192.0.2.198/24", "dns_name": "prod-vm-01" },
+        "primary_ip6": { "address": "2001:db8:1::198/64", "dns_name": "prod-vm-01" },
+        "services": [],
+        "interfaces": [
+          {
+            "id": "1",
+            "name": "ens18",
+            "enabled": true,
+            "mtu": null,
+            "mac_address": "52:54:00:12:34:49",
+            "tags": [{ "slug": "vm-tag" }],
+            "ip_addresses": [
+              { "id": "3", "address": "192.0.2.198/24", "dns_name": "prod-vm-01", "status": "active" },
+              { "id": "4", "address": "2001:db8:1::198/64", "dns_name": "prod-vm-01", "status": "active" },
+              { "id": "5", "address": "fd00:1::198/64", "dns_name": "prod-vm-01", "status": "active" }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "2",
+        "name": "dev-vm-01",
+        "status": "offline",
+        "primary_ip4": null,
+        "primary_ip6": null,
+        "services": [],
+        "interfaces": [
+          {
+            "id": "2",
+            "name": "net0",
+            "enabled": true,
+            "mtu": null,
+            "mac_address": "52:54:00:12:34:50",
+            "tags": [{ "slug": "vm-tag" }],
+            "ip_addresses": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/unit/inventory/test_nb_inventory_graphql.py
+++ b/tests/unit/inventory/test_nb_inventory_graphql.py
@@ -1,0 +1,591 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026 Mikulas Willaschek
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+"""Unit tests for nb_inventory_graphql.
+
+All GraphQL responses are mocked (JSON fixtures under fixtures/nb_inventory_graphql/, or inline
+dicts for small variations); no real network calls are made. Jinja templates (source.hostname,
+compose, keyed_groups) must come from a trusted-as-template source, exactly like
+_read_config_data() loads the real YAML inventory config — see load_trusted_config().
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+try:
+    from ansible_collections.netbox.netbox.plugins.inventory import (
+        nb_inventory_graphql,
+    )
+    from ansible_collections.netbox.netbox.plugins.inventory.nb_inventory_graphql import (
+        InventoryModule,
+    )
+    from ansible_collections.netbox.netbox.plugins.test.any_attribute_equals import (
+        any_attribute_equals,
+    )
+except ImportError:
+    import sys
+
+    # Not installed as a collection - try importing relative to the root directory
+    # of this ansible_modules checkout instead (see CONTRIBUTING.md).
+    sys.path.append("plugins/inventory")
+    sys.path.append("plugins/test")
+    import nb_inventory_graphql
+    from nb_inventory_graphql import InventoryModule
+    from any_attribute_equals import any_attribute_equals
+
+# Register plugins/test/ with the real Jinja test loader so any_attribute_equals is resolvable
+# as `is any_attribute_equals(...)` inside Templar-evaluated compose expressions. Required
+# unconditionally (not just in the sys.path fallback above): even when the try block above
+# succeeds via the ansible_collections namespace, a bare `pytest` run - unlike `ansible-test
+# units` - does not itself initialize collection-based Jinja plugin discovery.
+from pathlib import Path as _Path
+
+from ansible.plugins.loader import test_loader
+
+test_loader.add_directory(
+    str(_Path(__file__).resolve().parents[3] / "plugins" / "test")
+)
+
+from ansible.errors import AnsibleError
+from ansible.inventory.data import InventoryData
+from ansible.parsing.dataloader import DataLoader
+
+FIXTURES = Path(__file__).parent / "fixtures" / "nb_inventory_graphql"
+VMS_QUERY_FILE = str(FIXTURES / "queries" / "vms.graphql")
+DEVICES_QUERY_FILE = str(FIXTURES / "queries" / "devices.graphql")
+
+DEFAULT_OPTIONS = {
+    "plugin": "nb_inventory_graphql",
+    "api_endpoint": "http://netbox.example.com",
+    "token": None,
+    "validate_certs": True,
+    "cert": None,
+    "key": None,
+    "ca_path": None,
+    "follow_redirects": "urllib2",
+    "timeout": 60,
+    "headers": {},
+    "ansible_host_dns_name": False,
+    "sources": [],
+    "compose": {},
+    "groups": {},
+    "keyed_groups": [],
+    "leading_separator": True,
+    "use_extra_vars": False,
+    "strict": False,
+    "cache": False,
+}
+
+
+def load_fixture(name):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def load_trusted_config(tmp_path, loader, yaml_text):
+    """Parse YAML the same way _read_config_data() does, so Jinja templates in
+    sources[].hostname / compose / keyed_groups pass ansible-core's template trust check.
+    """
+    config_path = tmp_path / "netbox_graphql.yml"
+    config_path.write_text(yaml_text)
+    return loader.load_from_file(str(config_path), trusted_as_template=True)
+
+
+def make_plugin(tmp_path, yaml_text="", **overrides):
+    loader = DataLoader()
+    config = load_trusted_config(tmp_path, loader, yaml_text) if yaml_text else {}
+
+    plugin = InventoryModule()
+    plugin._options = dict(DEFAULT_OPTIONS, **dict(config, **overrides))
+    plugin.inventory = InventoryData()
+    plugin.display = Mock()
+    plugin.graphql_url = "http://netbox.example.com/graphql/"
+    plugin.headers = {"Content-Type": "application/json"}
+    plugin.loader = loader
+    plugin._inventory_dir = str(tmp_path)
+    return plugin
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode()
+
+    def read(self):
+        return self._body
+
+
+def run_sources(plugin, sources):
+    seen_hosts = {}
+    for source in sources:
+        for element in plugin._fetch_source_elements(source):
+            plugin._populate_host_from_element(source, element, seen_hosts)
+    return seen_hosts
+
+
+def source(
+    name="vms",
+    query_file=VMS_QUERY_FILE,
+    list_path="virtual_machine_list",
+    hostname="{{ name }}",
+):
+    return {
+        "name": name,
+        "query_file": query_file,
+        "list_path": list_path,
+        "hostname": hostname,
+    }
+
+
+# --- 1. Standard scenario: reproduces the v0.1 acceptance graph via keyed_groups --------------
+
+
+def test_standard_scenario_matches_acceptance_graph(tmp_path):
+    yaml_text = """
+sources:
+  - name: vms
+    query_file: {0}
+    list_path: virtual_machine_list
+    hostname: "{{{{ name }}}}"
+keyed_groups:
+  - key: services | map(attribute='name') | list
+    prefix: ""
+    separator: ""
+""".format(
+        VMS_QUERY_FILE
+    )
+    plugin = make_plugin(tmp_path, yaml_text, ansible_host_dns_name=True)
+    payload = load_fixture("standard.json")
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        run_sources(plugin, plugin.get_option("sources"))
+    plugin.inventory.reconcile_inventory()
+
+    groups = plugin.inventory.get_groups_dict()
+    assert groups["web"] == ["app-vm-01"]
+    assert groups["api"] == ["app-vm-01"]
+    assert sorted(groups["ungrouped"]) == ["dev-vm-01", "prod-vm-01"]
+
+    app_vm_vars = plugin.inventory.get_host("app-vm-01").get_vars()
+    assert app_vm_vars["ansible_host"] == "app-vm-01"
+    assert app_vm_vars["primary_ip4"] == {
+        "address": "192.0.2.73/24",
+        "dns_name": "app-vm-01",
+    }
+    assert [s["name"] for s in app_vm_vars["services"]] == ["web", "api"]
+
+    dev_vm_vars = plugin.inventory.get_host("dev-vm-01").get_vars()
+    assert "ansible_host" not in dev_vm_vars
+
+
+def test_keyed_groups_with_prefix_yields_prefixed_group_names(tmp_path):
+    yaml_text = """
+sources:
+  - name: vms
+    query_file: {0}
+    list_path: virtual_machine_list
+    hostname: "{{{{ name }}}}"
+keyed_groups:
+  - key: services | map(attribute='name') | list
+    prefix: service
+""".format(
+        VMS_QUERY_FILE
+    )
+    plugin = make_plugin(tmp_path, yaml_text)
+    payload = load_fixture("standard.json")
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        run_sources(plugin, plugin.get_option("sources"))
+
+    groups = plugin.inventory.get_groups_dict()
+    assert groups["service_web"] == ["app-vm-01"]
+    assert groups["service_api"] == ["app-vm-01"]
+
+
+# --- 2. ansible_host derivation — direct unit test, no templating involved --------------------
+
+
+def vm(name, primary_ip4=None, primary_ip6=None):
+    return {
+        "id": "1",
+        "name": name,
+        "primary_ip4": primary_ip4,
+        "primary_ip6": primary_ip6,
+    }
+
+
+@pytest.mark.parametrize(
+    "description, element, dns_name_option, expected_ansible_host",
+    [
+        (
+            "dns_name present + option on -> dns_name wins",
+            vm(
+                "a", primary_ip4={"address": "10.0.0.1/24", "dns_name": "a.example.com"}
+            ),
+            True,
+            "a.example.com",
+        ),
+        (
+            "empty dns_name + option on -> falls back to IP",
+            vm("b", primary_ip4={"address": "10.0.0.2/24", "dns_name": ""}),
+            True,
+            "10.0.0.2",
+        ),
+        (
+            "dns_name present but option off -> IP is used",
+            vm(
+                "c", primary_ip4={"address": "10.0.0.3/24", "dns_name": "c.example.com"}
+            ),
+            False,
+            "10.0.0.3",
+        ),
+        (
+            "no primary IP at all -> ansible_host not set",
+            vm("d"),
+            False,
+            None,
+        ),
+        (
+            "only primary_ip6 -> IPv6 address is used",
+            vm("e", primary_ip6={"address": "2001:db8::1/64", "dns_name": ""}),
+            False,
+            "2001:db8::1",
+        ),
+    ],
+)
+def test_ansible_host_matrix(
+    tmp_path, description, element, dns_name_option, expected_ansible_host
+):
+    plugin = make_plugin(tmp_path, ansible_host_dns_name=dns_name_option)
+    hostname = element["name"]
+    plugin.inventory.add_host(host=hostname)
+
+    plugin._derive_ansible_host(element, hostname)
+
+    host_vars = plugin.inventory.get_host(hostname).get_vars()
+    if expected_ansible_host is None:
+        assert "ansible_host" not in host_vars, description
+    else:
+        assert host_vars["ansible_host"] == expected_ansible_host, description
+
+
+# --- 3. Sources engine --------------------------------------------------------------------------
+
+
+def test_multiple_sources_produce_both_host_types(tmp_path):
+    yaml_text = """
+sources:
+  - name: vms
+    query_file: {0}
+    list_path: virtual_machine_list
+    hostname: "{{{{ name }}}}"
+  - name: devices
+    query_file: {1}
+    list_path: device_list
+    hostname: "{{{{ name }}}}"
+""".format(
+        VMS_QUERY_FILE, DEVICES_QUERY_FILE
+    )
+    plugin = make_plugin(tmp_path, yaml_text)
+    vm_payload = load_fixture("standard.json")
+    device_payload = load_fixture("devices.json")
+
+    with patch.object(
+        nb_inventory_graphql,
+        "open_url",
+        side_effect=[FakeResponse(vm_payload), FakeResponse(device_payload)],
+    ):
+        run_sources(plugin, plugin.get_option("sources"))
+
+    assert set(plugin.inventory.hosts) == {"app-vm-01", "dev-vm-01", "host-01", "prod-vm-01"}
+    host_vars = plugin.inventory.get_host("host-01").get_vars()
+    assert host_vars["device_type"]["model"] == "Server Model 1"
+    assert (
+        "services" not in host_vars
+    )  # VM-only field, never touched by the devices source
+
+
+def test_list_path_missing_raises_ansible_error(tmp_path):
+    plugin = make_plugin(tmp_path)
+    payload = {"data": {"virtual_machine_list": []}}
+
+    with pytest.raises(AnsibleError, match="list_path 'device_list' not found"):
+        plugin._resolve_list_path(payload["data"], "device_list", "vms")
+
+
+def test_list_path_wrong_type_raises_ansible_error(tmp_path):
+    plugin = make_plugin(tmp_path)
+    data = {"virtual_machine_list": {"not": "a list"}}
+
+    with pytest.raises(AnsibleError, match="does not resolve to a list"):
+        plugin._resolve_list_path(data, "virtual_machine_list", "vms")
+
+
+def test_list_path_supports_dotted_nesting(tmp_path):
+    plugin = make_plugin(tmp_path)
+    data = {"wrapper": {"nested_list": [{"id": "1"}]}}
+
+    result = plugin._resolve_list_path(data, "wrapper.nested_list", "vms")
+
+    assert result == [{"id": "1"}]
+
+
+def test_name_collision_between_sources_warns_and_last_writer_wins(tmp_path):
+    yaml_text = """
+sources:
+  - name: vms
+    query_file: {0}
+    list_path: virtual_machine_list
+    hostname: "{{{{ name }}}}"
+  - name: devices
+    query_file: {1}
+    list_path: device_list
+    hostname: "{{{{ name }}}}"
+""".format(
+        VMS_QUERY_FILE, DEVICES_QUERY_FILE
+    )
+    plugin = make_plugin(tmp_path, yaml_text)
+    vm_payload = {"data": {"virtual_machine_list": [{"id": "1", "name": "shared"}]}}
+    device_payload = {
+        "data": {
+            "device_list": [{"id": "2", "name": "shared", "role": {"name": "core"}}]
+        }
+    }
+
+    with patch.object(
+        nb_inventory_graphql,
+        "open_url",
+        side_effect=[FakeResponse(vm_payload), FakeResponse(device_payload)],
+    ):
+        run_sources(plugin, plugin.get_option("sources"))
+
+    host_vars = plugin.inventory.get_host("shared").get_vars()
+    assert host_vars["role"]["name"] == "core"  # the later source (devices) won
+    plugin.display.warning.assert_called()
+
+
+def test_query_file_not_found_raises_clear_error(tmp_path):
+    plugin = make_plugin(tmp_path)
+    missing = source(query_file=str(tmp_path / "does_not_exist.graphql"))
+
+    with pytest.raises(AnsibleError, match="could not read query_file"):
+        plugin._fetch_source_elements(missing)
+
+
+def test_query_file_relative_path_resolves_against_inventory_dir(tmp_path):
+    (tmp_path / "queries").mkdir()
+    (tmp_path / "queries" / "vms.graphql").write_text(
+        "query { virtual_machine_list { id name } }"
+    )
+    plugin = make_plugin(tmp_path)
+    rel_source = source(query_file="queries/vms.graphql")
+    payload = {"data": {"virtual_machine_list": []}}
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        elements = plugin._fetch_source_elements(rel_source)
+
+    assert elements == []
+
+
+# --- 4. compose reference cases -----------------------------------------------------------------
+
+
+def test_compose_use_case_1_selectattr_first(tmp_path):
+    yaml_text = """
+sources:
+  - name: vms
+    query_file: {0}
+    list_path: virtual_machine_list
+    hostname: "{{{{ name }}}}"
+compose:
+  web_service: >-
+    services | selectattr('name', 'equalto', 'web') | list | first | default(omit)
+""".format(
+        VMS_QUERY_FILE
+    )
+    plugin = make_plugin(tmp_path, yaml_text)
+    payload = load_fixture("standard.json")
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        run_sources(plugin, plugin.get_option("sources"))
+
+    assert (
+        plugin.inventory.get_host("app-vm-01").get_vars()["web_service"]["name"]
+        == "web"
+    )
+    assert "web_service" not in plugin.inventory.get_host("prod-vm-01").get_vars()
+
+
+def test_compose_use_case_2_cross_reference_test(tmp_path):
+    yaml_text = """
+sources:
+  - name: vms
+    query_file: {0}
+    list_path: virtual_machine_list
+    hostname: "{{{{ name }}}}"
+compose:
+  primary_interface: >-
+    interfaces
+    | selectattr('ip_addresses', 'any_attribute_equals', 'address', primary_ip4.address)
+    | first | default(omit)
+""".format(
+        VMS_QUERY_FILE
+    )
+    plugin = make_plugin(tmp_path, yaml_text)
+    payload = load_fixture("standard.json")
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        run_sources(plugin, plugin.get_option("sources"))
+
+    assert (
+        plugin.inventory.get_host("app-vm-01").get_vars()["primary_interface"]["name"]
+        == "ens18"
+    )
+    # dev-vm-01 has no primary_ip4 -> "primary_ip4.address" fails to resolve, no traceback, key just absent
+    assert "primary_interface" not in plugin.inventory.get_host("dev-vm-01").get_vars()
+
+
+# --- 5. any_attribute_equals: full coverage -----------------------------------------------------
+
+
+class TestAnyAttributeEquals:
+    def setup_method(self):
+        self.test = any_attribute_equals
+
+    def test_match_found(self):
+        items = [{"address": "10.0.0.1"}, {"address": "10.0.0.2"}]
+        assert self.test(items, "address", "10.0.0.2") is True
+
+    def test_no_match(self):
+        items = [{"address": "10.0.0.1"}]
+        assert self.test(items, "address", "10.0.0.99") is False
+
+    def test_multiple_matches_still_true(self):
+        items = [{"address": "10.0.0.1"}, {"address": "10.0.0.1"}]
+        assert self.test(items, "address", "10.0.0.1") is True
+
+    def test_empty_list(self):
+        assert self.test([], "address", "10.0.0.1") is False
+
+    def test_none_list(self):
+        assert self.test(None, "address", "10.0.0.1") is False
+
+    def test_missing_attribute_no_traceback(self):
+        items = [{"other": "field"}]
+        assert self.test(items, "address", "10.0.0.1") is False
+
+    def test_dotted_attribute_path(self):
+        items = [{"nested": {"address": "10.0.0.1"}}]
+        assert self.test(items, "nested.address", "10.0.0.1") is True
+
+    def test_dotted_path_partially_missing_no_traceback(self):
+        items = [{"nested": {}}]
+        assert self.test(items, "nested.address", "10.0.0.1") is False
+
+
+# --- 6. GraphQL errors ----------------------------------------------------------------------------
+
+
+def test_graphql_errors_without_data_raise_ansible_error(tmp_path):
+    plugin = make_plugin(tmp_path)
+    payload = load_fixture("errors_fatal.json")
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        with pytest.raises(AnsibleError, match="Cannot query field 'bogus_field'"):
+            plugin._fetch_source_elements(source())
+
+
+def test_graphql_errors_with_partial_data_warns_and_builds_inventory(tmp_path):
+    plugin = make_plugin(tmp_path)
+    payload = load_fixture("errors_partial.json")
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        elements = plugin._fetch_source_elements(source())
+
+    assert [e["name"] for e in elements] == ["prod-vm-01"]
+    plugin.display.warning.assert_called()
+
+
+# --- 7. Empty list -> empty inventory -------------------------------------------------------------
+
+
+def test_empty_list_yields_empty_inventory(tmp_path):
+    plugin = make_plugin(tmp_path)
+    payload = load_fixture("empty.json")
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ):
+        elements = plugin._fetch_source_elements(source())
+
+    assert elements == []
+    run_sources(plugin, [])
+    assert plugin.inventory.hosts == {}
+
+
+# --- 8. Pagination: two pages -> all elements fetched ----------------------------------------------
+
+
+def test_pagination_fetches_all_pages(tmp_path, monkeypatch):
+    monkeypatch.setattr(nb_inventory_graphql, "PAGE_SIZE", 2)
+    plugin = make_plugin(tmp_path)
+
+    page1 = {
+        "data": {
+            "virtual_machine_list": [{"id": "1", "name": "a"}, {"id": "2", "name": "b"}]
+        }
+    }
+    page2 = {"data": {"virtual_machine_list": [{"id": "3", "name": "c"}]}}
+    responses = [FakeResponse(page1), FakeResponse(page2)]
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", side_effect=responses
+    ) as mocked:
+        elements = plugin._fetch_source_elements(source())
+
+    assert [e["name"] for e in elements] == ["a", "b", "c"]
+    assert mocked.call_count == 2
+
+    first_body = json.loads(mocked.call_args_list[0].kwargs["data"])
+    second_body = json.loads(mocked.call_args_list[1].kwargs["data"])
+    assert first_body["variables"]["pagination"] == {"offset": 0, "limit": 2}
+    assert second_body["variables"]["pagination"] == {"offset": 2, "limit": 2}
+
+
+def test_source_variables_are_merged_with_pagination(tmp_path):
+    plugin = make_plugin(tmp_path)
+    payload = {"data": {"virtual_machine_list": []}}
+    src = source()
+    src["variables"] = {"status": "active"}
+
+    with patch.object(
+        nb_inventory_graphql, "open_url", return_value=FakeResponse(payload)
+    ) as mocked:
+        plugin._fetch_source_elements(src)
+
+    body = json.loads(mocked.call_args.kwargs["data"])
+    assert body["variables"]["status"] == "active"
+    assert body["variables"]["pagination"] == {
+        "offset": 0,
+        "limit": nb_inventory_graphql.PAGE_SIZE,
+    }


### PR DESCRIPTION
<!-- Draft PR body. Not part of the PR diff — copy into the actual GitHub PR, then delete this file. -->

## Summary

Adds `nb_inventory_graphql`, a NetBox inventory plugin built on the GraphQL API instead of
REST. Unlike `nb_inventory`, it has no built-in knowledge of the NetBox schema: users supply one
or more `.graphql` query files (`sources`), and the plugin turns every element the query returns
into a host, with every selected field becoming a host variable. Grouping and derived variables
go through the standard `constructed` fragment (`compose`, `groups`, `keyed_groups`) rather than
plugin-specific options.

Also adds a small, NetBox-agnostic Jinja test, `any_attribute_equals`, used to cross-reference
two independent nested lists in a `compose` expression (e.g. "which interface owns the primary
IP") — a case `selectattr` alone can't express.

## What's included

- `plugins/inventory/nb_inventory_graphql.py`
- `plugins/test/any_attribute_equals.py` (+ sidecar `any_attribute_equals.yml` docs)
- `tests/unit/inventory/test_nb_inventory_graphql.py` — 29 tests, mocked GraphQL responses, no
  network calls
- `examples/nb_inventory_graphql/` — minimal starter config + query files (VMs and devices,
  `id`/`name`/`primary_ip4`/`primary_ip6`)
- `changelogs/fragments/nb-inventory-graphql-plugin.yml`

## What's *not* included (see `DISCUSSION_PROPOSAL.md`)

- No `tests/integration/targets/...` target (would need `netbox-deploy.py`/
  `hacking/update_test_inventories.sh` extension against a live `netbox-docker` instance)
- `ansible-test sanity`/`ansible-test units` (the official runners) not yet executed locally —
  verified instead via plain `pytest`, `black --check`, and `ansible-lint --profile production`,
  all passing

## Test plan

```bash
## Test plan
Run from the root of the collection repository (`ansible_collections/netbox/netbox`):

```bash
# Run unit tests (29/29 mocked tests passing)
pytest tests/unit/inventory/test_nb_inventory_graphql.py -v

# Code formatting & linting
black --check plugins/inventory/nb_inventory_graphql.py plugins/test/any_attribute_equals.py
ansible-lint plugins/inventory/nb_inventory_graphql.py plugins/test/any_attribute_equals.py \
  examples/nb_inventory_graphql/netbox_graphql.yml

# Render plugin documentation
ansible-doc -t inventory netbox.netbox.nb_inventory_graphql
ansible-doc -t test netbox.netbox.any_attribute_equals
```
Also manually verified end-to-end against a live NetBox 4.6.5 instance (field names, pagination,
grouping, both `compose` reference patterns).
