### PR TITLE
Feature add start_on_boot to vm

### DIFF
--- a/changelogs/fragments/1554-feature-add-autostart-to-vm.yml
+++ b/changelogs/fragments/1554-feature-add-autostart-to-vm.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
-      - Add `start_on_boot` to `netbox_virtual_machine` module (https://github.com/netbox-community/ansible_modules/issues/1554)
+  - Add `start_on_boot` to `netbox_virtual_machine` module (https://github.com/netbox-community/ansible_modules/issues/1554)

--- a/changelogs/fragments/1554-feature-add-autostart-to-vm.yml
+++ b/changelogs/fragments/1554-feature-add-autostart-to-vm.yml
@@ -1,0 +1,2 @@
+minor_changes:
+      - Add `start_on_boot` to `netbox_virtual_machine` module (https://github.com/netbox-community/ansible_modules/issues/1554)

--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -70,6 +70,12 @@ options:
         required: false
         type: str
         version_added: "3.20.0"
+      start_on_boot:
+        description:
+          - Start on boot field of the virtual machine
+        required: false
+        type: bool
+        version_added: "4.6.8"
       primary_ip4:
         description:
           - Primary IPv4 address assigned to the virtual machine
@@ -242,6 +248,7 @@ def main():
                     disk=dict(required=False, type="int"),
                     device=dict(required=False, type="raw"),
                     status=dict(required=False, type="raw"),
+                    start_on_boot=dict(required=False, type="bool"),
                     tags=dict(required=False, type="list", elements="raw"),
                     custom_fields=dict(required=False, type="dict"),
                     local_context_data=dict(required=False, type="dict"),

--- a/plugins/modules/netbox_virtual_machine.py
+++ b/plugins/modules/netbox_virtual_machine.py
@@ -75,7 +75,7 @@ options:
           - Start on boot field of the virtual machine
         required: false
         type: bool
-        version_added: "4.6.8"
+        version_added: "3.23.0"
       primary_ip4:
         description:
           - Primary IPv4 address assigned to the virtual machine


### PR DESCRIPTION
## Related Issue

Fixes https://github.com/netbox-community/ansible_modules/issues/1554

## New Behavior

Add the possibility to use the new start_on_boot field on virtual machines


## Contrast to Current Behavior

Add and update start_on_boot on virtual machines in NetBox v4.6.8


## Discussion: Benefits and Drawbacks

Nice to be able to update start_on_boot parameter on VMs using Ansible


## Changes to the Documentation

...

## Proposed Release Note Entry

minor_changes:
- Add start_on_boot to netbox_virtual_machine module (https://github.com/netbox-community/ansible_modules/issues/1554)


## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.
