### PR TITLE
Add netbox_ip_range module

### DIFF
--- a/changelogs/fragments/netbox_ip_range.yml
+++ b/changelogs/fragments/netbox_ip_range.yml
@@ -3,4 +3,4 @@ minor_changes:
   - >-
     Add the ``netbox_ip_range`` module for creating, updating, and removing
     IP ranges (``/api/ipam/ip-ranges/``) in NetBox
-    (https://github.com/netbox-community/ansible_modules/issues/XXXX).
+    (https://github.com/netbox-community/ansible_modules/issues/1597).

--- a/changelogs/fragments/netbox_ip_range.yml
+++ b/changelogs/fragments/netbox_ip_range.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    Add the ``netbox_ip_range`` module for creating, updating, and removing
+    IP ranges (``/api/ipam/ip-ranges/``) in NetBox
+    (https://github.com/netbox-community/ansible_modules/issues/XXXX).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -47,6 +47,7 @@ action_groups:
     - netbox_inventory_item
     - netbox_inventory_item_role
     - netbox_ip_address
+    - netbox_ip_range
     - netbox_ipam_role
     - netbox_journal_entry
     - netbox_l2vpn

--- a/plugins/module_utils/netbox_ipam.py
+++ b/plugins/module_utils/netbox_ipam.py
@@ -20,6 +20,7 @@ NB_ASNS = "asns"
 NB_FHRP_GROUPS = "fhrp_groups"
 NB_FHRP_GROUP_ASSIGNMENTS = "fhrp_group_assignments"
 NB_IP_ADDRESSES = "ip_addresses"
+NB_IP_RANGES = "ip_ranges"
 NB_PREFIXES = "prefixes"
 NB_IPAM_ROLES = "roles"
 NB_RIRS = "rirs"
@@ -155,6 +156,7 @@ class NetboxIpamModule(NetboxModule):
         - fhrp_group_assignments
         - ipam_roles
         - ip_addresses
+        - ip_ranges
         - l2vpns
         - l2vpn_terminations
         - prefixes
@@ -189,6 +191,8 @@ class NetboxIpamModule(NetboxModule):
             name = data.get("address")
         elif self.endpoint in ["aggregates", "prefixes"]:
             name = data.get("prefix")
+        elif self.endpoint == "ip_ranges":
+            name = "%s-%s" % (data.get("start_address"), data.get("end_address"))
         elif self.endpoint == "asns":
             name = data.get("asn")
         elif self.endpoint == "fhrp_groups":

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -99,6 +99,7 @@ API_APPS_ENDPOINTS = dict(
         "fhrp_groups": {},
         "fhrp_group_assignments": {},
         "ip_addresses": {},
+        "ip_ranges": {},
         "l2vpns": {"deprecated": "3.7"},
         "l2vpn_terminations": {"deprecated": "3.7"},
         "prefixes": {},
@@ -278,6 +279,7 @@ CONVERT_TO_ID = {
     "interface_template": "interface_templates",
     "inventory_item_role": "inventory_item_roles",
     "ip_addresses": "ip_addresses",
+    "ip_range_role": "roles",
     "ipaddresses": "ip_addresses",
     "ipsec_profile": "ipsec_profiles",
     "location": "locations",
@@ -395,6 +397,7 @@ ENDPOINT_NAME_MAPPING = {
     "inventory_items": "inventory_item",
     "inventory_item_roles": "inventory_item_role",
     "ip_addresses": "ip_address",
+    "ip_ranges": "ip_range",
     "l2vpns": "l2vpn",
     "l2vpn_terminations": "l2vpn_termination",
     "locations": "location",
@@ -523,6 +526,7 @@ ALLOWED_QUERY_PARAMS = {
     "ipaddresses": set(
         ["address", "vrf", "device", "interface", "assigned_object", "virtual_machine"]
     ),
+    "ip_range": set(["start_address", "end_address", "vrf"]),
     "l2vpn": set(["name"]),
     "l2vpn_termination": set(
         ["l2vpn", "assigned_object_type", "interface_id", "vlan_id", "vminterface_id"]
@@ -640,6 +644,7 @@ REQUIRED_ID_FIND = {
     "interfaces": set(["form_factor", "mode", "type"]),
     "interface_templates": set(["type"]),
     "ip_addresses": set(["status", "role"]),
+    "ip_ranges": set(["status"]),
     "prefixes": set(["status"]),
     "power_feeds": set(["status", "type", "supply", "phase"]),
     "power_outlets": set(["type", "feed_leg"]),
@@ -668,6 +673,7 @@ CONVERT_KEYS = {
     "device_role": "role",
     "fhrp_group": "group",
     "inventory_item_role": "role",
+    "ip_range_role": "role",
     "parent_contact_group": "parent",
     "parent_location": "parent",
     "parent_interface": "parent",

--- a/plugins/modules/netbox_ip_range.py
+++ b/plugins/modules/netbox_ip_range.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, James Crowley (@james-crowley)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: netbox_ip_range
+short_description: Creates or removes IP ranges from NetBox
+description:
+  - Creates or removes IP ranges from NetBox
+notes:
+  - Tags should be defined as a YAML list
+  - This should be ran with connection C(local) and hosts C(localhost)
+author:
+  - James Crowley (@james-crowley)
+requirements:
+  - pynetbox
+version_added: '3.24.0'
+extends_documentation_fragment:
+  - netbox.netbox.common
+options:
+  data:
+    type: dict
+    description:
+      - Defines the IP range configuration
+    suboptions:
+      start_address:
+        description:
+          - Required if state is C(present). The starting address of the range, with mask.
+        required: false
+        type: str
+      end_address:
+        description:
+          - Required if state is C(present). The ending address of the range, with mask.
+        required: false
+        type: str
+      vrf:
+        description:
+          - VRF that the IP range is associated with
+        required: false
+        type: raw
+      tenant:
+        description:
+          - The tenant that the IP range will be assigned to
+        required: false
+        type: raw
+      status:
+        description:
+          - The status of the IP range
+        required: false
+        type: raw
+      ip_range_role:
+        description:
+          - The role of the IP range
+        required: false
+        type: raw
+      mark_populated:
+        description:
+          - Prevent the creation of IP addresses within this range
+        required: false
+        type: bool
+      mark_utilized:
+        description:
+          - Treat as 100% utilized
+        required: false
+        type: bool
+      description:
+        description:
+          - The description of the IP range
+        required: false
+        type: str
+      comments:
+        description:
+          - Comments that may include additional information in regards to the IP range
+        required: false
+        type: str
+      tags:
+        description:
+          - Any tags that the IP range may need to be associated with
+        required: false
+        type: list
+        elements: raw
+      custom_fields:
+        description:
+          - Must exist in NetBox and in key/value format
+        required: false
+        type: dict
+    required: true
+"""
+
+EXAMPLES = r"""
+- name: "Test NetBox IP range module"
+  connection: local
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Create IP range within NetBox with only required information
+      netbox.netbox.netbox_ip_range:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          start_address: 10.156.0.10/24
+          end_address: 10.156.0.50/24
+        state: present
+
+    - name: Delete IP range within NetBox
+      netbox.netbox.netbox_ip_range:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          start_address: 10.156.0.10/24
+          end_address: 10.156.0.50/24
+        state: absent
+
+    - name: Create IP range with several specified options
+      netbox.netbox.netbox_ip_range:
+        netbox_url: http://netbox.local
+        netbox_token: thisIsMyToken
+        data:
+          start_address: 10.156.32.10/24
+          end_address: 10.156.32.50/24
+          vrf: Test VRF
+          tenant: Test Tenant
+          status: Reserved
+          ip_range_role: Network of care
+          description: Test description
+          mark_populated: true
+          mark_utilized: true
+          tags:
+            - Schnozzberry
+        state: present
+"""
+
+RETURN = r"""
+ip_range:
+  description: Serialized object as created or already existent within NetBox
+  returned: on creation
+  type: dict
+msg:
+  description: Message indicating failure or info about what has been achieved
+  returned: always
+  type: str
+"""
+
+from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import (
+    NetboxAnsibleModule,
+    NETBOX_ARG_SPEC,
+)
+from ansible_collections.netbox.netbox.plugins.module_utils.netbox_ipam import (
+    NetboxIpamModule,
+    NB_IP_RANGES,
+)
+from copy import deepcopy
+
+
+def main():
+    """
+    Main entry point for module execution
+    """
+    argument_spec = deepcopy(NETBOX_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            data=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    start_address=dict(required=False, type="str"),
+                    end_address=dict(required=False, type="str"),
+                    vrf=dict(required=False, type="raw"),
+                    tenant=dict(required=False, type="raw"),
+                    status=dict(required=False, type="raw"),
+                    ip_range_role=dict(required=False, type="raw"),
+                    mark_populated=dict(required=False, type="bool"),
+                    mark_utilized=dict(required=False, type="bool"),
+                    description=dict(required=False, type="str"),
+                    comments=dict(required=False, type="str"),
+                    tags=dict(required=False, type="list", elements="raw"),
+                    custom_fields=dict(required=False, type="dict"),
+                ),
+            ),
+        )
+    )
+
+    required_if = [
+        ("state", "present", ["start_address", "end_address"]),
+        ("state", "absent", ["start_address", "end_address"]),
+    ]
+
+    module = NetboxAnsibleModule(
+        argument_spec=argument_spec, supports_check_mode=True, required_if=required_if
+    )
+
+    netbox_ip_range = NetboxIpamModule(module, NB_IP_RANGES)
+    netbox_ip_range.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/integration/targets/v4.5/tasks/main.yml
+++ b/tests/integration/targets/v4.5/tasks/main.yml
@@ -35,6 +35,15 @@
   tags:
     - netbox_ip_address
 
+- name: NETBOX_IP_RANGE TESTS
+  ansible.builtin.include_tasks:
+    file: netbox_ip_range.yml
+    apply:
+      tags:
+        - netbox_ip_range
+  tags:
+    - netbox_ip_range
+
 - name: NETBOX_PREFIX TESTS
   ansible.builtin.include_tasks:
     file: netbox_prefix.yml

--- a/tests/integration/targets/v4.5/tasks/netbox_ip_range.yml
+++ b/tests/integration/targets/v4.5/tasks/netbox_ip_range.yml
@@ -1,0 +1,176 @@
+---
+##
+##
+### NETBOX_IP_RANGE
+##
+##
+- name: 1 - Create IP range within NetBox with only required information
+  netbox.netbox.netbox_ip_range:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      start_address: 10.156.0.10/24
+      end_address: 10.156.0.50/24
+    state: present
+  register: test_one
+
+- name: 1 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['msg'] == "ip_range 10.156.0.10/24-10.156.0.50/24 created"
+      - test_one['ip_range']['start_address'] == "10.156.0.10/24"
+      - test_one['ip_range']['end_address'] == "10.156.0.50/24"
+      - test_one['ip_range']['status'] == "active"
+
+- name: 2 - Duplicate
+  netbox.netbox.netbox_ip_range:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      start_address: 10.156.0.10/24
+      end_address: 10.156.0.50/24
+    state: present
+  register: test_two
+
+- name: 2 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - not test_two['changed']
+      - test_two['msg'] == "ip_range 10.156.0.10/24-10.156.0.50/24 already exists"
+
+- name: 3 - Update 10.156.0.10/24-10.156.0.50/24
+  # vrf is intentionally left unset here: vrf is part of an IP range's
+  # lookup identity (ALLOWED_QUERY_PARAMS["ip_range"] = start_address,
+  # end_address, vrf), exactly as it is for netbox_prefix. Changing it in
+  # an "update" test would make the module look for a different object
+  # and create a second range instead of updating this one.
+  netbox.netbox.netbox_ip_range:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      start_address: 10.156.0.10/24
+      end_address: 10.156.0.50/24
+      tenant: Test Tenant
+      status: Reserved
+      ip_range_role: Network of care
+      description: This range has been updated
+      mark_populated: true
+      mark_utilized: true
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_three
+
+- name: 3 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['tenant'] == 1
+      - test_three['diff']['after']['status'] == "reserved"
+      - test_three['diff']['after']['role'] == 1
+      - test_three['diff']['after']['description'] == "This range has been updated"
+      - test_three['diff']['after']['mark_populated'] == true
+      - test_three['diff']['after']['mark_utilized'] == true
+      - test_three['msg'] == "ip_range 10.156.0.10/24-10.156.0.50/24 updated"
+      - test_three['ip_range']['tenant'] == 1
+      - test_three['ip_range']['status'] == "reserved"
+      - test_three['ip_range']['role'] == 1
+      - test_three['ip_range']['description'] == "This range has been updated"
+      - test_three['ip_range']['mark_populated'] == true
+      - test_three['ip_range']['mark_utilized'] == true
+      - test_three['ip_range']['tags'][0] == 4
+
+- name: 4 - Delete IP range within netbox
+  netbox.netbox.netbox_ip_range:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      start_address: 10.156.0.10/24
+      end_address: 10.156.0.50/24
+    state: absent
+  register: test_four
+
+- name: 4 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "ip_range 10.156.0.10/24-10.156.0.50/24 deleted"
+
+- name: 5 - Create IP range with several specified options
+  netbox.netbox.netbox_ip_range:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      start_address: 10.156.32.10/24
+      end_address: 10.156.32.50/24
+      vrf: Test VRF
+      tenant: Test Tenant
+      status: Reserved
+      ip_range_role: Network of care
+      description: Test description
+      mark_populated: true
+      mark_utilized: true
+      tags:
+        - Schnozzberry
+    state: present
+  register: test_five
+
+- name: 5 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "absent"
+      - test_five['diff']['after']['state'] == "present"
+      - test_five['msg'] == "ip_range 10.156.32.10/24-10.156.32.50/24 created"
+      - test_five['ip_range']['start_address'] == "10.156.32.10/24"
+      - test_five['ip_range']['end_address'] == "10.156.32.50/24"
+      - test_five['ip_range']['vrf'] == 1
+      - test_five['ip_range']['tenant'] == 1
+      - test_five['ip_range']['status'] == "reserved"
+      - test_five['ip_range']['role'] == 1
+      - test_five['ip_range']['description'] == "Test description"
+      - test_five['ip_range']['mark_populated'] == true
+      - test_five['ip_range']['mark_utilized'] == true
+      - test_five['ip_range']['tags'][0] == 4
+
+- name: 6 - Check mode must report changed and create nothing
+  netbox.netbox.netbox_ip_range:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      start_address: 10.156.99.10/24
+      end_address: 10.156.99.50/24
+    state: present
+  check_mode: true
+  register: test_six
+
+- name: 6 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_six is changed
+
+- name: 7 - Overlapping range in the same VRF must be rejected by NetBox itself
+  # NetBox only checks for overlap within the same VRF (IPRange.clean()
+  # filters by vrf=self.vrf), so this has to share the vrf used in test 5
+  # to actually overlap.
+  netbox.netbox.netbox_ip_range:
+    netbox_url: http://localhost:32768
+    netbox_token: "{{ lookup('file', '/tmp/.netbox_test_token', errors='ignore') | default(lookup('env', 'NETBOX_TOKEN', default='0123456789abcdef0123456789abcdef01234567'), true) }}"
+    data:
+      start_address: 10.156.32.20/24
+      end_address: 10.156.32.60/24
+      vrf: Test VRF
+    state: present
+  register: test_seven
+  ignore_errors: true
+
+- name: 7 - ASSERT
+  ansible.builtin.assert:
+    that:
+      - test_seven is failed
+      - "'overlap' in (test_seven['msg'] | lower)"

--- a/tests/unit/module_utils/test_data/netbox_utils/choices_id.json
+++ b/tests/unit/module_utils/test_data/netbox_utils/choices_id.json
@@ -118,6 +118,24 @@
         }
     },
     {
+        "endpoint": "ip_ranges",
+        "data": {
+            "status": "Active"
+        },
+        "expected": {
+            "status": "temp"
+        }
+    },
+    {
+        "endpoint": "ip_ranges",
+        "data": {
+            "status": 2
+        },
+        "expected": {
+            "status": 2
+        }
+    },
+    {
         "endpoint": "racks",
         "data": {
             "status": "Active",

--- a/tests/unit/module_utils/test_data/netbox_utils/find_app.json
+++ b/tests/unit/module_utils/test_data/netbox_utils/find_app.json
@@ -68,6 +68,10 @@
         "app": "ipam"
     },
     {
+        "endpoint": "ip_ranges",
+        "app": "ipam"
+    },
+    {
         "endpoint": "prefixes",
         "app": "ipam"
     },


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue

Closes #1597

## New Behavior

Adds `netbox_ip_range`, a new module for creating, updating, and removing IP ranges (`/api/ipam/ip-ranges/`) in NetBox. It's modeled directly on `netbox_prefix`: same DOCUMENTATION/EXAMPLES/RETURN layout, same `NetboxAnsibleModule` / `NetboxIpamModule` plumbing, same `argument_spec` style.

It covers `start_address`, `end_address`, `vrf`, `tenant`, `status`, `role` (exposed as `ip_range_role`, matching the `prefix_role` / `vlan_role` naming already used for other FK-to-Role fields), `mark_populated`, `mark_utilized`, `description`, `comments`, `tags`, and `custom_fields`. That's the writable `IPRangeSerializer` field set as of NetBox 4.5 (checked against `netbox/ipam/api/serializers_/ip.py` and `netbox/ipam/models/ip.py` in netbox-community/netbox), minus `size` (server-computed) and `owner` (a generic ownership field no module in this collection implements yet, including `netbox_prefix`, so leaving it out here keeps the module consistent with the rest of the collection).

## Contrast to Current Behavior

Today every other IPAM object type in NetBox (prefix, IP address, VRF, role, and so on) has a dedicated module. IP ranges don't, so managing one through Ansible means a raw REST call outside the collection's normal declarative pattern. This PR closes that gap.

Wiring changes follow CONTRIBUTING.md's steps for adding an endpoint:

- `API_APPS_ENDPOINTS["ipam"]` gets `ip_ranges`.
- `ENDPOINT_NAME_MAPPING` maps `ip_ranges` to `ip_range`.
- `ALLOWED_QUERY_PARAMS["ip_range"]` is `start_address`, `end_address`, `vrf`.
- `REQUIRED_ID_FIND["ip_ranges"]` only lists `status`. Role here is a real FK to `ipam.Role`, not a choices field, so it doesn't belong in that set the way it does for `ip_addresses`, where role actually is a choices field.
- `CONVERT_KEYS` and `CONVERT_TO_ID` map `ip_range_role` to `role` and `roles`.
- `NetboxIpamModule.run()` derives a name for messages and diffs as `start_address-end_address`, since a range has no single natural key.

## Discussion: Benefits and Drawbacks

This brings IP range management in line with every other IPAM endpoint in the collection: idempotent create/update/delete through the same module pattern users already know. It's purely additive, a new module and new wiring branches keyed off a new endpoint name, so it doesn't change behavior for any existing module. I only added the integration test target under `v4.5/`. IP ranges have existed in NetBox for a long time, so the target probably belongs in `v4.0` through `v4.4` too, but I didn't want to duplicate five more near-identical files before getting a read on whether the module is wanted as designed. Happy to add those, or anything else, based on review.

## Changes to the Documentation

None beyond the module's own DOCUMENTATION/EXAMPLES/RETURN strings, which `ansible-doc` renders correctly.

## Proposed Release Note Entry

Add the `netbox_ip_range` module for creating, updating, and removing IP ranges (`/api/ipam/ip-ranges/`) in NetBox.

## Double Check

* [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netbox-community/ansible_modules/blob/devel/CONTRIBUTING.md).
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `devel` branch.

---

Testing, run locally against this branch:

- `black --check .` is clean.
- `python3 -m pytest tests/unit` passes: 243, versus 240 on unmodified `devel`, the difference being the 3 new test data rows.
- `ansible-doc netbox.netbox.netbox_ip_range` renders correctly.
- `ansible-lint tests/integration/targets/v4.5/tasks/netbox_ip_range.yml` reports 0 failures on the production profile.
- Brought up NetBox 4.5 with netbox-docker, provisioned a token with `tests/netbox-docker/provision-token.sh`, seeded fixtures with `tests/integration/netbox-deploy.py`, and ran the test file above with `ansible-playbook` against that live instance. All 7 tasks passed against the real API, not a mock.
- To check the test actually catches a regression, I removed the name-derivation branch from `netbox_ipam.py`, reran the test, watched it fail on the expected assertion, then put the branch back and confirmed everything was green again.

I added rows for the new endpoint to the unit test data in `tests/unit/module_utils/test_data/netbox_utils/find_app.json` and `choices_id.json`, and wired the new integration test target into `tests/integration/targets/v4.5/tasks/main.yml`.
