### PR TITLE
chore(changelog): reclassify CI-only fragments as trivial for 3.23.1

### DIFF
--- a/changelogs/fragments/int-236-ansible-core-219-ci.yml
+++ b/changelogs/fragments/int-236-ansible-core-219-ci.yml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+trivial:
   - >-
     CI now exercises the collection against ansible-core 2.19 alongside the
     existing 2.18 baseline. Three new unit-test legs (Python 3.11, 3.12,

--- a/changelogs/fragments/v45-provision-v2-token.yml
+++ b/changelogs/fragments/v45-provision-v2-token.yml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+trivial:
   - >-
     CI for NetBox v4.5 now provisions a real v2 API token
     (``nbt_<KEY>.<TOKEN>``) at runtime via


### PR DESCRIPTION
## Summary

Reclassify two pending changelog fragments from `minor_changes` to `trivial` so
the upcoming **3.23.1 patch** renders a bugfix-only changelog.

Both reclassified entries describe CI and test-infrastructure work with no
runtime effect on collection users:

- `int-236-ansible-core-219-ci.yml` — the two `minor_changes` items (the
  ansible-core 2.19 CI matrix, and integration-fixture updates for 2.19's
  stricter templating). **Its `bugfixes` entry is untouched**: the
  `netbox_contact` `fail_json` fix is genuinely user-facing and stays in the
  changelog.
- `v45-provision-v2-token.yml` — runtime v2 API token provisioning for the
  NetBox v4.5 CI leg.

`changelogs/config.yaml` already sets `trivial_section_name: trivial`, so
antsibull-changelog accepts the section and excludes it from the rendered
changelog. The work stays recorded in git history; it just stops appearing as a
user-facing "Minor Changes" entry.

## Why

3.23.1 exists to fix a semver break: 3.23.0 shipped a `_to_slug()` behavior
change in a minor release, the Ansible Release Management WG flagged it in
 #1563, and the collection is currently pinned to `<3.23.0` in
ansible-build-data #680.

Patch releases here are cut by merging `devel` into `master` rather than
branching from the previous tag, so 3.23.1 will carry every fragment currently
pending on `devel`. With those two fragments left as `minor_changes`, the 3.23.1
changelog renders a **"Minor Changes"** heading — a minor-level entry in a patch
release, which is the same class of defect 3.23.1 is being cut to correct, in
front of the working group that filed the report.

The substance is harmless (CI only). The changelog section name is what is
wrong, and that is what reviewers of a patch release read.

## Verification

Simulated the 3.23.1 release in throwaway worktrees off `devel` with
`antsibull-changelog release --version 3.23.1`, including PR #1591's fragment so
the simulation matches the real release contents.

**Before** (fragments as they are on `devel`) — sections rendered for 3.23.1:

```
Minor Changes
Bugfixes
```

**After** (this PR) — sections rendered for 3.23.1:

```
Bugfixes
```

All four real bugfixes survive, confirming only the CI items moved:

- the slug-generation revert (#1591)
- unordered m2m list fields compared as sets (#1486)
- `netbox_contact` compatibility gate via `fail_json` (from the file edited here)
- `netbox_device_interface` legacy `mac_address` phantom change (#1502)

`antsibull-changelog lint` passes (exit 0).

No code, module, or test changes: this touches two changelog fragment section
names only.

## Related

- #1591 — the 3.23.1 slug revert this release is being cut for
- #1563 — WG semver report (stays open until the 4.0.0 re-land and un-pin)

Related to INT-480
