### PR TITLE
Update documatation of custom field module

### DIFF
--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -171,7 +171,8 @@ EXAMPLES = r"""
           content_types:
             - dcim.device
             - virtualization.virtualmachine
-          name: A Custom Field
+          name: custom_field
+          label: Custom Field
           type: text
 
     - name: Create a custom field of type selection
@@ -179,7 +180,7 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          name: "Custom_Field"
+          name: Custom_Field_2
           content_types:
             - dcim.device
             - virtualization.virtualmachine
@@ -191,7 +192,7 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          name: A Custom Field
+          name: custom_field
           required: true
 
     - name: Update the custom field to make it read only
@@ -199,7 +200,7 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          name: A Custom Field
+          name: custom_field
           ui_visibility: read-only
 
     - name: Delete the custom field
@@ -207,7 +208,7 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          name: A Custom Field
+          name: custom_field
         state: absent
 """
 

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -195,7 +195,7 @@ EXAMPLES = r"""
           name: custom_field
           required: true
 
-    - name: Update the custom field to make it read only
+    - name: Update the custom field to make it read-only in UI
       netbox.netbox.netbox_custom_field:
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken

--- a/plugins/modules/netbox_custom_field.py
+++ b/plugins/modules/netbox_custom_field.py
@@ -30,13 +30,13 @@ options:
     suboptions:
       content_types:
         description:
-          - The content type(s) to apply this custom field to
+          - The content type(s) to apply this custom field to (obsolete in NetBox 4.0+)
         required: false
         type: list
         elements: raw
       object_types:
         description:
-          - The content type(s) to apply this custom field to (NetBox 4.0+)
+          - The object type(s) to apply this custom field to (available and required in NetBox 4.0+)
         required: false
         type: list
         elements: raw
@@ -62,7 +62,7 @@ options:
         type: str
       object_type:
         description:
-          - The object type of the custom field (if any)
+          - The object type of the custom field (if any, obsolete in NetBox 4.0+, use object_types)
         required: false
         type: str
         version_added: "3.7.0"
@@ -168,7 +168,7 @@ EXAMPLES = r"""
         netbox_url: http://netbox.local
         netbox_token: thisIsMyToken
         data:
-          content_types:
+          object_types:
             - dcim.device
             - virtualization.virtualmachine
           name: custom_field
@@ -181,7 +181,7 @@ EXAMPLES = r"""
         netbox_token: thisIsMyToken
         data:
           name: Custom_Field_2
-          content_types:
+          object_types:
             - dcim.device
             - virtualization.virtualmachine
           type: select


### PR DESCRIPTION
## Related Issue

The examples of the `netbox_custom_field` module doesn't work with NetBox 4.x.

## New Behavior

The examples of the `netbox_custom_field` module are now working with NetBox 4.x.

## Contrast to Current Behavior

The examples are now working, before the examples weren't working.

Previous behaviour with the examples:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "{\"name\":[\"Only alphanumeric characters and underscores are allowed.\"]}"}
```
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "{\"object_types\":[\"This field is required.\"]}"}
```
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "content_types does not exist on existing object. Check to make sure valid field."}
```

## Discussion: Benefits and Drawbacks

Working examples in documenation, no drawbacks.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.